### PR TITLE
ci: use shared quarto docs workflow

### DIFF
--- a/.github/.shared-config.yaml
+++ b/.github/.shared-config.yaml
@@ -9,5 +9,6 @@
 workflows:
   - hygiene
   - python
+  - quarto-docs
   - wheel
   - release

--- a/.github/workflows/bespoke_build_quarto_docs.yaml
+++ b/.github/workflows/bespoke_build_quarto_docs.yaml
@@ -1,47 +1,20 @@
 name: build-quarto-docs
 
 on:
-  repository_dispatch:
-    types:
-      - dispatch-build-quarto-docs
-
+  push:
+    branches: [master]
+    paths:
+      - 'docs/**'
   workflow_dispatch:
-    inputs:
-      unused-variable:
-        description: unused-variable
-        required: false
-        type: string
-        default: dummy
 
+permissions:
+  contents: write
+  pages: write
 
 jobs:
-  configure:
-    uses: jr200-labs/github-action-templates/.github/workflows/preconfigure.yaml@master
-    with:
-      event_name: ${{ toJson(github.event_name) }}
-      event: ${{ toJson(github.event) }}
-
-  main:
-    needs: configure
+  build-quarto-docs:
     uses: jr200-labs/github-action-templates/.github/workflows/build_quarto_docs.yaml@master
-
-  spawn-workflow:
-    needs: main
-    runs-on: ${{ fromJSON(vars.RUNNER_PROFILES)[vars.RUNNER_PROFILE].default }}
-    steps:
-      - id: prepare_payload
-        run: |
-          cat <<EOF > old_payload.json
-          ${{ toJson(github.event.client_payload) }}
-          EOF
-
-          cat old_payload.json | jq '. + {"quarto_run_id": "${{ github.run_id }}"}' > new_payload.json
-          echo "payload=$(cat new_payload.json | jq -c '.')" >> $GITHUB_OUTPUT
-
-      - name: dispatch-next-workflow
-        uses: peter-evans/repository-dispatch@v4
-        if: github.event_name != 'workflow_dispatch'
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          event-type: dispatch-publish-uv-pypi
-          client-payload: ${{ steps.prepare_payload.outputs.payload }}
+    with:
+      checkout-ref: ${{ github.ref }}
+      site-path: docs
+      runner: ${{ fromJSON(vars.RUNNER_PROFILES)[vars.RUNNER_PROFILE].default }}

--- a/.github/workflows/publish-quarto-docs.yaml
+++ b/.github/workflows/publish-quarto-docs.yaml
@@ -1,20 +1,23 @@
-name: build-quarto-docs
+name: publish-quarto-docs
 
 on:
   push:
     branches: [master]
     paths:
-      - 'docs/**'
+      - 'docs/site/**'
   workflow_dispatch:
 
+# Only the caller's TOP-LEVEL permissions cascade into reusable
+# workflows. The Quarto Pages publisher needs contents:write to update
+# gh-pages.
 permissions:
   contents: write
   pages: write
 
 jobs:
-  build-quarto-docs:
+  publish-quarto-docs:
     uses: jr200-labs/github-action-templates/.github/workflows/build_quarto_docs.yaml@master
     with:
       checkout-ref: ${{ github.ref }}
-      site-path: docs
+      site-path: docs/site
       runner: ${{ fromJSON(vars.RUNNER_PROFILES)[vars.RUNNER_PROFILE].default }}


### PR DESCRIPTION
## Summary
- replace the custom Quarto docs wrapper with a thin caller to the shared `build_quarto_docs.yaml` reusable workflow
- add the top-level `contents: write` and `pages: write` permissions required by the shared Pages publisher
- point the shared workflow at this repo's actual Quarto project root (`docs`) instead of the old custom dispatch chain