### PR TITLE
chore(deps): disable renovate mariadb bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,11 @@
       "description": "Use semver tags for quarto-cli git dep, not commit digests",
       "matchPackageNames": ["quarto-cli"],
       "versioning": "semver"
+    },
+    {
+      "description": "Keep the MariaDB test image on the current major until the integration setup is intentionally migrated.",
+      "matchPackageNames": ["docker.io/library/mariadb"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- disable Renovate updates for `docker.io/library/mariadb` in this repo
- keeps the integration-test MariaDB image pinned on the current major until the test environment is intentionally migrated
- prevents future PRs like `renovate/docker.io-library-mariadb-12.x` from being recreated