### PR TITLE
fix: evolve additive delta table columns

### DIFF
--- a/polars_hist_db/core/table_config.py
+++ b/polars_hist_db/core/table_config.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     text,
     UniqueConstraint,
 )
+from sqlalchemy.schema import CreateColumn
 from sqlalchemy.schema import CreateTable
 
 from .db import DbOps
@@ -155,6 +156,33 @@ class TableConfigOps:
         tbl = tbo.get_table_metadata()
         return tbl
 
+    def _add_missing_delta_columns(
+        self, tbo: TableOps, table_config: TableConfig
+    ) -> None:
+        existing_table = tbo.get_table_metadata()
+        existing_columns = set(existing_table.columns.keys())
+        missing_columns = [
+            column
+            for column in table_config.build_sqlalchemy_columns(is_delta_table=True)
+            if column.name not in existing_columns
+        ]
+
+        for column in missing_columns:
+            column_sql = str(CreateColumn(column).compile(self.connection))
+            LOGGER.info(
+                "adding missing column %s.%s.%s",
+                tbo.table_schema,
+                tbo.table_name,
+                column.name,
+            )
+            DbOps(self.connection).execute_sqlalchemy(
+                f"sql.base.table_add_column.{tbo.table_name}.{column.name}",
+                text(
+                    f"ALTER TABLE {tbo.table_schema}.{tbo.table_name} "
+                    f"ADD COLUMN {column_sql}"
+                ),
+            )
+
     def _create_nontemporal(
         self,
         table_name: str,
@@ -166,6 +194,8 @@ class TableConfigOps:
     ) -> Table:
         tbo = TableOps(table_config.schema, table_name, self.connection)
         if tbo.table_exists():
+            if is_delta_table:
+                self._add_missing_delta_columns(tbo, table_config)
             return tbo.get_table_metadata()
 
         LOGGER.info("creating table %s.%s", tbo.table_schema, tbo.table_name)

--- a/polars_hist_db/dataset/scrape.py
+++ b/polars_hist_db/dataset/scrape.py
@@ -7,7 +7,7 @@ import polars as pl
 from sqlalchemy import Connection, Engine
 
 from ..config import TableConfig, TableConfigs, DatasetConfig
-from ..core import DataframeOps, TableConfigOps, TableOps
+from ..core import DataframeOps, TableConfigOps
 from ..utils import NonRetryableException
 
 from .extract_item import scrape_extract_item
@@ -48,14 +48,11 @@ def _ensure_delta_table(
     For temporary tables this must run in the same connection that will
     use the table, since TEMPORARY TABLEs are session-scoped.
     """
-    if not TableOps(
-        delta_table_config.schema, delta_table_config.name, connection
-    ).table_exists():
-        TableConfigOps(connection).create(
-            delta_table_config,
-            is_delta_table=True,
-            is_temporary_table=is_temporary_table,
-        )
+    TableConfigOps(connection).create(
+        delta_table_config,
+        is_delta_table=True,
+        is_temporary_table=is_temporary_table,
+    )
 
 
 async def try_run_pipeline_as_transaction(

--- a/tests/sql/test_delta_schema_evolution.py
+++ b/tests/sql/test_delta_schema_evolution.py
@@ -1,0 +1,53 @@
+import pytest
+
+from polars_hist_db.config import TableColumnConfig, TableConfig
+from polars_hist_db.core import TableConfigOps, TableOps
+
+from ..utils.dsv_helper import mariadb_engine_test
+
+pytestmark = pytest.mark.integration
+
+
+def test_delta_table_create_adds_missing_columns():
+    engine = mariadb_engine_test()
+    initial_config = TableConfig(
+        name="delta_schema_evolution",
+        schema="test",
+        columns=[
+            TableColumnConfig(
+                table="delta_schema_evolution",
+                name="id",
+                data_type="INT",
+            ),
+        ],
+    )
+    evolved_config = TableConfig(
+        name="delta_schema_evolution",
+        schema="test",
+        columns=[
+            TableColumnConfig(
+                table="delta_schema_evolution",
+                name="id",
+                data_type="INT",
+            ),
+            TableColumnConfig(
+                table="delta_schema_evolution",
+                name="image_url",
+                data_type="VARCHAR(255)",
+            ),
+        ],
+    )
+
+    with engine.begin() as connection:
+        table_ops = TableOps("test", "delta_schema_evolution", connection)
+        TableConfigOps(connection).drop(initial_config)
+        try:
+            TableConfigOps(connection).create(initial_config, is_delta_table=True)
+
+            assert "image_url" not in table_ops.get_table_metadata().columns
+
+            TableConfigOps(connection).create(evolved_config, is_delta_table=True)
+
+            assert "image_url" in table_ops.get_table_metadata().columns
+        finally:
+            TableConfigOps(connection).drop(evolved_config)


### PR DESCRIPTION
## Summary
- add additive column evolution for existing delta tables
- make dataset setup re-run delta table creation so configured columns are reconciled
- cover the existing-table path with a MariaDB integration test

## Verification
- uv run ruff check .
- uv run ruff format --check .
- uv run mypy .
- uv run python -m pytest tests/
- MARIADB_PORT=13307 uv run python -m pytest tests/sql/test_delta_schema_evolution.py -m integration