### PR TITLE
ci: adopt shared banned-words commitlint + PR metadata gate (JRL-31)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,3 +24,6 @@ jobs:
 
   lint-workflow-runners:
     uses: jr200-labs/github-action-templates/.github/workflows/lint_workflow_runners.yaml@master
+
+  lint-pr-metadata:
+    uses: jr200-labs/github-action-templates/.github/workflows/lint_pr_metadata.yaml@master

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,3 +1,1 @@
-export default {
-  extends: ['@commitlint/config-conventional'],
-}
+export { default } from './.shared/commitlint.config.mjs';


### PR DESCRIPTION
## Summary

- Re-export shared commitlint config so the `banned-words` rule (driven by `BANNED_COMMIT_WORDS` org var) runs against commit messages.
- Add `lint-pr-metadata` job to enforce the same banned list against branch name, PR title, and PR body.

Linear: https://linear.app/jr200-labs/issue/JRL-31