### PR TITLE
fix(ci): use arc-linux-jr200-labs runner for renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -35,7 +35,7 @@ jobs:
     with:
       log-level: ${{ inputs.log-level || 'info' }}
       dry-run: ${{ inputs.dry-run || '' }}
-      runner: arc-linux-whengas
+      runner: arc-linux-jr200-labs
     # The org-level INTEGRATION_APP_PRIVATE_KEY secret has to be passed
     # explicitly because GitHub Actions does NOT inherit secrets across
     # orgs (variables yes, secrets no). github-action-templates lives in


### PR DESCRIPTION
## Summary
- Fix renovate runner label from `arc-linux-whengas` to `arc-linux-jr200-labs`
- polars-hist-db is in jr200-labs org, can't access whengas org runners

## Test plan
- [ ] Renovate workflow completes after merge