### PR TITLE
fix: evolve persistent table columns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ check:
 	uv run mypy .
 
 run-tests:
-	NATS_PORT=$(NATS_PORT) MARIADB_PORT=$(MARIADB_PORT) uv run pytest tests/
+	NATS_PORT=$(NATS_PORT) MARIADB_PORT=$(MARIADB_PORT) uv run python -m pytest tests/
 
 render:
 	@echo "Rendering Quarto project in $(PROJECT_ROOT)/..."

--- a/polars_hist_db/core/table_config.py
+++ b/polars_hist_db/core/table_config.py
@@ -156,14 +156,12 @@ class TableConfigOps:
         tbl = tbo.get_table_metadata()
         return tbl
 
-    def _add_missing_delta_columns(
-        self, tbo: TableOps, table_config: TableConfig
-    ) -> None:
+    def _add_missing_columns(self, tbo: TableOps, table_config: TableConfig) -> None:
         existing_table = tbo.get_table_metadata()
         existing_columns = set(existing_table.columns.keys())
         missing_columns = [
             column
-            for column in table_config.build_sqlalchemy_columns(is_delta_table=True)
+            for column in table_config.build_sqlalchemy_columns(is_delta_table=False)
             if column.name not in existing_columns
         ]
 
@@ -194,8 +192,7 @@ class TableConfigOps:
     ) -> Table:
         tbo = TableOps(table_config.schema, table_name, self.connection)
         if tbo.table_exists():
-            if is_delta_table:
-                self._add_missing_delta_columns(tbo, table_config)
+            self._add_missing_columns(tbo, table_config)
             return tbo.get_table_metadata()
 
         LOGGER.info("creating table %s.%s", tbo.table_schema, tbo.table_name)

--- a/tests/sql/test_delta_schema_evolution.py
+++ b/tests/sql/test_delta_schema_evolution.py
@@ -51,3 +51,48 @@ def test_delta_table_create_adds_missing_columns():
             assert "image_url" in table_ops.get_table_metadata().columns
         finally:
             TableConfigOps(connection).drop(evolved_config)
+
+
+def test_nontemporal_table_create_adds_missing_columns():
+    engine = mariadb_engine_test()
+    initial_config = TableConfig(
+        name="nontemporal_schema_evolution",
+        schema="test",
+        columns=[
+            TableColumnConfig(
+                table="nontemporal_schema_evolution",
+                name="id",
+                data_type="INT",
+            ),
+        ],
+    )
+    evolved_config = TableConfig(
+        name="nontemporal_schema_evolution",
+        schema="test",
+        columns=[
+            TableColumnConfig(
+                table="nontemporal_schema_evolution",
+                name="id",
+                data_type="INT",
+            ),
+            TableColumnConfig(
+                table="nontemporal_schema_evolution",
+                name="image_file",
+                data_type="VARCHAR(255)",
+            ),
+        ],
+    )
+
+    with engine.begin() as connection:
+        table_ops = TableOps("test", "nontemporal_schema_evolution", connection)
+        TableConfigOps(connection).drop(initial_config)
+        try:
+            TableConfigOps(connection).create(initial_config)
+
+            assert "image_file" not in table_ops.get_table_metadata().columns
+
+            TableConfigOps(connection).create(evolved_config)
+
+            assert "image_file" in table_ops.get_table_metadata().columns
+        finally:
+            TableConfigOps(connection).drop(evolved_config)


### PR DESCRIPTION
## Summary
- evolve existing persistent nontemporal tables by adding newly configured columns before returning metadata
- keep delta table additive column evolution covered
- make the test target invoke pytest through the active Python interpreter

## Tests
- make check
- make run-tests
- uv run python -m pytest -m integration tests/sql