### PR TITLE
ci: wire lint-workflow-runners reusable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,3 +12,6 @@ jobs:
 
   commitlint:
     uses: jr200-labs/github-action-templates/.github/workflows/lint_commits.yaml@master
+
+  lint-workflow-runners:
+    uses: jr200-labs/github-action-templates/.github/workflows/lint_workflow_runners.yaml@master

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,15 @@ on:
   pull_request:
     branches: [master]
 
+# Top-level permissions cascade into reusable workflow jobs. Repo
+# default_workflow_permissions is `read` (contents only) + `none` for
+# everything else, which downgrades the reusables' declared
+# `pull-requests: read` to `pull-requests: none` and makes the workflow
+# fail to start. Declare the union here so the reusables can run.
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   ci:
     uses: jr200-labs/github-action-templates/.github/workflows/ci_uv_python.yaml@master


### PR DESCRIPTION
Adds the lint-workflow-runners reusable workflow to CI.