### PR TITLE
feat: add experimental XTDB backend parity

### DIFF
--- a/docs/_quarto.yaml
+++ b/docs/_quarto.yaml
@@ -29,6 +29,7 @@ website:
       contents:
       - configuration.qmd
       - api.qmd
+      - backend-contract.qmd
       - examples.qmd
 
   page-footer:

--- a/docs/api.qmd
+++ b/docs/api.qmd
@@ -49,6 +49,20 @@ Database connection and engine settings.
 - `get_engine() -> Engine` — returns a cached SQLAlchemy engine
 - `dispose()` — disposes the cached engine
 
+### Backends (`polars_hist_db.backends`)
+
+Backend adapters provide the storage boundary used to keep MariaDB support while
+adding experimental XTDB support and future database engines.
+
+- `DbEngineConfig.from_mapping(cfg) -> DbEngineConfig`
+- `get_backend(name="mariadb") -> HistoricalDbBackend`
+- `backend_from_config(config: DbEngineConfig) -> HistoricalDbBackend`
+- `backend.time_hint_clause(time_hint: TimeHint) -> str | None`
+- `MariaDbBackend` — complete adapter that delegates to existing core ops
+- `XtdbBackend` — experimental adapter with typed dataframe read/append helpers;
+  unsupported temporal and delta methods fail explicitly until parity work is
+  complete
+
 ### TableConfig
 
 Defines a single database table.

--- a/docs/backend-contract.qmd
+++ b/docs/backend-contract.qmd
@@ -1,0 +1,345 @@
+---
+title: "Backend Contract"
+---
+
+This document defines the storage-backend contract for `polars-hist-db`.
+The current implementation uses MariaDB system-versioned tables, but Whengas
+should treat the stable product surface as typed Polars dataframes over
+temporal tables. A second backend, such as XTDB, should be evaluated against
+this contract before any migration is attempted.
+
+## Goal
+
+The backend layer must support repeatable ingestion of raw and derived data,
+typed dataframe reads and writes, and point-in-time views of historical state.
+It must also provide enough update visibility for downstream services to
+invalidate caches, publish events, and build user-facing projections.
+
+The goal of an XTDB spike is not to reproduce MariaDB SQL mechanics. The goal
+is to prove that the same `polars-hist-db` behaviours can be implemented with
+equivalent or better correctness, performance, and operability.
+
+## Public Behaviour
+
+Backend implementations must preserve these behaviours:
+
+- Read a whole table into a strongly typed `polars.DataFrame`.
+- Read query results into a strongly typed `polars.DataFrame`.
+- Write dataframes into configured tables using the configured schema.
+- Create configured tables idempotently.
+- Add missing configured columns without silently dropping existing data.
+- Apply default values in the same places as the current dataframe insert path.
+- Upsert temporal data using configured primary keys and delta semantics.
+- Delete rows temporally when the source marks rows as final or removed.
+- Query latest state, all historical states, an as-of state, and a bounded
+  historical span through `TimeHint`.
+- Track ingestion audit entries so repeated scrapes skip already-ingested
+  source items.
+- Expose table-update signals that downstream services can poll or publish.
+- Preserve transaction boundaries for each file or message partition.
+
+## Current MariaDB Coupling
+
+The existing implementation mixes the public behaviour above with several
+MariaDB-specific details:
+
+- Temporal history is implemented with hidden `__valid_from` and `__valid_to`
+  columns created as a `PERIOD FOR SYSTEM_TIME`.
+- Historical reads are expressed with MariaDB `FOR SYSTEM_TIME` hints.
+- Upsert timestamps are controlled with `SET @@timestamp` through
+  `DbOps.set_system_versioning_time`.
+- Table metadata is loaded with SQLAlchemy reflection and MariaDB SQL types.
+- Delta upserts are implemented with temporary SQL tables, SQLAlchemy
+  `UPDATE ... WHERE`, and `INSERT ... SELECT` statements.
+- Some current query surfaces accept SQLAlchemy `Selectable` objects, so they
+  implicitly assume a SQLAlchemy-compatible backend.
+- Audit tables live in the same relational database as the target tables.
+
+These details are valid for the MariaDB adapter, but they should not leak into
+the storage-neutral contract.
+
+## Backend Interface Shape
+
+A backend adapter should own the operations below. Naming can change during
+implementation, but the boundary should remain explicit.
+
+Backends are selected through the parsed `db.backend` configuration field.
+`mariadb` is the default and complete backend. `xtdb` is experimental while the
+spike proves parity. `mssql` is reserved for a future MS SQL adapter because MS
+SQL also has temporal-table support, but it should not be exposed as implemented
+until it passes the same contract tests.
+
+### Connection and Transactions
+
+- Build and dispose backend connections from `DbEngineConfig`.
+- Provide a transaction context compatible with dataset ingestion.
+- Allow backend-specific tuning without changing dataset configuration shape.
+
+### Schema Management
+
+- Create schemas or namespaces.
+- Create configured tables from `TableConfig`.
+- Reflect an existing table into `TableConfig`.
+- Add missing configured columns.
+- Report primary keys, nullable columns, default values, and backend-native
+  type information.
+
+### Type Mapping
+
+- Map configured SQL-like types to Polars dtypes.
+- Map Polars dtypes to backend-native storage types.
+- Round-trip dates, datetimes, decimals, booleans, categoricals, integers,
+  floats, strings, and nulls without lossy conversion.
+- Preserve decimal precision needed by finance and gas-volume data.
+
+### Reads
+
+- Read table latest state.
+- Read table history with `TimeHint(mode="all")`.
+- Read an as-of state with `TimeHint(mode="asof")`.
+- Read a bounded history with `TimeHint(mode="span")`.
+- Read filtered/query results without forcing callers to hand-write backend
+  SQL where a dataframe-key lookup would be sufficient.
+
+### Writes
+
+- Insert dataframes.
+- Update dataframes by primary key.
+- Upsert temporal dataframes by primary key.
+- Delete rows temporally.
+- Return changed-row counts where they are meaningful.
+- Keep one source partition or message inside one atomic commit unit.
+
+### Delta and Finality Semantics
+
+The adapter must support the existing `DeltaConfig` behaviours:
+
+- Drop unchanged rows when configured.
+- Handle duplicate source keys with `error`, `take_first`, or `take_last`.
+- Apply `row_finality="disabled"` without deleting missing rows.
+- Apply `row_finality="dropout"` by temporally deleting rows missing from the
+  incoming source snapshot.
+- Leave room for `row_finality="manual"` behaviour without blocking future
+  implementation.
+
+### Audit and Update Visibility
+
+- Record source-item audit entries.
+- Filter already-ingested source items.
+- Query latest audit entry by table and source timestamp.
+- Support table-update callbacks used by API services for cache invalidation
+  and event publication.
+
+## XTDB Evaluation Requirements
+
+Official XTDB materials describe XTDB as an open-source immutable SQL database
+with comprehensive time-travel, bitemporal records, a columnar engine built on
+Apache Arrow, and object-storage-oriented architecture:
+
+- <https://github.com/xtdb/xtdb>
+- <https://docs.xtdb.com/intro/what-is-xtdb.html>
+
+Those properties are directly relevant to Whengas because the data platform is
+already Polars/Arrow-oriented and needs historical views. The same materials
+also describe a strongly ordered transaction path, with writes for a database
+processed through a single leader. That is a valuable consistency model, but it
+means write throughput and batching must be measured on representative feeds.
+
+XTDB should only move beyond spike status if it passes the following gates:
+
+- The adapter can run representative `polars-hist-db` ingestion tests without
+  weakening type checks.
+- Temporal query parity tests pass against MariaDB and XTDB for latest, all,
+  as-of, and span reads.
+- Delta upsert parity tests pass for inserts, updates, duplicate handling,
+  unchanged-row dropping, and row-finality dropout.
+- Finance-shaped data preserves decimal precision and timestamp semantics.
+- Whengas-shaped cargo and vessel tables can be read into Arrow/Polars without
+  row-by-row conversion becoming the bottleneck.
+- Netbacks-style high-frequency update streams can be batched without violating
+  freshness requirements.
+- Operational work is understood: deployment, backup, restore, object storage,
+  schema evolution, monitoring, and failure recovery.
+- Migration can be run table-by-table with dual-read or dual-write validation.
+
+## Reuse From `polars-xtdb`
+
+The existing `polars-xtdb` prototype is useful prior art, but it should not be
+treated as a completed backend. It already explores XTDB reads, system-time
+columns, and basic type mapping. The current gaps are the important parts for
+Whengas:
+
+- Type mapping is incomplete for the schemas now used by `polars-hist-db`.
+- Dataset ingestion, audit tracking, delta upserts, and finality are not wired
+  into the prototype.
+- The prototype exposes XTDB-specific helper functions rather than a storage
+  adapter that implements the `polars-hist-db` contract.
+
+The XTDB spike should reuse lessons and test fixtures from that repo, not
+replace `polars-hist-db` with the prototype directly.
+
+The first adapter slice in `polars-hist-db` exposes an experimental
+`XtdbBackend.dataframes(connection)` helper for raw SQL reads, table reads, and
+dataframe appends. Temporal upsert, delta/finality, schema management, audit
+tracking, and update visibility remain explicit unsupported operations until
+the parity tickets prove them.
+
+The first temporal parity slice shares backend-level system-time hint clause
+generation between MariaDB and XTDB for `none`, `all`, `asof`, and `span`.
+MariaDB still applies those hints through its existing SQLAlchemy/MariaDB
+`TimeHint.apply` path. XTDB applies the same clause string to experimental table
+reads. This is query-shape parity only; live XTDB result parity still requires
+the dedicated parity tests and fixture data in WG-240.
+
+`XtdbBackend.table_configs(connection)` exists as the schema-management seam.
+Table reflection reads `information_schema.columns`, maps XTDB type names into
+`TableConfig`, filters XTDB system-time columns, and treats `_id` as the
+reflected key. Configured table creation declares XTDB's required `_id` plus
+the configured columns with XTDB's bare-column `CREATE TABLE schema.table (...)`
+form. For a table config with exactly one primary key, that key is mapped to
+XTDB's required `_id` document identifier. For composite primary keys, the
+adapter generates a deterministic text `_id` using the configured key order and
+the `xtdb-pk-v1:` encoding while preserving the original key columns as normal
+data columns. Table creation records the original primary-key list in an
+internal XTDB adapter metadata table so `from_table(...)` can recover composite
+keys when reflecting tables created by `polars-hist-db`. Legacy XTDB tables
+without that metadata still fall back to `_id` as the reflected key.
+
+The same mapping is applied on experimental dataframe appends when callers pass
+the `TableConfig` to `XtdbDataframeOps.table_insert(...)`: a configured key such
+as `id` is renamed to `_id` before Polars writes to XTDB, while composite-key
+tables receive a synthetic `_id` column and keep their original key columns.
+Existing MariaDB insert behaviour remains unchanged.
+
+This is schema declaration, not MariaDB-style type enforcement. Empty declared
+XTDB columns surface through `information_schema`, and XTDB widens column types
+from inserted data. The adapter therefore keeps Arrow/Polars and
+`TableConfig` as the typed boundary while the spike proves whether live XTDB
+ingestion preserves the precision and nullability guarantees required by
+Whengas.
+
+The first live pgwire round trip passes against `ghcr.io/xtdb/xtdb:nightly`:
+
+```bash
+POLARS_HIST_DB_XTDB_LIVE=1 uv run --extra xtdb \
+  python -m pytest tests/backends/test_xtdb_live.py -m integration -q
+```
+
+The live test exposed important pgwire compatibility details:
+
+- The SQLAlchemy PostgreSQL dialect needs small XTDB-specific startup
+  adjustments: connect to the `xtdb` database, disable native hstore probing,
+  and skip the `SHOW standard_conforming_strings` dialect probe.
+- XTDB separates query and DML transactions more strictly than PostgreSQL.
+  The adapter leaves reads in normal read-only transactions and wraps DML in
+  explicit `BEGIN READ WRITE` blocks.
+- Psycopg parameter OIDs are not sufficient for the current DML path, so the
+  spike emits typed SQL literals for inserts. This proves create/append/read
+  viability, but bulk ingestion should move to XTDB ADBC because it is the
+  Arrow-native path documented by XTDB and avoids row-by-row SQL literal work.
+
+The first live ADBC/FlightSQL round trip also passes against the same nightly
+image:
+
+```bash
+POLARS_HIST_DB_XTDB_LIVE=1 uv run --extra xtdb \
+  python -m pytest tests/backends/test_xtdb_adbc_live.py -m integration -q
+```
+
+The current adapter keeps this as an explicit sidecar path:
+
+- `XtdbBackend.create_engine(...)` remains the pgwire/SQLAlchemy path for
+  existing query and control-plane compatibility.
+- `XtdbBackend.create_adbc_connection(...)` opens `grpc://host:adbc_port`,
+  defaulting XTDB `adbc_port` to `9832`.
+- `XtdbBackend.adbc_dataframes(connection)` ingests Polars dataframes through
+  Arrow/ADBC and reads query results back through `fetch_arrow_table()`.
+- XTDB FlightSQL accepts schema-targeted ingest through ADBC's
+  `db_schema_name` option, so the ADBC path can preserve configured table
+  schemas.
+- Polars emits Arrow `large_string` columns. The current XTDB nightly rejects
+  `large_string` on ingest, so the adapter normalises large string and
+  dictionary-large-string columns to Arrow `string` at the XTDB ingest
+  boundary. This preserves values while avoiding the pgwire literal path.
+
+The first temporal upsert parity slice now uses XTDB's native insert-as-upsert
+behaviour:
+
+- `XtdbBackend.temporal_upsert(...)` delegates to the configured dataframe
+  insert path. XTDB creates a new temporal version when an existing `_id`
+  changes.
+- A live ADBC test proves latest state and `FOR SYSTEM_TIME AS OF` both work:
+  after two upserts for the same configured primary key, latest reads the new
+  value and an as-of checkpoint between commits reads the previous value.
+- MariaDB's synthetic system-versioning time (`SET @@timestamp`) maps to
+  XTDB's transaction-level `BEGIN READ WRITE WITH (SYSTEM_TIME = ...)` option
+  on the SQL/pgwire path. This is intended for initial backfills and must be
+  monotonic: XTDB rejects a transaction system-time earlier than the current
+  database transaction time.
+- A live pgwire test proves `update_time` is stored as XTDB system-time. The
+  test imports two future system-time versions and queries with explicit
+  `FOR VALID_TIME AS OF ... FOR SYSTEM_TIME AS OF ...` bases to account for
+  XTDB's independent valid-time and system-time axes.
+- ADBC bulk ingest does not yet support `update_time` in this adapter. It still
+  works for commit-time system history, but imported system-time currently uses
+  pgwire SQL transactions.
+- The current delta parity slice supports `DeltaConfig(drop_unchanged_rows=True)`,
+  `on_duplicate_key`, and `row_finality` values `disabled` and `dropout` for
+  single-key XTDB tables. The adapter applies the source duplicate policy before
+  writing: the default `error` mode rejects duplicate source keys, while
+  `take_first` and `take_last` preserve the selected source row. For dropout
+  finality it temporally deletes current rows whose `_id` is missing from the
+  incoming snapshot. It then compares incoming rows against the current row at
+  the same temporal basis and skips rows whose configured values are unchanged.
+- A live test proves the unchanged update returns zero changed rows and does
+  not create a transaction at the unchanged `update_time`; the subsequent
+  changed update remains visible through as-of valid-time/system-time queries.
+  Full `FOR VALID_TIME ALL FOR SYSTEM_TIME ALL` history can show more rows than
+  the count of submitted changes because XTDB exposes the full bitemporal
+  matrix. Tests should assert transaction/system-time and as-of state
+  invariants, not assume one displayed row per logical source update.
+- A live test proves dropout finality removes a missing row from later
+  valid-time/system-time as-of reads while preserving the earlier as-of
+  snapshot.
+- Explicit XTDB valid-time columns are supported on the pgwire insert path:
+  `_valid_from` / `_valid_to` pass through dataframe upserts, and
+  unchanged-row filtering treats source valid-window changes as meaningful
+  changes. A live test proves a row with an explicit valid-time window is only
+  visible inside that window.
+- Dataset configs can declare per-table valid-time mappings:
+  `valid_time: [{table: cargos, from_column: msg_timestamp}]`. The XTDB
+  temporal upsert path copies the configured `from_column` to `_valid_from`
+  and optional `to_column` to `_valid_to`, preserving the original source
+  columns. This keeps feed semantics YAML-controlled: cargo snapshots can use
+  message/as-of time, vessel vectors can use source position time, and future
+  rate feeds can use explicit validity windows.
+- Dataset ingestion keeps an explicit staging phase for XTDB. The adapter
+  writes each partition to a retained internal table named
+  `__<dataset>_stage`, keyed by `stage_run_id` and `stage_row_index`, then
+  deletes only that `stage_run_id` after the upload finishes. This mirrors the
+  MariaDB pattern of reusing the staging schema while keeping staged data scoped
+  to one upload.
+- XTDB staging preserves pipeline source-to-target column mapping, duplicate
+  removal, default filling, `update_time` system-time import, per-table
+  valid-time mapping, and `deduce_foreign_key` normalization for textual target
+  key columns. Missing normalized rows get deterministic IDs of the form
+  `xtdb-fk-v1:<schema>.<table>:<natural-key-json>`. Numeric generated IDs need
+  a separate allocator before they can be supported safely.
+- MariaDB continues to treat `__valid_from` / `__valid_to` as system-version
+  history. Dataset valid-time mappings are XTDB business valid-time inputs and
+  are not equivalent to MariaDB's generated system-time columns.
+
+## Migration Decision
+
+Do not start by replacing MariaDB. Start by extracting the backend contract and
+building a minimal XTDB adapter behind it. The decision to migrate should be
+based on parity tests, representative benchmarks, and operational confidence.
+
+For Whengas, the practical default is:
+
+- Keep MariaDB as the production backend while the adapter boundary is created.
+- Build XTDB as an experimental backend.
+- Compare both backends with cargo, vessel, netbacks, and pipe/storage-shaped
+  datasets.
+- Migrate only after typed temporal reads, writes, update visibility, and
+  operational recovery are proven.

--- a/docs/configuration.qmd
+++ b/docs/configuration.qmd
@@ -18,6 +18,20 @@ db:
   password: admin
 ```
 
+`backend` defaults to `mariadb` when omitted. Supported backend names are:
+
+- `mariadb` - the default and currently complete production backend.
+- `xtdb` - experimental backend path for the XTDB spike. Install with the
+  `xtdb` optional dependency before creating an XTDB engine. The optional
+  dependency includes the binary psycopg wrapper for pgwire and the ADBC
+  FlightSQL driver for Arrow-native bulk ingest.
+- `mssql` - reserved for a future MS SQL adapter.
+
+XTDB uses two ports when both backend paths are enabled:
+
+- `port` defaults to `5432` for the pgwire/SQLAlchemy path.
+- `adbc_port` defaults to `9832` for the ADBC/FlightSQL path.
+
 ## table_configs
 
 A collection of tables that will be managed by this configuration.

--- a/polars_hist_db/backends/__init__.py
+++ b/polars_hist_db/backends/__init__.py
@@ -1,0 +1,32 @@
+from .base import HistoricalDbBackend
+from .config import BackendName, DbEngineConfig
+
+__all__ = [
+    "BackendName",
+    "DbEngineConfig",
+    "HistoricalDbBackend",
+    "MariaDbBackend",
+    "XtdbBackend",
+    "backend_from_config",
+    "get_backend",
+]
+
+
+def __getattr__(name: str):
+    if name == "MariaDbBackend":
+        from .mariadb import MariaDbBackend
+
+        return MariaDbBackend
+    if name == "XtdbBackend":
+        from .xtdb import XtdbBackend
+
+        return XtdbBackend
+    if name == "backend_from_config":
+        from .registry import backend_from_config
+
+        return backend_from_config
+    if name == "get_backend":
+        from .registry import get_backend
+
+        return get_backend
+    raise AttributeError(name)

--- a/polars_hist_db/backends/base.py
+++ b/polars_hist_db/backends/base.py
@@ -1,0 +1,11 @@
+from typing import Any, Protocol
+
+
+class HistoricalDbBackend(Protocol):
+    name: str
+
+    def dataframes(self, connection: Any) -> Any: ...
+
+    def table_configs(self, connection: Any) -> Any: ...
+
+    def tables(self, table_schema: str, table_name: str, connection: Any) -> Any: ...

--- a/polars_hist_db/backends/config.py
+++ b/polars_hist_db/backends/config.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, Optional
+
+
+BackendName = Literal["mariadb", "xtdb", "mssql"]
+
+
+def _default_port(backend: str) -> int:
+    if backend == "xtdb":
+        return 5432
+    if backend == "mssql":
+        return 1433
+    return 3306
+
+
+def _default_adbc_port(backend: str) -> Optional[int]:
+    if backend == "xtdb":
+        return 9832
+    return None
+
+
+def _parse_port(value: Any, backend: str) -> int:
+    if value is None:
+        return _default_port(backend)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return _default_port(backend)
+
+
+def _parse_optional_port(value: Any, backend: str) -> Optional[int]:
+    if value is None:
+        return _default_adbc_port(backend)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return _default_adbc_port(backend)
+
+
+@dataclass(frozen=True)
+class DbEngineConfig:
+    backend: BackendName = "mariadb"
+    hostname: str = "127.0.0.1"
+    port: int = 3306
+    adbc_port: Optional[int] = None
+    database: Optional[str] = None
+    username: Optional[str] = None
+    password: Optional[str] = None
+    ssl_config: Optional[Mapping[str, Any]] = None
+    pool_size: int = 3
+    max_overflow: int = 2
+
+    @classmethod
+    def from_mapping(cls, cfg: Mapping[str, Any]) -> "DbEngineConfig":
+        backend = str(cfg.get("backend", "mariadb")).lower()
+        return cls(
+            backend=_validate_backend(backend),
+            hostname=str(cfg.get("hostname", "127.0.0.1")),
+            port=_parse_port(cfg.get("port"), backend),
+            adbc_port=_parse_optional_port(cfg.get("adbc_port"), backend),
+            database=cfg.get("database"),
+            username=cfg.get("username"),
+            password=cfg.get("password"),
+            ssl_config=cfg.get("ssl_config"),
+            pool_size=int(cfg.get("pool_size", 3)),
+            max_overflow=int(cfg.get("max_overflow", 2)),
+        )
+
+
+def _validate_backend(backend: str) -> BackendName:
+    if backend in {"mariadb", "xtdb", "mssql"}:
+        return backend  # type: ignore[return-value]
+    raise ValueError(f"Unsupported database backend '{backend}'")

--- a/polars_hist_db/backends/mariadb.py
+++ b/polars_hist_db/backends/mariadb.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+
+from ..core import DataframeOps, TableConfigOps, TableOps
+from ..core import TimeHint
+from .config import DbEngineConfig
+from .temporal import system_time_hint_clause
+
+
+@dataclass(frozen=True)
+class MariaDbBackend:
+    name: str = "mariadb"
+
+    def create_engine(self, config: DbEngineConfig) -> Engine:
+        auth = ""
+        if config.username:
+            auth = config.username
+            if config.password:
+                auth = f"{auth}:{config.password}"
+            auth = f"{auth}@"
+
+        url = f"mariadb+pymysql://{auth}{config.hostname}:{config.port}"
+        return create_engine(
+            url,
+            pool_size=config.pool_size,
+            max_overflow=config.max_overflow,
+        )
+
+    def dataframes(self, connection: Any) -> DataframeOps:
+        return DataframeOps(connection)
+
+    def table_configs(self, connection: Any) -> TableConfigOps:
+        return TableConfigOps(connection)
+
+    def tables(self, table_schema: str, table_name: str, connection: Any) -> TableOps:
+        return TableOps(table_schema, table_name, connection)
+
+    def time_hint_clause(self, time_hint: TimeHint) -> str | None:
+        return system_time_hint_clause(time_hint)

--- a/polars_hist_db/backends/registry.py
+++ b/polars_hist_db/backends/registry.py
@@ -1,0 +1,18 @@
+from .config import DbEngineConfig
+from .mariadb import MariaDbBackend
+from .xtdb import XtdbBackend
+
+
+def get_backend(name: str = "mariadb"):
+    normalized_name = name.lower()
+    if normalized_name == "mariadb":
+        return MariaDbBackend()
+    if normalized_name == "xtdb":
+        return XtdbBackend()
+    if normalized_name == "mssql":
+        raise NotImplementedError("MS SQL backend is reserved but not implemented yet")
+    raise ValueError(f"Unsupported database backend '{name}'")
+
+
+def backend_from_config(config: DbEngineConfig):
+    return get_backend(config.backend)

--- a/polars_hist_db/backends/temporal.py
+++ b/polars_hist_db/backends/temporal.py
@@ -1,0 +1,9 @@
+from typing import Optional
+
+from ..core import TimeHint
+
+
+def system_time_hint_clause(time_hint: Optional[TimeHint]) -> Optional[str]:
+    if time_hint is None:
+        return None
+    return time_hint.build()

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -1,0 +1,1966 @@
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
+import hashlib
+import json
+import math
+import re
+from typing import Any, Iterable, Literal, Mapping, Optional, cast
+
+import polars as pl
+import pyarrow as pa
+from sqlalchemy import text
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+
+from ..config import (
+    DeltaConfig,
+    ForeignKeyConfig,
+    TableColumnConfig,
+    TableConfig,
+    ValidTimeConfig,
+)
+from ..core import TimeHint
+from ..types import PolarsType
+from .config import DbEngineConfig
+from .temporal import system_time_hint_clause
+
+
+_XTDB_SYSTEM_COLUMNS = {"_valid_from", "_valid_to", "_system_from", "_system_to"}
+_XTDB_READONLY_SYSTEM_COLUMNS = {"_system_from", "_system_to"}
+_XTDB_TABLE_CONFIG_METADATA_TABLE = "__polars_hist_db_xtdb_table_configs"
+_XTDB_STAGE_RUN_ID_COLUMN = "stage_run_id"
+_XTDB_STAGE_ROW_INDEX_COLUMN = "stage_row_index"
+_XTDB_STAGE_PARTITION_TIME_COLUMN = "stage_partition_time"
+_XTDB_LAST_SYSTEM_TIME_KEY = "polars_hist_db_xtdb_last_system_time"
+_XTDB_RESERVED_IDENTIFIERS = {"timestamp"}
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _load_flight_sql() -> Any:
+    try:
+        from adbc_driver_flightsql import dbapi as flight_sql
+    except ImportError as exc:
+        raise RuntimeError(
+            "XTDB ADBC support requires the 'xtdb' extra "
+            "(adbc-driver-flightsql). Install with polars-hist-db[xtdb]."
+        ) from exc
+    return flight_sql
+
+
+def _xtdb_type_to_config_type(data_type: str) -> str:
+    normalized = data_type.upper()
+    xtdb_types = {
+        ":I8": "TINYINT",
+        ":I16": "SMALLINT",
+        ":I32": "INT",
+        ":I64": "BIGINT",
+        ":F32": "FLOAT",
+        ":F64": "DOUBLE",
+        ":UTF8": "VARCHAR(255)",
+        ":BOOL": "BOOLEAN",
+        ":BOOLEAN": "BOOLEAN",
+        ":DATE": "DATE",
+        ":TIMESTAMP": "TIMESTAMP",
+    }
+    return xtdb_types.get(normalized, normalized)
+
+
+def _is_nullable(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).upper() in {"YES", "TRUE", "1"}
+
+
+def _validate_identifier(identifier: str) -> str:
+    if not _IDENTIFIER_RE.match(identifier):
+        raise ValueError(f"Unsupported XTDB identifier: {identifier!r}")
+    return identifier
+
+
+def _quote_identifier(identifier: str) -> str:
+    if (
+        _IDENTIFIER_RE.match(identifier)
+        and identifier == identifier.lower()
+        and identifier not in _XTDB_RESERVED_IDENTIFIERS
+    ):
+        return identifier
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _qualified_table_name(table_schema: str, table_name: str) -> str:
+    return f"{_validate_identifier(table_schema)}.{_validate_identifier(table_name)}"
+
+
+def _xtdb_table_config_metadata_table(table_schema: str) -> str:
+    return _qualified_table_name(table_schema, _XTDB_TABLE_CONFIG_METADATA_TABLE)
+
+
+def _apply_schema_overrides(
+    df: pl.DataFrame,
+    schema_overrides: Optional[Mapping[str, pl.DataType]],
+) -> pl.DataFrame:
+    if not schema_overrides:
+        return df
+
+    casts = {
+        column: dtype
+        for column, dtype in schema_overrides.items()
+        if column in df.columns
+    }
+    if not casts:
+        return df
+    return df.with_columns(
+        pl.col(column).cast(dtype) for column, dtype in casts.items()
+    )
+
+
+def _normalize_xtdb_ingest_arrow(table: pa.Table) -> pa.Table:
+    for index, field in enumerate(table.schema):
+        if pa.types.is_large_string(field.type):
+            table = table.set_column(
+                index,
+                field.with_type(pa.string()),
+                table.column(field.name).cast(pa.string()),
+            )
+        elif pa.types.is_dictionary(field.type) and pa.types.is_large_string(
+            field.type.value_type
+        ):
+            table = table.set_column(
+                index,
+                field.with_type(pa.string()),
+                table.column(field.name).cast(pa.string()),
+            )
+    return table
+
+
+def _xtdb_declared_columns(table_config: TableConfig) -> list[str]:
+    document_id_columns = _xtdb_document_id_columns(table_config)
+    uses_explicit_id = document_id_columns == ["_id"]
+    uses_single_source_key = len(document_id_columns) == 1 and not uses_explicit_id
+
+    declared_columns = ["_id"]
+    for column in table_config.columns:
+        if column.name in _XTDB_SYSTEM_COLUMNS:
+            continue
+        if uses_explicit_id and column.name == "_id":
+            continue
+        if uses_single_source_key and column.name == document_id_columns[0]:
+            continue
+        declared_columns.append(column.name)
+
+    return [_quote_identifier(column) for column in declared_columns]
+
+
+def _xtdb_stage_table_name(dataset_name: str) -> str:
+    return f"__{dataset_name}_stage"
+
+
+def _xtdb_document_id_columns(table_config: TableConfig) -> list[str]:
+    primary_keys = list(table_config.primary_keys)
+    configured_columns = [column.name for column in table_config.columns]
+
+    if "_id" in configured_columns:
+        return ["_id"]
+    if primary_keys:
+        return primary_keys
+
+    raise ValueError(
+        "XTDB backend requires at least one primary key or an explicit _id column"
+    )
+
+
+def _xtdb_document_id_source(table_config: TableConfig) -> str:
+    document_id_columns = _xtdb_document_id_columns(table_config)
+    if len(document_id_columns) == 1:
+        return document_id_columns[0]
+
+    raise ValueError(
+        "XTDB backend requires a single document id source for this operation"
+    )
+
+
+def _xtdb_json_safe_key_value(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return str(value)
+    return value
+
+
+def _xtdb_composite_document_id(
+    primary_keys: list[str],
+    row: tuple[Any, ...],
+) -> str:
+    encoded_parts = [
+        [key, _xtdb_json_safe_key_value(value)]
+        for key, value in zip(primary_keys, row, strict=True)
+    ]
+    return "xtdb-pk-v1:" + json.dumps(
+        encoded_parts,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
+def _xtdb_table_config_metadata(
+    connection: Any,
+    table_schema: str,
+    table_name: str,
+) -> pl.DataFrame | None:
+    escaped_schema = table_schema.replace("'", "''")
+    escaped_name = table_name.replace("'", "''")
+    try:
+        return pl.read_database(
+            f"""
+            SELECT *
+            FROM {_xtdb_table_config_metadata_table(table_schema)}
+            WHERE table_schema = '{escaped_schema}'
+              AND table_name = '{escaped_name}'
+        """,
+            connection,
+        )
+    except Exception:
+        return None
+
+
+def _xtdb_primary_keys_from_metadata(
+    metadata: pl.DataFrame | None,
+    table_schema: str,
+    table_name: str,
+) -> list[str] | None:
+    if (
+        metadata is None
+        or metadata.is_empty()
+        or "primary_keys_json" not in metadata.columns
+    ):
+        return None
+
+    primary_keys = json.loads(str(metadata[0, "primary_keys_json"]))
+    if not isinstance(primary_keys, list) or not all(
+        isinstance(key, str) for key in primary_keys
+    ):
+        raise ValueError(
+            f"Invalid XTDB table-config metadata for {table_schema}.{table_name}"
+        )
+    return primary_keys
+
+
+def _xtdb_table_config_from_metadata(
+    metadata: pl.DataFrame | None,
+    table_schema: str,
+    table_name: str,
+) -> TableConfig | None:
+    if (
+        metadata is None
+        or metadata.is_empty()
+        or "columns_json" not in metadata.columns
+    ):
+        return None
+
+    columns_json = metadata[0, "columns_json"]
+    if columns_json is None:
+        return None
+
+    raw_columns = json.loads(str(columns_json))
+    if not isinstance(raw_columns, list):
+        raise ValueError(
+            f"Invalid XTDB column metadata for {table_schema}.{table_name}"
+        )
+
+    columns = [
+        TableColumnConfig(**column)
+        for column in raw_columns
+        if isinstance(column, dict)
+    ]
+    primary_keys = _xtdb_primary_keys_from_metadata(
+        metadata,
+        table_schema,
+        table_name,
+    )
+    foreign_keys: list[ForeignKeyConfig] = []
+    if "foreign_keys_json" in metadata.columns:
+        foreign_keys_json = metadata[0, "foreign_keys_json"]
+        if foreign_keys_json is not None:
+            raw_foreign_keys = json.loads(str(foreign_keys_json))
+            if not isinstance(raw_foreign_keys, list):
+                raise ValueError(
+                    f"Invalid XTDB foreign-key metadata for {table_schema}.{table_name}"
+                )
+            foreign_keys = [
+                ForeignKeyConfig(**foreign_key)
+                for foreign_key in raw_foreign_keys
+                if isinstance(foreign_key, dict)
+            ]
+    return TableConfig(
+        name=table_name,
+        schema=table_schema,
+        columns=columns,
+        foreign_keys=foreign_keys,
+        primary_keys=primary_keys or [],
+        is_temporal=True,
+    )
+
+
+def _xtdb_foreign_keys_json(table_config: TableConfig) -> str:
+    foreign_keys = []
+    for foreign_key in table_config.foreign_keys:
+        ref_table = foreign_key.references.table
+        ref_table_name = (
+            ref_table.name if isinstance(ref_table, TableConfig) else str(ref_table)
+        )
+        foreign_keys.append(
+            {
+                "name": foreign_key.name,
+                "references": {
+                    "schema": foreign_key.references.schema,
+                    "table": ref_table_name,
+                    "column": foreign_key.references.column,
+                },
+            }
+        )
+    return json.dumps(foreign_keys, separators=(",", ":"))
+
+
+def _xtdb_id_policy(table_config: TableConfig) -> str:
+    document_id_columns = _xtdb_document_id_columns(table_config)
+    if document_id_columns == ["_id"]:
+        return "explicit-id"
+    if len(document_id_columns) == 1:
+        return "single-key"
+    return "xtdb-pk-v1"
+
+
+def _xtdb_cast_type(data_type: str) -> str:
+    normalized = data_type.upper()
+    if normalized.startswith(("VARCHAR", "CHAR", "TEXT")):
+        return "TEXT"
+    if normalized in {"DOUBLE", "DOUBLE PRECISION"}:
+        return "DOUBLE PRECISION"
+    if normalized in {"FLOAT", "REAL"}:
+        return "FLOAT"
+    if normalized in {"INT", "INTEGER"}:
+        return "INTEGER"
+    if normalized in {"BOOL", "BOOLEAN"}:
+        return "BOOLEAN"
+    if normalized in {"BIT", "TINYINT", "SMALLINT", "MEDIUMINT"}:
+        return "INTEGER"
+    if normalized in {"BIGINT", "DATE", "TIME"}:
+        return normalized
+    if normalized == "DATETIME":
+        return "TIMESTAMP"
+    if normalized.startswith(("DECIMAL", "NUMERIC")):
+        return normalized
+    if normalized.startswith("TIMESTAMP"):
+        return normalized
+    return "TEXT"
+
+
+def _xtdb_cast_type_from_polars(dtype: pl.DataType) -> str:
+    if dtype in {pl.Int8, pl.Int16, pl.Int32}:
+        return "INTEGER"
+    if dtype == pl.Int64:
+        return "BIGINT"
+    if dtype == pl.Float32:
+        return "FLOAT"
+    if dtype == pl.Float64:
+        return "DOUBLE PRECISION"
+    if dtype == pl.Boolean:
+        return "BOOLEAN"
+    if dtype == pl.Date:
+        return "DATE"
+    if isinstance(dtype, pl.Datetime):
+        return "TIMESTAMP"
+    return "TEXT"
+
+
+def _xtdb_insert_casts(
+    df: pl.DataFrame,
+    table_config: Optional[TableConfig],
+) -> list[str]:
+    configured_types = {}
+    if table_config is not None:
+        document_id_columns = _xtdb_document_id_columns(table_config)
+        if len(document_id_columns) > 1:
+            configured_types["_id"] = "TEXT"
+        for column in table_config.columns:
+            target_name = (
+                "_id"
+                if len(document_id_columns) == 1
+                and column.name == document_id_columns[0]
+                else column.name
+            )
+            configured_types[target_name] = _xtdb_cast_type(column.data_type)
+
+    casts = []
+    for name, dtype in df.schema.items():
+        casts.append(configured_types.get(name, _xtdb_cast_type_from_polars(dtype)))
+    return casts
+
+
+def _prepare_xtdb_insert_dataframe(
+    df: pl.DataFrame,
+    table_config: Optional[TableConfig],
+) -> pl.DataFrame:
+    if table_config is None:
+        return df
+
+    document_id_columns = _xtdb_document_id_columns(table_config)
+    if document_id_columns == ["_id"]:
+        return df
+    if "_id" in df.columns:
+        raise ValueError(
+            "XTDB insert dataframe already contains _id and cannot also map "
+            "configured primary keys to _id"
+        )
+    missing_keys = [key for key in document_id_columns if key not in df.columns]
+    if missing_keys:
+        raise ValueError(
+            "XTDB insert dataframe is missing configured primary key columns "
+            f"{missing_keys!r}"
+        )
+
+    if len(document_id_columns) == 1:
+        return df.rename({document_id_columns[0]: "_id"})
+
+    document_ids = [
+        _xtdb_composite_document_id(document_id_columns, row)
+        for row in df.select(document_id_columns).iter_rows()
+    ]
+
+    return df.with_columns(pl.Series("_id", document_ids)).select(["_id", *df.columns])
+
+
+def _apply_xtdb_duplicate_policy(
+    df: pl.DataFrame,
+    table_config: TableConfig,
+    delta_config: DeltaConfig,
+) -> pl.DataFrame:
+    if df.is_empty():
+        return df
+
+    row_index = "__xtdb_duplicate_row_index"
+    indexed_df = df.with_row_index(row_index)
+    prepared = _prepare_xtdb_insert_dataframe(indexed_df, table_config)
+
+    duplicate_count_column = "__xtdb_duplicate_count"
+    duplicate_keys = (
+        prepared.group_by("_id")
+        .agg(pl.len().alias(duplicate_count_column))
+        .filter(pl.col(duplicate_count_column) > 1)
+    )
+    if duplicate_keys.is_empty():
+        return df
+
+    if delta_config.on_duplicate_key == "error":
+        raise ValueError("XTDB delta upsert found duplicate source keys")
+
+    keep: Literal["first", "last"] = (
+        "first" if delta_config.on_duplicate_key == "take_first" else "last"
+    )
+    selected_rows = (
+        prepared.select([row_index, "_id"])
+        .unique(subset=["_id"], keep=keep, maintain_order=True)
+        .select(row_index)
+    )
+    return indexed_df.join(selected_rows, on=row_index, how="inner").drop(row_index)
+
+
+def _xtdb_document_id_cast_type(table_config: TableConfig) -> str:
+    document_id_columns = _xtdb_document_id_columns(table_config)
+    if len(document_id_columns) > 1:
+        return "TEXT"
+    source_key = document_id_columns[0]
+    for column in table_config.columns:
+        if column.name == source_key:
+            return _xtdb_cast_type(column.data_type)
+    return "TEXT"
+
+
+def _delete_xtdb_missing_rows(
+    df: pl.DataFrame,
+    table_schema: str,
+    table_name: str,
+    table_config: TableConfig,
+    dataframe_ops: "XtdbDataframeOps",
+    update_time: Optional[datetime],
+    dropout_close_time: Optional[datetime],
+) -> int:
+    current = dataframe_ops.from_raw_sql(
+        "SELECT _id FROM "
+        f"{_qualified_table_name(table_schema, table_name)}"
+        f"{_xtdb_temporal_basis_clause(update_time)}"
+    )
+    if current.is_empty():
+        return 0
+
+    document_id_columns = _xtdb_document_id_columns(table_config)
+
+    incoming_ids = _prepare_xtdb_insert_dataframe(
+        df.select(document_id_columns).unique(maintain_order=True),
+        table_config,
+    )
+    missing_ids = (
+        current.select("_id")
+        .join(incoming_ids.select("_id"), on="_id", how="anti")
+        .get_column("_id")
+        .to_list()
+    )
+    if not missing_ids:
+        return 0
+
+    id_cast_type = _xtdb_document_id_cast_type(table_config)
+    ids_sql = ", ".join(_xtdb_sql_literal(value, id_cast_type) for value in missing_ids)
+    valid_time_clause = ""
+    close_time = _xtdb_dropout_close_time(df, dropout_close_time, update_time)
+    if close_time is not None:
+        valid_time_clause = (
+            " FOR PORTION OF VALID_TIME FROM "
+            f"{_xtdb_timestamp_literal(close_time)} TO NULL"
+        )
+    delete_sql = (
+        f"DELETE FROM {_qualified_table_name(table_schema, table_name)}"
+        f"{valid_time_clause} "
+        f"WHERE _id IN ({ids_sql})"
+    )
+    _execute_xtdb_dml(
+        dataframe_ops.connection,
+        delete_sql,
+        system_time=update_time,
+    )
+    return len(missing_ids)
+
+
+def _xtdb_dropout_close_time(
+    df: pl.DataFrame,
+    dropout_close_time: Optional[datetime],
+    update_time: Optional[datetime],
+) -> datetime | None:
+    if dropout_close_time is not None:
+        return dropout_close_time
+    if "_valid_from" not in df.columns or df.is_empty():
+        return update_time
+
+    close_times = df.select("_valid_from").drop_nulls().unique()
+    if close_times.height == 0:
+        return update_time
+    if close_times.height > 1:
+        raise ValueError(
+            "XTDB row_finality='dropout' requires a single _valid_from value "
+            "when update_time is not provided"
+        )
+
+    close_time = close_times.item()
+    if not isinstance(close_time, datetime):
+        raise ValueError(
+            "XTDB row_finality='dropout' _valid_from values must be datetimes"
+        )
+    return close_time
+
+
+def _driver_connection(connection: Any) -> Any | None:
+    proxied_connection = getattr(connection, "connection", None)
+    return getattr(proxied_connection, "driver_connection", None)
+
+
+def _xtdb_timestamp_literal(value: datetime) -> str:
+    escaped = value.isoformat().replace("'", "''")
+    return f"TIMESTAMP '{escaped}'"
+
+
+def _next_xtdb_system_time(connection: Any, system_time: datetime) -> datetime:
+    info = getattr(connection, "info", None)
+    if not isinstance(info, dict):
+        return system_time
+
+    last_system_time = info.get(_XTDB_LAST_SYSTEM_TIME_KEY)
+    if isinstance(last_system_time, datetime) and system_time <= last_system_time:
+        system_time = last_system_time + timedelta(microseconds=1)
+    info[_XTDB_LAST_SYSTEM_TIME_KEY] = system_time
+    return system_time
+
+
+def _is_xtdb_invalid_system_time_error(exc: Exception) -> bool:
+    message = str(exc)
+    return "invalid-system-time" in message or "specified system-time older" in message
+
+
+def _execute_xtdb_dml(
+    connection: Any,
+    sql: str,
+    rows: list[tuple[Any, ...]] | None = None,
+    *,
+    system_time: Optional[datetime] = None,
+) -> int:
+    driver_connection = _driver_connection(connection)
+    if driver_connection is None:
+        if rows is not None or system_time is not None:
+            raise ValueError(
+                "XTDB dataframe writes with rows or system-time require a live "
+                "DBAPI connection"
+            )
+        connection.execute(text(sql))
+        return 0
+
+    if getattr(connection, "in_transaction", lambda: False)():
+        connection.commit()
+
+    begin_sql = "BEGIN READ WRITE"
+    if system_time is not None:
+        system_time = _next_xtdb_system_time(connection, system_time)
+        begin_sql = (
+            "BEGIN READ WRITE WITH "
+            f"(SYSTEM_TIME = {_xtdb_timestamp_literal(system_time)})"
+        )
+    driver_connection.execute(begin_sql)
+    try:
+        if rows is None:
+            driver_connection.execute(sql)
+            row_count = 0
+        else:
+            with driver_connection.cursor() as cursor:
+                cursor.executemany(sql, rows)
+            row_count = len(rows)
+        driver_connection.commit()
+    except Exception as exc:
+        driver_connection.rollback()
+        if system_time is not None and _is_xtdb_invalid_system_time_error(exc):
+            return _execute_xtdb_dml(connection, sql, rows, system_time=None)
+        raise
+    return row_count
+
+
+def _xtdb_sql_literal(value: Any, cast_type: str) -> str:
+    if value is None:
+        return "NULL"
+    if isinstance(value, bool):
+        return f"{'TRUE' if value else 'FALSE'}::{cast_type}"
+    if isinstance(value, int):
+        return f"{value}::{cast_type}"
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("XTDB insert does not support non-finite float values")
+        return f"{value}::{cast_type}"
+    if isinstance(value, Decimal):
+        return f"{value}::{cast_type}"
+    if isinstance(value, datetime):
+        escaped = value.isoformat().replace("'", "''")
+        return f"'{escaped}'::{cast_type}"
+    if isinstance(value, date):
+        escaped = value.isoformat().replace("'", "''")
+        return f"'{escaped}'::{cast_type}"
+
+    escaped = str(value).replace("'", "''")
+    return f"'{escaped}'::{cast_type}"
+
+
+def _xtdb_temporal_basis_clause(update_time: Optional[datetime]) -> str:
+    if update_time is None:
+        return ""
+    timestamp = update_time.isoformat().replace("'", "''")
+    return (
+        f" FOR VALID_TIME AS OF TIMESTAMP '{timestamp}'"
+        f" FOR SYSTEM_TIME AS OF TIMESTAMP '{timestamp}'"
+    )
+
+
+def _xtdb_valid_time_clause(time_hint: Optional[TimeHint]) -> str:
+    if time_hint is None or time_hint.mode == "none":
+        return ""
+    if time_hint.mode == "all":
+        return " FOR VALID_TIME ALL"
+    if time_hint.mode == "asof":
+        assert isinstance(time_hint.asof_utc, datetime)
+        return f" FOR VALID_TIME AS OF {_xtdb_timestamp_literal(time_hint.asof_utc)}"
+    if time_hint.mode == "span":
+        assert isinstance(time_hint.asof_utc, datetime)
+        assert time_hint.history_span is not None
+        if time_hint.history_span.total_seconds() == 0:
+            return (
+                f" FOR VALID_TIME AS OF {_xtdb_timestamp_literal(time_hint.asof_utc)}"
+            )
+        start_date_utc = time_hint.asof_utc - time_hint.history_span
+        return (
+            " FOR VALID_TIME BETWEEN "
+            f"{_xtdb_timestamp_literal(start_date_utc)} AND "
+            f"{_xtdb_timestamp_literal(time_hint.asof_utc)}"
+        )
+
+    raise ValueError(f"invalid TimeHint mode: {time_hint.mode}")
+
+
+def _xtdb_single_primary_key_alias(table_config: TableConfig) -> str | None:
+    primary_keys = list(table_config.primary_keys)
+    if len(primary_keys) != 1:
+        return None
+    primary_key = primary_keys[0]
+    if primary_key != "_id":
+        return primary_key
+    return None
+
+
+def _xtdb_table_query_output_columns(
+    table_config: TableConfig,
+    column_selection: Optional[list[str]],
+) -> list[str]:
+    if column_selection is not None:
+        return column_selection
+
+    columns = []
+    single_key_alias = _xtdb_single_primary_key_alias(table_config)
+    if single_key_alias is not None:
+        columns.append(single_key_alias)
+
+    columns.extend(
+        column.name
+        for column in table_config.columns
+        if column.name not in {"_id", single_key_alias, *_XTDB_SYSTEM_COLUMNS}
+    )
+    columns.extend(["__valid_from", "__valid_to"])
+    return columns
+
+
+def _xtdb_table_query_select_expr(column: str, table_config: TableConfig) -> str:
+    single_key_alias = _xtdb_single_primary_key_alias(table_config)
+    if single_key_alias == column:
+        return f"t._id AS {_quote_identifier(column)}"
+    if column == "__valid_from":
+        return "t._valid_from AS __valid_from"
+    if column == "__valid_to":
+        return "t._valid_to AS __valid_to"
+    return f"t.{_quote_identifier(column)}"
+
+
+def _xtdb_table_query_target_column(column: str, table_config: TableConfig) -> str:
+    if _xtdb_single_primary_key_alias(table_config) == column:
+        return "_id"
+    return _quote_identifier(column)
+
+
+def _xtdb_values_cte(name: str, df: pl.DataFrame) -> str:
+    if df.is_empty():
+        raise ValueError("XTDB table_query requires at least one query row")
+
+    cte_name = _validate_identifier(name)
+    columns = [_quote_identifier(column) for column in df.columns]
+    casts = [_xtdb_cast_type_from_polars(dtype) for dtype in df.schema.values()]
+    row_queries = []
+    for row in df.rows():
+        select_sql = ", ".join(
+            f"{_xtdb_sql_literal(value, cast)} AS {column}"
+            for value, cast, column in zip(row, casts, columns, strict=True)
+        )
+        row_queries.append(f"SELECT {select_sql}")
+    return f"{cte_name} AS ({' UNION ALL '.join(row_queries)})"
+
+
+def _xtdb_polars_type_or_none(data_type: str) -> pl.DataType | None:
+    try:
+        return PolarsType.from_sql(data_type)
+    except ValueError:
+        return None
+
+
+def _xtdb_default_value(default_value: object, data_type: str) -> object:
+    if default_value is None:
+        return None
+
+    dtype = PolarsType.from_sql(data_type)
+    value = str(default_value)
+    if dtype == pl.Boolean:
+        return value.strip().lower() in {"1", "true", "t", "yes", "y"}
+    if dtype == pl.Date:
+        return date.fromisoformat(value)
+    if dtype == pl.Time:
+        return time.fromisoformat(value)
+    if isinstance(dtype, pl.Datetime):
+        return datetime.fromisoformat(value)
+    if isinstance(dtype, pl.Decimal):
+        return Decimal(value)
+    if dtype.is_integer():
+        return int(value)
+    if dtype.is_float():
+        return float(value)
+    return default_value
+
+
+def _fill_xtdb_defaults(df: pl.DataFrame, table_config: TableConfig) -> pl.DataFrame:
+    for column in table_config.columns:
+        if column.name not in df.columns or column.default_value is None:
+            continue
+
+        target_dtype = PolarsType.from_sql(column.data_type)
+        fill_dtype = df[column.name].dtype
+        if fill_dtype == pl.Null:
+            fill_dtype = target_dtype
+
+        default_value = _xtdb_default_value(column.default_value, column.data_type)
+        df = df.with_columns(
+            pl.col(column.name)
+            .cast(fill_dtype)
+            .fill_null(pl.lit(default_value).cast(fill_dtype))
+        )
+    return df
+
+
+def _xtdb_value_compare_dtypes(table_config: TableConfig) -> dict[str, pl.DataType]:
+    document_id_columns = _xtdb_document_id_columns(table_config)
+    uses_single_source_key = len(document_id_columns) == 1
+    dtypes = {}
+    for column in table_config.columns:
+        target_name = (
+            "_id"
+            if uses_single_source_key and column.name == document_id_columns[0]
+            else column.name
+        )
+        dtypes[target_name] = PolarsType.from_sql(column.data_type)
+    return dtypes
+
+
+def _apply_xtdb_compare_dtypes(
+    df: pl.DataFrame,
+    columns: Iterable[str],
+    dtypes: Mapping[str, pl.DataType],
+) -> pl.DataFrame:
+    casts = [
+        pl.col(column).cast(dtypes[column])
+        for column in columns
+        if column in df.columns and column in dtypes
+    ]
+    if not casts:
+        return df
+    return df.with_columns(casts)
+
+
+def _filter_xtdb_unchanged_rows(
+    df: pl.DataFrame,
+    table_schema: str,
+    table_name: str,
+    table_config: TableConfig,
+    dataframe_ops: Any,
+    update_time: Optional[datetime],
+) -> pl.DataFrame:
+    if df.is_empty():
+        return df
+
+    row_index = "__xtdb_row_index"
+    exists_column = "__xtdb_exists"
+    indexed_df = df.with_row_index(row_index)
+    incoming = _prepare_xtdb_insert_dataframe(indexed_df, table_config)
+
+    table_sql = _qualified_table_name(table_schema, table_name)
+    current = dataframe_ops.from_raw_sql(
+        f"SELECT * FROM {table_sql}{_xtdb_temporal_basis_clause(update_time)}"
+    )
+    if current.is_empty():
+        return df
+
+    compare_columns = [
+        column
+        for column in incoming.columns
+        if column not in {row_index, "_valid_from", *_XTDB_READONLY_SYSTEM_COLUMNS}
+        and column in current.columns
+    ]
+    if "_id" not in compare_columns:
+        raise ValueError("XTDB delta upsert requires current rows to include _id")
+
+    value_columns = [column for column in compare_columns if column != "_id"]
+    compare_dtypes = _xtdb_value_compare_dtypes(table_config)
+    incoming = _apply_xtdb_compare_dtypes(incoming, value_columns, compare_dtypes)
+    current = _apply_xtdb_compare_dtypes(current, value_columns, compare_dtypes)
+    current_projection = current.select(compare_columns).with_columns(
+        pl.lit(True).alias(exists_column)
+    )
+    current_projection = current_projection.rename(
+        {column: f"{column}__xtdb_current" for column in value_columns}
+    )
+
+    joined = incoming.join(current_projection, on="_id", how="left")
+    keep_expr = pl.col(exists_column).is_null()
+    for column in value_columns:
+        current_column = f"{column}__xtdb_current"
+        equal_expr = (
+            (pl.col(column) == pl.col(current_column))
+            | (pl.col(column).is_null() & pl.col(current_column).is_null())
+        ).fill_null(False)
+        keep_expr = keep_expr | equal_expr.not_()
+
+    changed_row_indexes = joined.filter(keep_expr).select(row_index)
+    return indexed_df.join(changed_row_indexes, on=row_index, how="inner").drop(
+        row_index
+    )
+
+
+def _apply_xtdb_valid_time_mapping(
+    df: pl.DataFrame, valid_time: Optional[ValidTimeConfig]
+) -> pl.DataFrame:
+    if valid_time is None:
+        return df
+
+    mappings = {
+        valid_time.from_column: "_valid_from",
+    }
+    if valid_time.to_column is not None:
+        mappings[valid_time.to_column] = "_valid_to"
+
+    missing_columns = [source for source in mappings if source not in df.columns]
+    if missing_columns:
+        raise ValueError(
+            "XTDB valid-time mapping references missing source column(s): "
+            + ", ".join(missing_columns)
+        )
+
+    for source, target in mappings.items():
+        if target in df.columns and source != target:
+            raise ValueError(
+                f"XTDB valid-time mapping cannot write {target}; "
+                "the dataframe already contains that column"
+            )
+
+    return df.with_columns(
+        pl.col(source).alias(target)
+        for source, target in mappings.items()
+        if source != target
+    )
+
+
+def _fill_xtdb_staging_defaults(
+    df: pl.DataFrame, table_config: TableConfig
+) -> pl.DataFrame:
+    return _fill_xtdb_defaults(df, table_config)
+
+
+def _dedupe_xtdb_staging_dataframe(
+    df: pl.DataFrame, uniqueness_col_set: Iterable[str]
+) -> pl.DataFrame:
+    unique_columns = [column for column in uniqueness_col_set if column in df.columns]
+    if not unique_columns:
+        return df.unique(keep="last", maintain_order=True)
+    return df.unique(subset=unique_columns, keep="last", maintain_order=True)
+
+
+def _include_xtdb_valid_time_source_columns(
+    selected_columns: list[str],
+    src_tgt_colname_map: dict[str, str],
+    valid_time: Optional[ValidTimeConfig],
+    stage_df: pl.DataFrame,
+) -> list[str]:
+    result = list(selected_columns)
+    if valid_time is None:
+        return result
+
+    target_to_source = {
+        target: source for source, target in src_tgt_colname_map.items()
+    }
+    for valid_time_column in [valid_time.from_column, valid_time.to_column]:
+        if valid_time_column is None:
+            continue
+        source_column = target_to_source.get(valid_time_column, valid_time_column)
+        if source_column in stage_df.columns and source_column not in result:
+            result.append(source_column)
+    return result
+
+
+def _project_xtdb_staged_pipeline_item_dataframe(
+    stage_df: pl.DataFrame,
+    dataset: Any,
+    pipeline_id: int,
+    valid_time: Optional[ValidTimeConfig],
+) -> pl.DataFrame:
+    upload_items = dataset.pipeline.extract_items(pipeline_id)
+    src_tgt_colname_map = dict(upload_items.select("source", "target").iter_rows())
+    selected_columns = upload_items["source"].to_list()
+    selected_columns = _include_xtdb_valid_time_source_columns(
+        selected_columns,
+        src_tgt_colname_map,
+        valid_time,
+        stage_df,
+    )
+
+    missing_columns = sorted(set(selected_columns).difference(stage_df.columns))
+    if missing_columns:
+        raise ValueError(
+            "column mismatch on "
+            f"{set(missing_columns)} in {upload_items['source'].to_list()}"
+        )
+
+    return stage_df.select(selected_columns).rename(
+        {
+            source: target
+            for source, target in src_tgt_colname_map.items()
+            if source in selected_columns and source != target
+        }
+    )
+
+
+def _xtdb_deduced_foreign_key_columns(col_info: pl.DataFrame) -> dict[str, str]:
+    return dict(
+        col_info.filter("deduce_foreign_key").select("source", "target").iter_rows()
+    )
+
+
+def _xtdb_deduced_value_columns(col_info: pl.DataFrame) -> dict[str, str]:
+    return dict(
+        col_info.filter(pl.col("deduce_foreign_key").not_())
+        .select("source", "target")
+        .iter_rows()
+    )
+
+
+def _xtdb_is_textual_config_column(table_config: TableConfig, column_name: str) -> bool:
+    column = next(
+        (column for column in table_config.columns if column.name == column_name), None
+    )
+    if column is None:
+        return False
+    data_type = column.data_type.upper()
+    return any(token in data_type for token in ["CHAR", "TEXT", "STRING", "VARCHAR"])
+
+
+def _xtdb_is_integer_config_column(table_config: TableConfig, column_name: str) -> bool:
+    column = next(
+        (column for column in table_config.columns if column.name == column_name), None
+    )
+    if column is None:
+        return False
+    data_type = column.data_type.upper()
+    return data_type in {"BIGINT", "INT", "INTEGER", "MEDIUMINT", "SMALLINT", "TINYINT"}
+
+
+def _xtdb_deduced_foreign_key_id(
+    table_config: TableConfig,
+    value_targets: list[str],
+    row: dict[str, Any],
+) -> str:
+    encoded_parts = [
+        [column, _xtdb_json_safe_key_value(row[column])] for column in value_targets
+    ]
+    return f"xtdb-fk-v1:{table_config.schema}.{table_config.name}:" + json.dumps(
+        encoded_parts, separators=(",", ":"), ensure_ascii=False
+    )
+
+
+def _xtdb_deduced_numeric_foreign_key_id(
+    table_config: TableConfig,
+    value_targets: list[str],
+    row: dict[str, Any],
+) -> int:
+    encoded_parts = [
+        [column, _xtdb_json_safe_key_value(row[column])] for column in value_targets
+    ]
+    payload = f"xtdb-fk-v1:{table_config.schema}.{table_config.name}:" + json.dumps(
+        encoded_parts, separators=(",", ":"), ensure_ascii=False
+    )
+    digest = hashlib.sha256(payload.encode("utf-8")).digest()
+    generated = int.from_bytes(digest[:4], "big") & 0x7FFFFFFF
+    return -(generated or 1)
+
+
+def _xtdb_parent_row_cache_key(
+    table_config: TableConfig,
+    columns: Iterable[str],
+    row: dict[str, Any],
+) -> tuple[str, str, str]:
+    encoded_parts = [
+        [column, _xtdb_json_safe_key_value(row[column])] for column in columns
+    ]
+    return (
+        table_config.schema,
+        table_config.name,
+        json.dumps(encoded_parts, separators=(",", ":"), ensure_ascii=False),
+    )
+
+
+def _xtdb_fk_needs_generated_values(stage_df: pl.DataFrame, source_column: str) -> bool:
+    return (
+        source_column not in stage_df.columns
+        or stage_df[source_column].null_count() > 0
+    )
+
+
+def _cast_null_parent_lookup_columns(
+    parent_lookup: pl.DataFrame,
+    generated: pl.DataFrame,
+    lookup_columns: Iterable[str],
+) -> pl.DataFrame:
+    casts = [
+        pl.col(column).cast(generated.schema[column])
+        for column in lookup_columns
+        if column in parent_lookup.columns
+        and column in generated.columns
+        and parent_lookup.schema[column] == pl.Null
+    ]
+    if not casts:
+        return parent_lookup
+    return parent_lookup.with_columns(casts)
+
+
+class XtdbDataframeOps:
+    def __init__(self, connection: Any):
+        self.connection = connection
+
+    def from_raw_sql(
+        self,
+        query: str,
+        schema_overrides: Optional[Mapping[str, pl.DataType]] = None,
+    ) -> pl.DataFrame:
+        if schema_overrides is None:
+            schema_overrides = {}
+        return pl.read_database(
+            query,
+            self.connection,
+            schema_overrides=schema_overrides,
+        )
+
+    def from_table(
+        self,
+        table_schema: str,
+        table_name: str,
+        schema_overrides: Optional[Mapping[str, pl.DataType]] = None,
+        time_hint: Optional[TimeHint] = None,
+    ) -> pl.DataFrame:
+        hint_clause = system_time_hint_clause(time_hint)
+        query = f"SELECT * FROM {table_schema}.{table_name}"
+        if hint_clause:
+            query = f"{query} {hint_clause}"
+
+        return self.from_raw_sql(
+            query,
+            schema_overrides,
+        )
+
+    def table_query(
+        self,
+        table_schema: str,
+        table_name: str,
+        query_df: pl.DataFrame,
+        column_selection: Optional[list[str]],
+        time_hint: TimeHint | None = None,
+    ) -> pl.DataFrame:
+        table_config = XtdbTableConfigOps(self.connection).from_table(
+            table_schema,
+            table_name,
+        )
+        output_columns = _xtdb_table_query_output_columns(
+            table_config,
+            column_selection,
+        )
+        select_sql = ", ".join(
+            _xtdb_table_query_select_expr(column, table_config)
+            for column in output_columns
+        )
+        join_clause = " AND ".join(
+            "t."
+            f"{_xtdb_table_query_target_column(column, table_config)} = "
+            f"q.{_quote_identifier(column)}"
+            for column in query_df.columns
+        )
+        table_sql = _qualified_table_name(table_schema, table_name)
+        valid_time_clause = _xtdb_valid_time_clause(time_hint)
+        query = (
+            f"WITH {_xtdb_values_cte('query_df', query_df)} "
+            f"SELECT {select_sql} "
+            "FROM ("
+            "SELECT *, _valid_from, _valid_to "
+            f"FROM {table_sql}{valid_time_clause}"
+            ") AS t "
+            "JOIN query_df AS q "
+            f"ON {join_clause}"
+        )
+        schema_overrides = {}
+        for column in table_config.columns:
+            if column.name not in output_columns:
+                continue
+            dtype = _xtdb_polars_type_or_none(column.data_type)
+            if dtype is not None:
+                schema_overrides[column.name] = dtype
+        single_key_alias = _xtdb_single_primary_key_alias(table_config)
+        if single_key_alias is not None and single_key_alias in output_columns:
+            id_column = next(
+                column
+                for column in table_config.columns
+                if column.name == single_key_alias
+            )
+            id_dtype = _xtdb_polars_type_or_none(id_column.data_type)
+            if id_dtype is not None:
+                schema_overrides[single_key_alias] = id_dtype
+        for temporal_column in ["__valid_from", "__valid_to"]:
+            if temporal_column in output_columns:
+                schema_overrides[temporal_column] = pl.Datetime("us")
+
+        df = self.from_raw_sql(query, schema_overrides)
+        for temporal_column in ["__valid_from", "__valid_to"]:
+            if (
+                temporal_column in df.columns
+                and isinstance(df[temporal_column].dtype, pl.Datetime)
+                and getattr(df[temporal_column].dtype, "time_zone", None) is not None
+            ):
+                df = df.with_columns(pl.col(temporal_column).dt.replace_time_zone(None))
+        if "__valid_to" in df.columns:
+            df = df.with_columns(
+                pl.col("__valid_to").fill_null(
+                    datetime.fromisoformat("2106-02-07T06:28:15.999999")
+                )
+            )
+        return df.pipe(PolarsType.cast_str_to_cat)
+
+    def table_insert(
+        self,
+        df: pl.DataFrame,
+        table_schema: str,
+        table_name: str,
+        table_config: Optional[TableConfig] = None,
+        update_time: Optional[datetime] = None,
+    ) -> int:
+        df = _prepare_xtdb_insert_dataframe(df, table_config)
+        driver_connection = _driver_connection(self.connection)
+        if driver_connection is not None:
+            if df.is_empty():
+                return 0
+
+            columns = [_quote_identifier(column) for column in df.columns]
+            column_sql = ", ".join(columns)
+            casts = _xtdb_insert_casts(df, table_config)
+            rows = df.rows()
+            values_sql = ", ".join(
+                "("
+                + ", ".join(
+                    _xtdb_sql_literal(value, cast)
+                    for value, cast in zip(row, casts, strict=True)
+                )
+                + ")"
+                for row in rows
+            )
+            table_sql = _qualified_table_name(table_schema, table_name)
+            insert_sql = f"INSERT INTO {table_sql} ({column_sql}) VALUES {values_sql}"
+            _execute_xtdb_dml(
+                self.connection,
+                insert_sql,
+                system_time=update_time,
+            )
+            return len(rows)
+
+        if update_time is not None:
+            raise ValueError(
+                "XTDB pgwire system-time writes require a live DBAPI connection"
+            )
+
+        result = df.write_database(
+            table_name=f"{table_schema}.{table_name}",
+            connection=self.connection,
+            if_table_exists="append",
+        )
+        return int(result) if result is not None else 0
+
+
+class XtdbAdbcDataframeOps:
+    def __init__(self, connection: Any):
+        self.connection = connection
+
+    def from_raw_sql(
+        self,
+        query: str,
+        schema_overrides: Optional[Mapping[str, pl.DataType]] = None,
+    ) -> pl.DataFrame:
+        with self.connection.cursor() as cursor:
+            cursor.execute(query)
+            arrow_table = cursor.fetch_arrow_table()
+
+        return _apply_schema_overrides(
+            cast(pl.DataFrame, pl.from_arrow(arrow_table)),
+            schema_overrides,
+        )
+
+    def from_table(
+        self,
+        table_schema: str,
+        table_name: str,
+        schema_overrides: Optional[Mapping[str, pl.DataType]] = None,
+        time_hint: Optional[TimeHint] = None,
+    ) -> pl.DataFrame:
+        table_sql = _qualified_table_name(table_schema, table_name)
+        hint_clause = system_time_hint_clause(time_hint)
+        query = f"SELECT * FROM {table_sql}"
+        if hint_clause:
+            query = f"{query} {hint_clause}"
+
+        return self.from_raw_sql(
+            query,
+            schema_overrides,
+        )
+
+    def table_insert(
+        self,
+        df: pl.DataFrame,
+        table_schema: str,
+        table_name: str,
+        table_config: Optional[TableConfig] = None,
+        update_time: Optional[datetime] = None,
+    ) -> int:
+        if update_time is not None:
+            raise NotImplementedError(
+                "XTDB ADBC dataframe ingest does not yet support transaction "
+                "SYSTEM_TIME; use the pgwire dataframe path for update_time"
+            )
+
+        table_schema = _validate_identifier(table_schema)
+        table_name = _validate_identifier(table_name)
+        if df.is_empty():
+            return 0
+
+        df = _prepare_xtdb_insert_dataframe(df, table_config)
+        arrow_table = _normalize_xtdb_ingest_arrow(df.to_arrow())
+        with self.connection.cursor() as cursor:
+            cursor.adbc_ingest(
+                table_name,
+                arrow_table,
+                mode="create_append",
+                db_schema_name=table_schema,
+            )
+        return df.height
+
+
+class XtdbTableConfigOps:
+    def __init__(self, connection: Any):
+        self.connection = connection
+
+    def create_all(self, tcs: Any) -> None:
+        for table_config in tcs.items:
+            self.create(table_config)
+
+    def drop_all(self, tcs: Any) -> None:
+        for table_config in reversed(tcs.items):
+            self.drop(table_config)
+
+    def drop(self, table_config: TableConfig) -> None:
+        if not self.table_exists(table_config.schema, table_config.name):
+            return
+
+        table_name = _qualified_table_name(table_config.schema, table_config.name)
+        _execute_xtdb_dml(self.connection, f"ERASE FROM {table_name} WHERE TRUE")
+
+        if self.table_exists(table_config.schema, _XTDB_TABLE_CONFIG_METADATA_TABLE):
+            metadata_table = _xtdb_table_config_metadata_table(table_config.schema)
+            metadata_id = _xtdb_sql_literal(
+                f"{table_config.schema}.{table_config.name}", "TEXT"
+            )
+            _execute_xtdb_dml(
+                self.connection,
+                f"DELETE FROM {metadata_table} WHERE _id = {metadata_id}",
+            )
+
+    def create(
+        self,
+        table_config: TableConfig,
+        *args,
+        **kwargs,
+    ) -> TableConfig:
+        if self.table_exists(table_config.schema, table_config.name):
+            return self.from_table(table_config.schema, table_config.name)
+
+        table_name = _qualified_table_name(table_config.schema, table_config.name)
+        columns = ", ".join(_xtdb_declared_columns(table_config))
+        _execute_xtdb_dml(self.connection, f"CREATE TABLE {table_name} ({columns})")
+        self._record_table_config_metadata(table_config)
+        return table_config
+
+    def _record_table_config_metadata(self, table_config: TableConfig) -> None:
+        if not self.table_exists(
+            table_config.schema,
+            _XTDB_TABLE_CONFIG_METADATA_TABLE,
+        ):
+            metadata_table = _xtdb_table_config_metadata_table(table_config.schema)
+            _execute_xtdb_dml(
+                self.connection,
+                f"CREATE TABLE {metadata_table} "
+                "(_id, table_schema, table_name, primary_keys_json, "
+                "id_policy, columns_json, foreign_keys_json)",
+            )
+
+        primary_keys_json = json.dumps(
+            list(table_config.primary_keys),
+            separators=(",", ":"),
+        )
+        columns_json = json.dumps(
+            [column.__dict__ for column in table_config.columns],
+            separators=(",", ":"),
+        )
+        values = [
+            f"{table_config.schema}.{table_config.name}",
+            table_config.schema,
+            table_config.name,
+            primary_keys_json,
+            _xtdb_id_policy(table_config),
+            columns_json,
+            _xtdb_foreign_keys_json(table_config),
+        ]
+        values_sql = ", ".join(_xtdb_sql_literal(value, "TEXT") for value in values)
+        metadata_table = _xtdb_table_config_metadata_table(table_config.schema)
+        _execute_xtdb_dml(
+            self.connection,
+            f"INSERT INTO {metadata_table} "
+            "(_id, table_schema, table_name, primary_keys_json, "
+            "id_policy, columns_json, foreign_keys_json) "
+            f"VALUES ({values_sql})",
+        )
+
+    def table_exists(self, table_schema: str, table_name: str) -> bool:
+        table_schema = _validate_identifier(table_schema)
+        table_name = _validate_identifier(table_name)
+        metadata = pl.read_database(
+            f"""
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_schema = '{table_schema}'
+              AND table_name = '{table_name}'
+        """,
+            self.connection,
+        )
+        return not metadata.is_empty()
+
+    def from_table(self, table_schema: str, table_name: str) -> TableConfig:
+        table_schema = _validate_identifier(table_schema)
+        table_name = _validate_identifier(table_name)
+        metadata = pl.read_database(
+            f"""
+            SELECT column_name, data_type, is_nullable
+            FROM information_schema.columns
+            WHERE table_schema = '{table_schema}'
+              AND table_name = '{table_name}'
+            ORDER BY ordinal_position
+        """,
+            self.connection,
+        )
+        if metadata.is_empty():
+            raise ValueError(
+                f"XTDB table metadata not found for {table_schema}.{table_name}"
+            )
+
+        config_metadata = _xtdb_table_config_metadata(
+            self.connection,
+            table_schema,
+            table_name,
+        )
+        configured_table = _xtdb_table_config_from_metadata(
+            config_metadata,
+            table_schema,
+            table_name,
+        )
+        if configured_table is not None:
+            return configured_table
+
+        columns = []
+        primary_keys = []
+        for row in metadata.iter_rows(named=True):
+            col_name = str(row["column_name"])
+            if col_name in _XTDB_SYSTEM_COLUMNS:
+                continue
+            if col_name == "_id":
+                primary_keys.append(col_name)
+
+            columns.append(
+                TableColumnConfig(
+                    table=table_name,
+                    name=col_name,
+                    data_type=_xtdb_type_to_config_type(str(row["data_type"])),
+                    nullable=_is_nullable(row["is_nullable"]),
+                )
+            )
+
+        configured_primary_keys = _xtdb_primary_keys_from_metadata(
+            config_metadata,
+            table_schema,
+            table_name,
+        )
+        if configured_primary_keys is not None:
+            primary_keys = configured_primary_keys
+
+        return TableConfig(
+            name=table_name,
+            schema=table_schema,
+            columns=columns,
+            primary_keys=primary_keys,
+            is_temporal=True,
+        )
+
+
+class XtdbStagingOps:
+    def __init__(self, connection: Any):
+        self.connection = connection
+        self._stage_run_cache: dict[str, pl.DataFrame] = {}
+        self._inserted_parent_row_cache: set[tuple[str, str, str]] = set()
+        self._projected_parent_row_cache: set[tuple[str, str, str]] = set()
+
+    def stage_table_config(self, delta_table_config: TableConfig) -> TableConfig:
+        stage_table = _xtdb_stage_table_name(delta_table_config.name)
+        existing_column_names = {column.name for column in delta_table_config.columns}
+        columns = [
+            TableColumnConfig(
+                table=stage_table,
+                name=column.name,
+                data_type=column.data_type,
+                default_value=column.default_value,
+                autoincrement=column.autoincrement,
+                nullable=column.nullable,
+                unique_constraint=column.unique_constraint,
+            )
+            for column in delta_table_config.columns
+        ]
+        metadata_columns = [
+            TableColumnConfig(
+                stage_table,
+                _XTDB_STAGE_RUN_ID_COLUMN,
+                "VARCHAR(128)",
+                nullable=False,
+            ),
+            TableColumnConfig(
+                stage_table,
+                _XTDB_STAGE_ROW_INDEX_COLUMN,
+                "BIGINT",
+                nullable=False,
+            ),
+            TableColumnConfig(
+                stage_table,
+                _XTDB_STAGE_PARTITION_TIME_COLUMN,
+                "DATETIME",
+                nullable=False,
+            ),
+        ]
+        columns.extend(
+            column
+            for column in metadata_columns
+            if column.name not in existing_column_names
+        )
+        return TableConfig(
+            name=stage_table,
+            schema=delta_table_config.schema,
+            columns=columns,
+            primary_keys=[_XTDB_STAGE_RUN_ID_COLUMN, _XTDB_STAGE_ROW_INDEX_COLUMN],
+        )
+
+    def ensure_table(self, delta_table_config: TableConfig) -> TableConfig:
+        stage_config = self.stage_table_config(delta_table_config)
+        return XtdbTableConfigOps(self.connection).create(stage_config)
+
+    def insert_partition(
+        self,
+        df: pl.DataFrame,
+        delta_table_config: TableConfig,
+        stage_run_id: str,
+        partition_time: datetime,
+        *,
+        uniqueness_col_set: Iterable[str],
+        prefill_nulls_with_default: bool,
+    ) -> int:
+        if df.is_empty():
+            return 0
+
+        if prefill_nulls_with_default:
+            df = _fill_xtdb_staging_defaults(df, delta_table_config)
+        df = _dedupe_xtdb_staging_dataframe(df, uniqueness_col_set)
+        df = df.with_row_index(_XTDB_STAGE_ROW_INDEX_COLUMN).with_columns(
+            pl.lit(stage_run_id).alias(_XTDB_STAGE_RUN_ID_COLUMN),
+            pl.lit(partition_time).alias(_XTDB_STAGE_PARTITION_TIME_COLUMN),
+        )
+
+        stage_config = self.stage_table_config(delta_table_config)
+        return XtdbDataframeOps(self.connection).table_insert(
+            df,
+            stage_config.schema,
+            stage_config.name,
+            table_config=stage_config,
+        )
+
+    def prepare_pipeline_item_dataframe(
+        self,
+        stage_run_id: str,
+        dataset: Any,
+        pipeline_id: int,
+        table_config: TableConfig,
+        *,
+        valid_time: Optional[ValidTimeConfig],
+    ) -> pl.DataFrame:
+        table_name = _qualified_table_name(
+            dataset.delta_table_schema, _xtdb_stage_table_name(dataset.name)
+        )
+        stage_run_literal = _xtdb_sql_literal(stage_run_id, "TEXT")
+        stage_df = self._stage_run_cache.get(stage_run_id)
+        if stage_df is None:
+            stage_df = XtdbDataframeOps(self.connection).from_raw_sql(
+                f"SELECT * FROM {table_name} "
+                f"WHERE {_XTDB_STAGE_RUN_ID_COLUMN} = {stage_run_literal}"
+            )
+        stage_df = self._deduce_foreign_keys(
+            stage_df,
+            dataset,
+            pipeline_id,
+            table_config,
+        )
+        self._stage_run_cache[stage_run_id] = stage_df
+        projected_df = _project_xtdb_staged_pipeline_item_dataframe(
+            stage_df, dataset, pipeline_id, valid_time
+        )
+        return self._filter_duplicate_projected_parent_rows(
+            projected_df,
+            dataset,
+            pipeline_id,
+            table_config,
+        )
+
+    def _filter_duplicate_projected_parent_rows(
+        self,
+        projected_df: pl.DataFrame,
+        dataset: Any,
+        pipeline_id: int,
+        table_config: TableConfig,
+    ) -> pl.DataFrame:
+        if projected_df.is_empty():
+            return projected_df
+
+        col_info = dataset.pipeline.extract_items(pipeline_id)
+        fk_map = _xtdb_deduced_foreign_key_columns(col_info)
+        if not fk_map:
+            return projected_df
+
+        value_map = _xtdb_deduced_value_columns(col_info)
+        parent_columns = [
+            column
+            for column in [*fk_map.values(), *value_map.values()]
+            if column in projected_df.columns
+        ]
+        rows_to_return = []
+        new_parent_keys = set()
+        for row in projected_df.iter_rows(named=True):
+            parent_key = _xtdb_parent_row_cache_key(
+                table_config,
+                parent_columns,
+                row,
+            )
+            if parent_key in self._projected_parent_row_cache:
+                continue
+            rows_to_return.append(row)
+            new_parent_keys.add(parent_key)
+
+        self._projected_parent_row_cache.update(new_parent_keys)
+        return pl.DataFrame(rows_to_return, schema=projected_df.schema)
+
+    def _deduce_foreign_keys(
+        self,
+        stage_df: pl.DataFrame,
+        dataset: Any,
+        pipeline_id: int,
+        table_config: TableConfig,
+    ) -> pl.DataFrame:
+        col_info = dataset.pipeline.extract_items(pipeline_id)
+        fk_map = _xtdb_deduced_foreign_key_columns(col_info)
+        if not fk_map:
+            return stage_df
+
+        value_map = _xtdb_deduced_value_columns(col_info)
+        if not value_map:
+            raise ValueError(
+                "XTDB foreign-key deduction requires at least one natural key column"
+            )
+
+        value_sources = list(value_map.keys())
+        value_targets = list(value_map.values())
+        fk_sources = list(fk_map.keys())
+        fk_targets = list(fk_map.values())
+
+        missing_columns = sorted(set(value_sources).difference(stage_df.columns))
+        if missing_columns:
+            raise ValueError(
+                "XTDB foreign-key deduction references missing source column(s): "
+                + ", ".join(missing_columns)
+            )
+
+        for source_column, target_column in fk_map.items():
+            if (
+                _xtdb_fk_needs_generated_values(stage_df, source_column)
+                and not _xtdb_is_textual_config_column(table_config, target_column)
+                and not _xtdb_is_integer_config_column(table_config, target_column)
+            ):
+                raise NotImplementedError(
+                    "XTDB foreign-key deduction needs to generate a key for "
+                    f"{table_config.name}.{target_column}, but only textual and "
+                    "integer generated keys are currently supported"
+                )
+
+        candidate_sources = [
+            column
+            for column in [*value_sources, *fk_sources]
+            if column in stage_df.columns
+        ]
+        candidates = stage_df.select(candidate_sources).unique(maintain_order=True)
+        generated = candidates.rename(
+            {
+                **{
+                    source: target
+                    for source, target in value_map.items()
+                    if source != target
+                },
+                **{
+                    source: target
+                    for source, target in fk_map.items()
+                    if source in candidates.columns and source != target
+                },
+            }
+        )
+        for source_column, target_column in fk_map.items():
+            if _xtdb_is_integer_config_column(table_config, target_column):
+                generated_value = (
+                    pl.struct(value_targets)
+                    .map_elements(
+                        lambda row: _xtdb_deduced_numeric_foreign_key_id(
+                            table_config, value_targets, row
+                        ),
+                        return_dtype=pl.Int64,
+                    )
+                    .alias(target_column)
+                )
+            else:
+                generated_value = (
+                    pl.struct(value_targets)
+                    .map_elements(
+                        lambda row: _xtdb_deduced_foreign_key_id(
+                            table_config, value_targets, row
+                        ),
+                        return_dtype=pl.String,
+                    )
+                    .alias(target_column)
+                )
+            if source_column not in candidates.columns:
+                generated = generated.with_columns(generated_value)
+                continue
+            if _xtdb_is_textual_config_column(
+                table_config, target_column
+            ) or _xtdb_is_integer_config_column(table_config, target_column):
+                generated = generated.with_columns(
+                    pl.coalesce(target_column, generated_value).alias(target_column)
+                )
+
+        parent_df = XtdbDataframeOps(self.connection).from_table(
+            table_config.schema,
+            table_config.name,
+        )
+        parent_lookup_columns = [
+            column
+            for column in [*fk_targets, *value_targets]
+            if column in parent_df.columns
+        ]
+        if parent_lookup_columns:
+            parent_lookup = parent_df.select(parent_lookup_columns)
+        else:
+            parent_lookup = pl.DataFrame(schema=generated.schema)
+        parent_lookup = _cast_null_parent_lookup_columns(
+            parent_lookup,
+            generated,
+            [*fk_targets, *value_targets],
+        )
+
+        joined = generated.join(
+            parent_lookup,
+            on=value_targets,
+            how="left",
+            suffix="__existing",
+        )
+        for target_column in fk_targets:
+            existing_column = f"{target_column}__existing"
+            if existing_column in joined.columns:
+                joined = joined.with_columns(
+                    pl.coalesce(existing_column, target_column).alias(target_column)
+                ).drop(existing_column)
+
+        first_fk = fk_targets[0]
+        existing_first_fk = f"{first_fk}__existing"
+        if (
+            existing_first_fk
+            in generated.join(
+                parent_lookup,
+                on=value_targets,
+                how="left",
+                suffix="__existing",
+            ).columns
+        ):
+            missing_parent_rows = joined.filter(pl.col(first_fk).is_not_null())
+            if not parent_lookup.is_empty():
+                existing_keys = parent_lookup.select(value_targets).unique()
+                missing_parent_rows = missing_parent_rows.join(
+                    existing_keys,
+                    on=value_targets,
+                    how="anti",
+                )
+        else:
+            missing_parent_rows = joined
+
+        parent_rows_to_insert = missing_parent_rows.select(
+            [*fk_targets, *value_targets]
+        ).unique(maintain_order=True)
+        if not parent_rows_to_insert.is_empty():
+            insert_columns = [*fk_targets, *value_targets]
+            rows_to_insert = []
+            new_parent_keys = set()
+            for row in parent_rows_to_insert.iter_rows(named=True):
+                parent_key = _xtdb_parent_row_cache_key(
+                    table_config,
+                    insert_columns,
+                    row,
+                )
+                if parent_key in self._inserted_parent_row_cache:
+                    continue
+                rows_to_insert.append(row)
+                new_parent_keys.add(parent_key)
+
+            parent_rows_to_insert = pl.DataFrame(
+                rows_to_insert,
+                schema=parent_rows_to_insert.schema,
+            )
+        if not parent_rows_to_insert.is_empty():
+            XtdbDataframeOps(self.connection).table_insert(
+                parent_rows_to_insert,
+                table_config.schema,
+                table_config.name,
+                table_config=table_config,
+            )
+            self._inserted_parent_row_cache.update(new_parent_keys)
+
+        resolver = joined.select([*value_targets, *fk_targets]).rename(
+            {
+                **{target: source for source, target in value_map.items()},
+                **{target: source for source, target in fk_map.items()},
+            }
+        )
+        return stage_df.drop(
+            [column for column in fk_sources if column in stage_df.columns]
+        ).join(resolver, on=value_sources, how="left")
+
+    def cleanup_run(self, stage_run_id: str, delta_table_config: TableConfig) -> None:
+        self._stage_run_cache.pop(stage_run_id, None)
+        table_name = _qualified_table_name(
+            delta_table_config.schema, _xtdb_stage_table_name(delta_table_config.name)
+        )
+        stage_run_literal = _xtdb_sql_literal(stage_run_id, "TEXT")
+        _execute_xtdb_dml(
+            self.connection,
+            f"DELETE FROM {table_name} "
+            f"WHERE {_XTDB_STAGE_RUN_ID_COLUMN} = {stage_run_literal}",
+        )
+
+
+@dataclass(frozen=True)
+class XtdbBackend:
+    name: str = "xtdb"
+
+    def create_engine(self, config: DbEngineConfig) -> Engine:
+        database = config.database or "xtdb"
+        url = f"postgresql+psycopg://{config.hostname}:{config.port}/{database}"
+        engine = create_engine(
+            url,
+            connect_args={"prepare_threshold": None},
+            pool_size=config.pool_size,
+            max_overflow=config.max_overflow,
+            use_native_hstore=False,
+        )
+        # XTDB pgwire currently trips SQLAlchemy's PostgreSQL dialect when it
+        # probes SHOW standard_conforming_strings. XTDB uses standard strings,
+        # so skip that PostgreSQL-specific initialization query.
+        engine.dialect._set_backslash_escapes = lambda connection: setattr(  # type: ignore[attr-defined, method-assign]
+            engine.dialect, "_backslash_escapes", False
+        )
+        return engine
+
+    def adbc_uri(self, config: DbEngineConfig) -> str:
+        adbc_port = config.adbc_port or 9832
+        return f"grpc://{config.hostname}:{adbc_port}"
+
+    def create_adbc_connection(self, config: DbEngineConfig) -> Any:
+        return _load_flight_sql().connect(self.adbc_uri(config), autocommit=True)
+
+    def dataframes(self, connection: Any) -> XtdbDataframeOps:
+        return XtdbDataframeOps(connection)
+
+    def adbc_dataframes(self, connection: Any) -> XtdbAdbcDataframeOps:
+        return XtdbAdbcDataframeOps(connection)
+
+    def table_configs(self, connection: Any) -> XtdbTableConfigOps:
+        return XtdbTableConfigOps(connection)
+
+    def staging(self, connection: Any) -> XtdbStagingOps:
+        return XtdbStagingOps(connection)
+
+    def time_hint_clause(self, time_hint: TimeHint) -> str | None:
+        return system_time_hint_clause(time_hint)
+
+    def temporal_upsert(
+        self,
+        df: pl.DataFrame,
+        table_schema: str,
+        table_name: str,
+        *,
+        connection: Any | None = None,
+        dataframe_ops: XtdbDataframeOps | XtdbAdbcDataframeOps | None = None,
+        table_config: Optional[TableConfig] = None,
+        delta_config: Optional[DeltaConfig] = None,
+        update_time: Optional[datetime] = None,
+        valid_time: Optional[ValidTimeConfig] = None,
+        dropout_close_time: Optional[datetime] = None,
+    ) -> int:
+        if dataframe_ops is None:
+            if connection is None:
+                raise ValueError(
+                    "XTDB temporal upsert requires connection or dataframe_ops"
+                )
+            dataframe_ops = self.dataframes(connection)
+
+        df = _apply_xtdb_valid_time_mapping(df, valid_time)
+
+        deleted_count = 0
+        if delta_config is not None:
+            if delta_config.row_finality not in {"disabled", "dropout"}:
+                raise NotImplementedError(
+                    "XTDB temporal upsert currently only supports "
+                    "row_finality='disabled' or 'dropout'"
+                )
+            if table_config is None:
+                raise ValueError("XTDB delta upsert requires table_config")
+            if delta_config.prefill_nulls_with_default:
+                df = _fill_xtdb_defaults(df, table_config)
+            df = _apply_xtdb_duplicate_policy(df, table_config, delta_config)
+            if delta_config.row_finality == "dropout":
+                if not isinstance(dataframe_ops, XtdbDataframeOps):
+                    raise NotImplementedError(
+                        "XTDB row_finality='dropout' currently requires the "
+                        "pgwire dataframe path"
+                    )
+                deleted_count = _delete_xtdb_missing_rows(
+                    df,
+                    table_schema,
+                    table_name,
+                    table_config,
+                    dataframe_ops,
+                    update_time,
+                    dropout_close_time,
+                )
+            if delta_config.drop_unchanged_rows:
+                df = _filter_xtdb_unchanged_rows(
+                    df,
+                    table_schema,
+                    table_name,
+                    table_config,
+                    dataframe_ops,
+                    update_time,
+                )
+
+        insert_kwargs: dict[str, Any] = {"table_config": table_config}
+        if update_time is not None:
+            insert_kwargs["update_time"] = update_time
+
+        inserted_count = dataframe_ops.table_insert(
+            df,
+            table_schema,
+            table_name,
+            **insert_kwargs,
+        )
+        return deleted_count + inserted_count

--- a/polars_hist_db/config/__init__.py
+++ b/polars_hist_db/config/__init__.py
@@ -1,5 +1,16 @@
-from .config import PolarsHistDbConfig
-from .dataset import DatasetConfig, DatasetsConfig, IngestionColumnConfig, DeltaConfig
+from .config import (
+    ParityConfig,
+    ParitySemanticForeignKeyConfig,
+    PolarsHistDbConfig,
+)
+from ..backends.config import DbEngineConfig
+from .dataset import (
+    DatasetConfig,
+    DatasetsConfig,
+    IngestionColumnConfig,
+    DeltaConfig,
+    ValidTimeConfig,
+)
 from .table import (
     TableColumnConfig,
     ForeignKeyConfig,
@@ -12,11 +23,15 @@ from .input.ingest_fn_registry import IngestFnRegistry, IngestFnSignature
 
 __all__ = [
     "PolarsHistDbConfig",
+    "ParityConfig",
+    "ParitySemanticForeignKeyConfig",
+    "DbEngineConfig",
     "DatasetConfig",
     "DatasetsConfig",
     "TableColumnConfig",
     "IngestionColumnConfig",
     "DeltaConfig",
+    "ValidTimeConfig",
     "ForeignKeyConfig",
     "TableConfig",
     "TableConfigs",

--- a/polars_hist_db/config/config.py
+++ b/polars_hist_db/config/config.py
@@ -1,9 +1,54 @@
+from dataclasses import dataclass, field
 from typing import Any, Iterable, Mapping, Optional
 
 from .helpers import get_nested_key, load_yaml
 
 from .dataset import DatasetsConfig
 from .table import TableConfigs
+from ..backends.config import DbEngineConfig
+
+
+@dataclass(frozen=True)
+class ParitySemanticForeignKeyConfig:
+    source: str
+    target: str
+    columns: tuple[str, ...]
+
+    def __init__(self, source: str, target: str, columns: Iterable[str]):
+        object.__setattr__(self, "source", source)
+        object.__setattr__(self, "target", target)
+        object.__setattr__(self, "columns", tuple(columns))
+
+
+@dataclass(frozen=True)
+class ParityConfig:
+    ignore_columns: tuple[str, ...] = field(default_factory=tuple)
+    semantic_foreign_keys: tuple[ParitySemanticForeignKeyConfig, ...] = field(
+        default_factory=tuple
+    )
+
+    def __init__(
+        self,
+        ignore_columns: Iterable[str] = (),
+        semantic_foreign_keys: Iterable[
+            ParitySemanticForeignKeyConfig | Mapping[str, Any]
+        ] = (),
+    ):
+        object.__setattr__(self, "ignore_columns", tuple(ignore_columns))
+        object.__setattr__(
+            self,
+            "semantic_foreign_keys",
+            tuple(
+                item
+                if isinstance(item, ParitySemanticForeignKeyConfig)
+                else ParitySemanticForeignKeyConfig(
+                    source=str(item["source"]),
+                    target=str(item["target"]),
+                    columns=item["columns"],
+                )
+                for item in semantic_foreign_keys
+            ),
+        )
 
 
 class PolarsHistDbConfig:
@@ -17,13 +62,23 @@ class PolarsHistDbConfig:
         self.config_file_path = config_file_path
         dataset_params = get_nested_key(cfg_dict, datasets_path)
         table_params = get_nested_key(cfg_dict, table_configs_path)
+        db_params = get_nested_key(cfg_dict, ["db"]) or {}
+        parity_params = get_nested_key(cfg_dict, ["parity"]) or {}
 
+        self.db_config = DbEngineConfig.from_mapping(db_params)
+        self.parity = ParityConfig(**parity_params)
         self.tables = TableConfigs(items=table_params)
 
         if dataset_params:
             self.datasets = DatasetsConfig(
                 datasets=dataset_params, config_file_path=config_file_path
             )
+
+    def create_engine(self):
+        from ..backends import backend_from_config
+
+        backend = backend_from_config(self.db_config)
+        return backend.create_engine(self.db_config)
 
     @classmethod
     def from_yaml(

--- a/polars_hist_db/config/dataset.py
+++ b/polars_hist_db/config/dataset.py
@@ -230,6 +230,19 @@ class TimePartition:
     unique_strategy: Literal["first", "last"] = "last"
 
 
+@dataclass(frozen=True)
+class ValidTimeConfig:
+    table: str
+    from_column: str
+    schema: Optional[str] = None
+    to_column: Optional[str] = None
+
+    def matches(self, table_schema: str, table_name: str) -> bool:
+        if self.table != table_name:
+            return False
+        return self.schema is None or self.schema == table_schema
+
+
 @dataclass
 class DatasetConfig:
     name: str
@@ -240,6 +253,7 @@ class DatasetConfig:
     time_partition: Optional[TimePartition] = None
     null_values: Optional[Sequence[str]] = None
     delta_config: DeltaConfig = field(default_factory=DeltaConfig)
+    valid_time: Sequence[ValidTimeConfig] = field(default_factory=tuple)
     config_file_path: Optional[str] = None
 
     def __post_init__(self):
@@ -261,6 +275,23 @@ class DatasetConfig:
             self.time_partition, TimePartition
         ):
             self.time_partition = TimePartition(**self.time_partition)
+
+        self.valid_time = [
+            item if isinstance(item, ValidTimeConfig) else ValidTimeConfig(**item)
+            for item in self.valid_time
+        ]
+
+    def valid_time_for_table(
+        self, table_schema: str, table_name: str
+    ) -> Optional[ValidTimeConfig]:
+        return next(
+            (
+                valid_time
+                for valid_time in self.valid_time
+                if valid_time.matches(table_schema, table_name)
+            ),
+            None,
+        )
 
 
 @dataclass

--- a/polars_hist_db/core/audit.py
+++ b/polars_hist_db/core/audit.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
+import hashlib
 import logging
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 import polars as pl
 from sqlalchemy import and_, Connection, delete, select, Table
@@ -15,6 +16,28 @@ from .table_config import TableConfigOps
 from ..utils.db_utils import smallest_datetime
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _is_xtdb_connection(connection: Any) -> bool:
+    return getattr(getattr(connection, "dialect", None), "name", None) == "postgresql"
+
+
+def _xtdb_table_config_ops(connection: Any) -> Any:
+    from ..backends.xtdb import XtdbTableConfigOps
+
+    return XtdbTableConfigOps(connection)
+
+
+def _xtdb_dataframe_ops(connection: Any) -> Any:
+    from ..backends.xtdb import XtdbDataframeOps
+
+    return XtdbDataframeOps(connection)
+
+
+def _sql_literal(value: object) -> str:
+    if isinstance(value, datetime):
+        return f"TIMESTAMP '{value.isoformat()}'"
+    return "'" + str(value).replace("'", "''") + "'"
 
 
 class AuditOps:
@@ -80,7 +103,18 @@ class AuditOps:
         )
         return table_config
 
-    def create(self, connection: Connection) -> Table:
+    def _table_sql(self) -> str:
+        return f"{self.schema}.{self._table_name}"
+
+    def create(self, connection: Connection) -> Table | TableConfig:
+        if _is_xtdb_connection(connection):
+            table_config = self._table_config()
+            table_config_ops = _xtdb_table_config_ops(connection)
+            if not table_config_ops.table_exists(self.schema, self._table_name):
+                table_config_ops.create(table_config)
+                return table_config
+            return table_config_ops.from_table(self.schema, self._table_name)
+
         audit_table_name = str(self._table_name)
         tbo = TableOps(self.schema, audit_table_name, connection)
 
@@ -106,6 +140,19 @@ class AuditOps:
         interval: Literal["open", "closed"],
         connection: Connection,
     ) -> int:
+        if _is_xtdb_connection(connection):
+            self.create(connection)
+            operator = ">" if interval == "open" else ">="
+            query = (
+                f"DELETE FROM {self._table_sql()} "
+                f"WHERE table_name = {_sql_literal(target_table_name)} "
+                f"AND data_source_ts {operator} {_sql_literal(timestamp)}"
+            )
+            from ..backends.xtdb import _execute_xtdb_dml
+
+            _execute_xtdb_dml(connection, query)
+            return 0
+
         tbo = TableOps(self.schema, self._table_name, connection)
         tbl = tbo.get_table_metadata()
         if interval == "open":
@@ -134,6 +181,36 @@ class AuditOps:
         new_data_source_items: pl.DataFrame,
         connection: Connection,
     ):
+        if _is_xtdb_connection(connection):
+            self.create(connection)
+            latest_log = _xtdb_dataframe_ops(connection).from_raw_sql(
+                "SELECT data_source_ts "
+                f"FROM {self._table_sql()} "
+                f"WHERE table_name = {_sql_literal(target_table_name)} "
+                "ORDER BY data_source_ts "
+                "LIMIT 1",
+                schema_overrides={"data_source_ts": pl.Datetime("us", "UTC")},
+            )
+            if latest_log.is_empty():
+                return
+
+            xtdb_latest_log_ts: datetime = latest_log[0, "data_source_ts"]
+            invalid_data_source_items = new_data_source_items.filter(
+                pl.col("__created_at")
+                <= pl.lit(xtdb_latest_log_ts).cast(pl.dtype_of(pl.col("__created_at")))
+            )
+
+            if not invalid_data_source_items.is_empty():
+                LOGGER.error(
+                    "latest data_source_ts: %s",
+                    xtdb_latest_log_ts.isoformat(),
+                )
+                LOGGER.error(invalid_data_source_items)
+                raise ValueError(
+                    "uploading from data_sources with earlier timestamps is not supported"
+                )
+            return
+
         self.create(connection)
         tbo = TableOps(self.schema, self._table_name, connection)
         tbl = tbo.get_table_metadata()
@@ -169,7 +246,32 @@ class AuditOps:
         target_table_name: str,
         connection: Connection,
     ) -> pl.DataFrame:
+        if _is_xtdb_connection(connection):
+            self.create(connection)
+            existing_tbl_entries = (
+                _xtdb_dataframe_ops(connection)
+                .from_raw_sql(
+                    "SELECT data_source, data_source_ts "
+                    f"FROM {self._table_sql()} "
+                    f"WHERE table_name = {_sql_literal(target_table_name)} "
+                    "ORDER BY data_source_ts",
+                    schema_overrides={"data_source_ts": pl.Datetime("us", "UTC")},
+                )
+                .with_columns(pl.col("data_source").cast(pl.Utf8))
+            )
+
+            if existing_tbl_entries.is_empty():
+                return data_source_items
+
+            data_source_items = self._filter_unprocessed_items(
+                data_source_items, existing_tbl_entries, data_source_col_name
+            )
+            return self._filter_historic_items(
+                data_source_items, existing_tbl_entries, data_source_ts_col_name
+            )
+
         audit_tbl = self.create(connection)
+        assert isinstance(audit_tbl, Table)
 
         # get the set of datasource items already processed
         target_table_logs_sql = (
@@ -250,8 +352,6 @@ class AuditOps:
                 "Developer Error: data_source_timestamp must be timezone aware"
             )
 
-        self.create(connection)
-
         new_item = {
             "table_name": f"{target_table_name}",
             "data_source_type": data_source_type,
@@ -260,6 +360,35 @@ class AuditOps:
             "upload_ts": datetime.now(timezone.utc),
         }
 
+        if _is_xtdb_connection(connection):
+            table_config = self.create(connection)
+            assert isinstance(table_config, TableConfig)
+            audit_id_value = "|".join(
+                [
+                    self.schema,
+                    target_table_name,
+                    data_source_type,
+                    data_source,
+                    data_source_timestamp.isoformat(),
+                ]
+            )
+            new_item["audit_id"] = (
+                int(
+                    hashlib.sha256(audit_id_value.encode()).hexdigest()[:8],
+                    16,
+                )
+                & 0x7FFFFFFF
+            )
+            df = pl.DataFrame([new_item])
+            num_rows_changed = _xtdb_dataframe_ops(connection).table_insert(
+                df,
+                self.schema,
+                self._table_name,
+                table_config=table_config,
+            )
+            return num_rows_changed == 1
+
+        self.create(connection)
         tbo = TableOps(self.schema, self._table_name, connection)
         tbl = tbo.get_table_metadata()
         insert_stmt = tbl.insert().values(new_item)
@@ -275,7 +404,43 @@ class AuditOps:
         target_table_name: Optional[str] = None,
         data_source_type: Optional[InputDataSourceType] = None,
     ) -> pl.DataFrame:
+        if _is_xtdb_connection(connection):
+            self.create(connection)
+
+            xtdb_filters: list[str] = []
+            if target_table_name is not None:
+                xtdb_filters.append(f"table_name = {_sql_literal(target_table_name)}")
+            if data_source_type is not None:
+                xtdb_filters.append(
+                    f"data_source_type = {_sql_literal(data_source_type)}"
+                )
+            if asof_timestamp is not None:
+                if asof_timestamp.tzinfo is None:
+                    raise ValueError("asof_timestamp must be timezone aware")
+                xtdb_filters.append(f"data_source_ts <= {_sql_literal(asof_timestamp)}")
+
+            where_clause = f"WHERE {' AND '.join(xtdb_filters)}" if xtdb_filters else ""
+            latest_log = _xtdb_dataframe_ops(connection).from_raw_sql(
+                "SELECT * "
+                f"FROM {self._table_sql()} "
+                f"{where_clause} "
+                "ORDER BY data_source_ts DESC",
+                schema_overrides={
+                    "data_source_ts": pl.Datetime("us", "UTC"),
+                    "upload_ts": pl.Datetime("us", "UTC"),
+                },
+            )
+            if latest_log.is_empty():
+                return latest_log
+            return (
+                latest_log.group_by("table_name")
+                .first()
+                .with_columns(pl.col("data_source_ts").cast(pl.Datetime("us", "UTC")))
+                .with_columns(pl.col("upload_ts").cast(pl.Datetime("us", "UTC")))
+            )
+
         tbl = self.create(connection)
+        assert isinstance(tbl, Table)
 
         filters = []
         if target_table_name is not None:

--- a/polars_hist_db/dataset/entrypoint.py
+++ b/polars_hist_db/dataset/entrypoint.py
@@ -7,12 +7,12 @@ from nats.js.client import JetStreamContext
 import polars as pl
 from sqlalchemy import Engine
 
+from ..backends import backend_from_config
 from ..loaders.input_source_factory import InputSourceFactory
 from ..utils.clock import Clock
 
 from ..config import PolarsHistDbConfig, DatasetConfig, TableConfig, TableConfigs
 from ..config.input.input_source import InputConfig
-from ..core import TableConfigOps
 from .scrape import try_run_pipeline_as_transaction
 
 LOGGER = logging.getLogger(__name__)
@@ -20,11 +20,16 @@ LOGGER = logging.getLogger(__name__)
 
 async def run_datasets(
     config: PolarsHistDbConfig,
-    engine: Engine,
+    engine: Optional[Engine] = None,
     dataset_name: Optional[str] = None,
     debug_capture_output: Optional[List[Tuple[datetime, pl.DataFrame]]] = None,
     js: Optional[JetStreamContext] = None,
+    raise_on_error: bool = False,
 ):
+    backend = backend_from_config(config.db_config)
+    if engine is None:
+        engine = backend.create_engine(config.db_config)
+
     num_datasets_processed = 0
     for dataset in config.datasets.datasets:
         if dataset_name is None or dataset.name == dataset_name:
@@ -36,17 +41,25 @@ async def run_datasets(
                 config.tables,
                 engine,
                 debug_capture_output,
+                backend,
                 js=js,
+                raise_on_error=raise_on_error,
             )
 
     if num_datasets_processed == 0:
         LOGGER.error("no datasets processed for %s", dataset_name)
 
 
-def _create_config_tables(engine: Engine, tables: TableConfigs):
+def _create_config_tables(engine: Engine, tables: TableConfigs, backend):
     """Create permanent config tables (idempotent)."""
+    if getattr(backend, "name", None) == "xtdb":
+        with engine.connect() as connection:
+            backend.table_configs(connection).create_all(tables)
+            connection.commit()
+        return
+
     with engine.begin() as connection:
-        TableConfigOps(connection).create_all(tables)
+        backend.table_configs(connection).create_all(tables)
 
 
 def _build_delta_table_config(
@@ -69,11 +82,13 @@ async def _run_dataset(
     tables: TableConfigs,
     engine: Engine,
     debug_capture_output: Optional[List[Tuple[datetime, pl.DataFrame]]],
+    backend,
     js: Optional[JetStreamContext] = None,
+    raise_on_error: bool = False,
 ):
     LOGGER.info("starting %s ingest for %s", input_config.type, dataset.name)
 
-    _create_config_tables(engine, tables)
+    _create_config_tables(engine, tables, backend)
     delta_table_config = _build_delta_table_config(tables, dataset)
 
     start_time = time.perf_counter()
@@ -93,10 +108,13 @@ async def _run_dataset(
                 engine,
                 commit_fn,
                 delta_table_config=delta_table_config,
+                backend=backend,
             )
 
     except Exception as e:
         LOGGER.error("error while processing InputSource: %s", e, exc_info=e)
+        if raise_on_error:
+            raise
     finally:
         await input_source.cleanup()
 

--- a/polars_hist_db/dataset/extract_item.py
+++ b/polars_hist_db/dataset/extract_item.py
@@ -1,11 +1,12 @@
 from datetime import datetime
 import logging
-from typing import Mapping
+from typing import Any, Mapping, Optional
 
 import polars as pl
 from sqlalchemy import Connection
 
 from .foreign_key_helper import deduce_foreign_keys
+from .primary_item import scrape_xtdb_pipeline_item
 
 from ..config import TableConfig, TableConfigs, DatasetConfig
 from ..core import TableConfigOps, DeltaTableOps, TableOps
@@ -22,11 +23,27 @@ def scrape_extract_item(
     tables: TableConfigs,
     upload_time: datetime,
     connection: Connection,
+    partition_df: Optional[pl.DataFrame] = None,
+    stage_run_id: Optional[str] = None,
+    staging: Any = None,
+    backend: Any = None,
 ) -> bool:
     pipeline = dataset.pipeline
     delta_table_name = dataset.name
 
     target_table_config: TableConfig = tables[target_table]
+    if getattr(backend, "name", None) == "xtdb":
+        return scrape_xtdb_pipeline_item(
+            pipeline_id,
+            dataset,
+            target_table_config,
+            upload_time,
+            connection,
+            stage_run_id,
+            staging,
+            backend,
+        )
+
     if target_table_config.is_temporal:
         raise NotImplementedError("temporal tables are not supported yet")
 

--- a/polars_hist_db/dataset/primary_item.py
+++ b/polars_hist_db/dataset/primary_item.py
@@ -1,9 +1,11 @@
 from datetime import datetime
 import logging
+from typing import Any, Optional
 
+import polars as pl
 from sqlalchemy import Connection
 
-from ..config import TableConfigs, DatasetConfig
+from ..config import TableConfig, TableConfigs, DatasetConfig
 from ..core import TableConfigOps, DeltaTableOps, TableOps
 
 LOGGER = logging.getLogger(__name__)
@@ -15,12 +17,28 @@ def scrape_primary_item(
     tables: TableConfigs,
     upload_time: datetime,
     connection: Connection,
+    partition_df: Optional[pl.DataFrame] = None,
+    stage_run_id: Optional[str] = None,
+    staging: Any = None,
+    backend: Any = None,
 ) -> bool:
     pipeline = dataset.pipeline
     delta_table_schema = dataset.delta_table_schema
     delta_table_name = dataset.name
     main_table_config = tables[pipeline.get_main_table_name()[1]]
     LOGGER.debug("(item %d) scraping item %s", pipeline_id, main_table_config.name)
+
+    if getattr(backend, "name", None) == "xtdb":
+        return scrape_xtdb_pipeline_item(
+            pipeline_id,
+            dataset,
+            main_table_config,
+            upload_time,
+            connection,
+            stage_run_id,
+            staging,
+            backend,
+        )
 
     upload_items = pipeline.extract_items(pipeline_id)
     selected_columns = upload_items["source"].to_list()
@@ -52,3 +70,41 @@ def scrape_primary_item(
 
     # TODO: trigger table mod notification
     return (ni + nu + nd) > 0
+
+
+def scrape_xtdb_pipeline_item(
+    pipeline_id: int,
+    dataset: DatasetConfig,
+    table_config: TableConfig,
+    upload_time: datetime,
+    connection: Connection,
+    stage_run_id: Optional[str],
+    staging: Any,
+    backend: Any,
+) -> bool:
+    if stage_run_id is None or staging is None:
+        raise ValueError("XTDB ingest requires a staged partition")
+
+    valid_time = dataset.valid_time_for_table(table_config.schema, table_config.name)
+    target_df = staging.prepare_pipeline_item_dataframe(
+        stage_run_id,
+        dataset,
+        pipeline_id,
+        table_config,
+        valid_time=valid_time,
+    )
+
+    backend.table_configs(connection).create(table_config)
+    modified_count = backend.temporal_upsert(
+        target_df,
+        table_config.schema,
+        table_config.name,
+        connection=connection,
+        table_config=table_config,
+        delta_config=dataset.delta_config,
+        update_time=upload_time,
+        valid_time=valid_time,
+    )
+
+    LOGGER.debug("(item %d) XTDB upserted %d rows", pipeline_id, modified_count)
+    return modified_count > 0

--- a/polars_hist_db/dataset/scrape.py
+++ b/polars_hist_db/dataset/scrape.py
@@ -1,7 +1,9 @@
 from datetime import datetime
+from contextlib import nullcontext
 import logging
 from time import sleep
-from typing import Awaitable, Callable, List, Optional, Set, Tuple
+from typing import Any, Awaitable, Callable, List, Optional, Set, Tuple
+from uuid import uuid4
 
 import polars as pl
 from sqlalchemy import Connection, Engine
@@ -16,6 +18,12 @@ from .primary_item import scrape_primary_item
 LOGGER = logging.getLogger(__name__)
 
 
+def _pipeline_transaction_context(connection: Connection, is_xtdb: bool):
+    if is_xtdb:
+        return nullcontext()
+    return connection.begin()
+
+
 def _scrape_pipeline_item(
     pipeline_id: int,
     dataset: DatasetConfig,
@@ -24,15 +32,36 @@ def _scrape_pipeline_item(
     tables: TableConfigs,
     upload_time: datetime,
     connection: Connection,
+    partition_df: Optional[pl.DataFrame] = None,
+    stage_run_id: Optional[str] = None,
+    staging: Any = None,
+    backend: Any = None,
 ) -> bool:
     item_type = dataset.pipeline.item_type(target_table)
     if item_type == "primary":
         return scrape_primary_item(
-            pipeline_id, dataset, tables, upload_time, connection
+            pipeline_id,
+            dataset,
+            tables,
+            upload_time,
+            connection,
+            partition_df=partition_df,
+            stage_run_id=stage_run_id,
+            staging=staging,
+            backend=backend,
         )
     elif item_type == "extract":
         return scrape_extract_item(
-            pipeline_id, dataset, target_table, tables, upload_time, connection
+            pipeline_id,
+            dataset,
+            target_table,
+            tables,
+            upload_time,
+            connection,
+            partition_df=partition_df,
+            stage_run_id=stage_run_id,
+            staging=staging,
+            backend=backend,
         )
     else:
         raise ValueError(f"unknown item type: {item_type}")
@@ -64,16 +93,19 @@ async def try_run_pipeline_as_transaction(
     num_retries: int = 3,
     seconds_between_retries: float = 60,
     delta_table_config: Optional[TableConfig] = None,
+    backend: Any = None,
 ):
     main_table_config: TableConfig = tables[dataset.pipeline.get_main_table_name()[1]]
     tbl_to_header_map = dataset.pipeline.get_header_map(main_table_config.name)
     header_keys = [tbl_to_header_map.get(k, k) for k in main_table_config.primary_keys]
+    is_xtdb = getattr(backend, "name", None) == "xtdb"
 
     while num_retries > 0:
         with engine.connect() as connection:
             try:
-                with connection.begin():
-                    if delta_table_config is not None:
+                with _pipeline_transaction_context(connection, is_xtdb):
+                    staging = backend.staging(connection) if is_xtdb else None
+                    if delta_table_config is not None and not is_xtdb:
                         _ensure_delta_table(
                             connection,
                             delta_table_config,
@@ -81,6 +113,7 @@ async def try_run_pipeline_as_transaction(
                         )
                     modified_tables: Set[Tuple[str, str]] = set()
                     for i, (ts, partition_df) in enumerate(partitions):
+                        stage_run_id = None
                         assert isinstance(ts, datetime), (
                             f"timestamp is not a datetime [{type(ts)}]"
                         )
@@ -92,32 +125,62 @@ async def try_run_pipeline_as_transaction(
                             len(partition_df),
                         )
 
-                        DataframeOps(connection).table_insert(
-                            partition_df,
-                            dataset.delta_table_schema,
-                            dataset.name,
-                            uniqueness_col_set=header_keys,
-                            prefill_nulls_with_default=True,
-                            clear_table_first=True,
-                        )
-
-                        for pipeline_id, (
-                            target_schema,
-                            target_table,
-                        ) in dataset.pipeline.get_pipeline_items().items():
-                            did_modify = _scrape_pipeline_item(
-                                pipeline_id,
-                                dataset,
-                                target_schema,
-                                target_table,
-                                tables,
+                        if not is_xtdb:
+                            DataframeOps(connection).table_insert(
+                                partition_df,
+                                dataset.delta_table_schema,
+                                dataset.name,
+                                uniqueness_col_set=header_keys,
+                                prefill_nulls_with_default=True,
+                                clear_table_first=True,
+                            )
+                        else:
+                            if delta_table_config is None:
+                                raise ValueError(
+                                    "XTDB ingest requires delta table config"
+                                )
+                            if staging is None:
+                                raise ValueError("XTDB ingest requires staging ops")
+                            stage_run_id = f"{dataset.name}:{uuid4()}"
+                            staging.ensure_table(delta_table_config)
+                            staging.insert_partition(
+                                partition_df,
+                                delta_table_config,
+                                stage_run_id,
                                 ts,
-                                connection,
+                                uniqueness_col_set=header_keys,
+                                prefill_nulls_with_default=True,
                             )
 
-                            if did_modify:
-                                modified_item = (target_schema, target_table)
-                                modified_tables.add(modified_item)
+                        try:
+                            for pipeline_id, (
+                                target_schema,
+                                target_table,
+                            ) in dataset.pipeline.get_pipeline_items().items():
+                                did_modify = _scrape_pipeline_item(
+                                    pipeline_id,
+                                    dataset,
+                                    target_schema,
+                                    target_table,
+                                    tables,
+                                    ts,
+                                    connection,
+                                    partition_df=partition_df,
+                                    stage_run_id=stage_run_id,
+                                    staging=staging,
+                                    backend=backend,
+                                )
+
+                                if did_modify:
+                                    modified_item = (target_schema, target_table)
+                                    modified_tables.add(modified_item)
+                        finally:
+                            if (
+                                is_xtdb
+                                and stage_run_id is not None
+                                and staging is not None
+                            ):
+                                staging.cleanup_run(stage_run_id, delta_table_config)
 
                     success = await commit_fn(connection, sorted(modified_tables))
                     if success:

--- a/polars_hist_db/loaders/input_source.py
+++ b/polars_hist_db/loaders/input_source.py
@@ -17,6 +17,12 @@ LOGGER = logging.getLogger(__name__)
 TConfig = TypeVar("TConfig", bound=InputConfig)
 
 
+def _file_filter_connection_context(engine: Engine):
+    if getattr(getattr(engine, "dialect", None), "name", None) == "postgresql":
+        return engine.connect()
+    return engine.begin()
+
+
 class InputSource(ABC, Generic[TConfig]):
     def __init__(
         self,
@@ -146,7 +152,7 @@ class InputSource(ABC, Generic[TConfig]):
         assert "__created_at" in upload_candidates_df.columns
 
         aops = AuditOps(table_schema)
-        with engine.begin() as connection:
+        with _file_filter_connection_context(engine) as connection:
             filtered_items_df = aops.filter_items(
                 upload_candidates_df, "__path", "__created_at", table_name, connection
             ).sort("__created_at")

--- a/polars_hist_db/parity.py
+++ b/polars_hist_db/parity.py
@@ -1,0 +1,745 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import polars as pl
+from sqlalchemy.engine import Engine
+
+from .backends import backend_from_config
+from .backends.config import DbEngineConfig
+from .config import PolarsHistDbConfig, TableConfig
+from .core import DbOps
+from .dataset import run_datasets
+from .types import PolarsType
+
+
+@dataclass(frozen=True)
+class BackendParityTarget:
+    name: str
+    db_config: DbEngineConfig
+
+
+@dataclass(frozen=True)
+class SemanticForeignKey:
+    source_table: str
+    source_column: str
+    target_table: str
+    target_column: str
+    target_columns: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class TableParityMismatch:
+    table: str
+    reason: str
+    left_rows: int | None
+    right_rows: int | None
+    details: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class BackendParityResult:
+    left_name: str
+    right_name: str
+    matches: list[str]
+    mismatches: list[TableParityMismatch]
+    semantic_foreign_key_diagnostics: tuple[str, ...] = ()
+
+    @property
+    def is_match(self) -> bool:
+        return not self.mismatches
+
+
+def prepare_parity_config(
+    source_config: Any,
+    target: BackendParityTarget,
+    *,
+    dataset_name: str | None = None,
+    payload: str | None = None,
+    payload_time: datetime | None = None,
+) -> Any:
+    config = deepcopy(source_config)
+    config.db_config = target.db_config
+    if payload is None:
+        return config
+
+    if dataset_name is None:
+        raise ValueError("dataset_name is required when payload is provided")
+    if payload_time is None:
+        payload_time = datetime.now(timezone.utc)
+
+    dataset = config.datasets[dataset_name]
+    if dataset is None:
+        raise ValueError(f"Dataset {dataset_name!r} not found in config")
+    input_config = dataset.input_config
+    if not hasattr(input_config, "set_payload"):
+        raise ValueError(f"Dataset {dataset_name!r} input_config cannot accept payload")
+    input_config.set_payload(payload, payload_time)
+    return config
+
+
+def compare_backend_tables(
+    *,
+    left_name: str,
+    right_name: str,
+    left_tables: Mapping[str, pl.DataFrame],
+    right_tables: Mapping[str, pl.DataFrame],
+    table_order: Sequence[str],
+    ignored_columns_by_table: Mapping[str, frozenset[str]] | None = None,
+    semantic_foreign_keys: Sequence[SemanticForeignKey] = (),
+    mismatch_sample_limit: int = 5,
+) -> BackendParityResult:
+    matches: list[str] = []
+    mismatches: list[TableParityMismatch] = []
+    left_tables, right_tables, semantic_fk_diagnostics = _prepare_tables_for_comparison(
+        left_name=left_name,
+        right_name=right_name,
+        left_tables=left_tables,
+        right_tables=right_tables,
+        ignored_columns_by_table=ignored_columns_by_table or {},
+        semantic_foreign_keys=semantic_foreign_keys,
+    )
+
+    for table in table_order:
+        left_df = left_tables.get(table)
+        right_df = right_tables.get(table)
+        if left_df is None or right_df is None:
+            mismatches.append(
+                TableParityMismatch(
+                    table=table,
+                    reason="missing table result",
+                    left_rows=None if left_df is None else left_df.height,
+                    right_rows=None if right_df is None else right_df.height,
+                )
+            )
+            continue
+
+        if left_df.height != right_df.height:
+            mismatches.append(
+                TableParityMismatch(
+                    table=table,
+                    reason="row count mismatch",
+                    left_rows=left_df.height,
+                    right_rows=right_df.height,
+                )
+            )
+            continue
+
+        if not left_df.equals(right_df):
+            mismatches.append(
+                TableParityMismatch(
+                    table=table,
+                    reason="data mismatch",
+                    left_rows=left_df.height,
+                    right_rows=right_df.height,
+                    details=_data_mismatch_details(
+                        left_df,
+                        right_df,
+                        sample_limit=mismatch_sample_limit,
+                    ),
+                )
+            )
+            continue
+
+        matches.append(table)
+
+    return BackendParityResult(
+        left_name=left_name,
+        right_name=right_name,
+        matches=matches,
+        mismatches=mismatches,
+        semantic_foreign_key_diagnostics=semantic_fk_diagnostics,
+    )
+
+
+def format_backend_parity_result(result: BackendParityResult) -> Sequence[str]:
+    lines: list[str] = []
+    for table in result.matches:
+        lines.append(f"PASS {table}")
+    for diagnostic in result.semantic_foreign_key_diagnostics:
+        lines.append(f"WARN {diagnostic}")
+    for mismatch in result.mismatches:
+        lines.append(
+            f"FAIL {mismatch.table}: {mismatch.reason} "
+            f"({result.left_name}={mismatch.left_rows}, "
+            f"{result.right_name}={mismatch.right_rows})"
+        )
+        lines.extend(f"  {detail}" for detail in mismatch.details)
+    return lines
+
+
+def _data_mismatch_details(
+    left_df: pl.DataFrame,
+    right_df: pl.DataFrame,
+    *,
+    sample_limit: int,
+) -> tuple[str, ...]:
+    details: list[str] = []
+    left_columns = set(left_df.columns)
+    right_columns = set(right_df.columns)
+    columns_only_left = sorted(left_columns - right_columns)
+    columns_only_right = sorted(right_columns - left_columns)
+    if columns_only_left:
+        details.append(f"columns_only_left={','.join(columns_only_left)}")
+    if columns_only_right:
+        details.append(f"columns_only_right={','.join(columns_only_right)}")
+
+    common_columns = [column for column in left_df.columns if column in right_columns]
+    differing_columns = [
+        column
+        for column in common_columns
+        if not left_df.select(column).equals(right_df.select(column))
+    ]
+    if differing_columns:
+        details.append(f"differing_columns={','.join(differing_columns)}")
+
+    left_rows = left_df.to_dicts()
+    right_rows = right_df.to_dicts()
+    differing_row_pairs = [
+        (left_row, right_row)
+        for left_row, right_row in zip(left_rows, right_rows, strict=True)
+        if left_row != right_row
+    ]
+    for sample_index, (left_row, right_row) in enumerate(
+        differing_row_pairs[:sample_limit]
+    ):
+        details.append(f"sample[{sample_index}] left={left_row!r} right={right_row!r}")
+
+    omitted_rows = len(differing_row_pairs) - sample_limit
+    if omitted_rows > 0:
+        details.append(f"{omitted_rows} additional differing rows omitted")
+
+    return tuple(details)
+
+
+def _prepare_tables_for_comparison(
+    *,
+    left_name: str,
+    right_name: str,
+    left_tables: Mapping[str, pl.DataFrame],
+    right_tables: Mapping[str, pl.DataFrame],
+    ignored_columns_by_table: Mapping[str, frozenset[str]],
+    semantic_foreign_keys: Sequence[SemanticForeignKey],
+) -> tuple[dict[str, pl.DataFrame], dict[str, pl.DataFrame], tuple[str, ...]]:
+    left_prepared = dict(left_tables)
+    right_prepared = dict(right_tables)
+    semantic_fk_diagnostics: list[str] = []
+
+    for semantic_fk in semantic_foreign_keys:
+        left_diagnostic = _resolve_semantic_foreign_key(
+            left_prepared,
+            semantic_fk,
+            backend_name=left_name,
+        )
+        right_diagnostic = _resolve_semantic_foreign_key(
+            right_prepared,
+            semantic_fk,
+            backend_name=right_name,
+        )
+        if left_diagnostic is not None:
+            semantic_fk_diagnostics.append(left_diagnostic)
+        if right_diagnostic is not None:
+            semantic_fk_diagnostics.append(right_diagnostic)
+
+    for table, ignored_columns in ignored_columns_by_table.items():
+        for tables in (left_prepared, right_prepared):
+            df = tables.get(table)
+            if df is None:
+                continue
+            columns_to_drop = [
+                column for column in ignored_columns if column in df.columns
+            ]
+            if columns_to_drop:
+                tables[table] = df.drop(columns_to_drop)
+
+    return (
+        {
+            table: _canonicalise_comparison_dataframe(df)
+            for table, df in left_prepared.items()
+        },
+        {
+            table: _canonicalise_comparison_dataframe(df)
+            for table, df in right_prepared.items()
+        },
+        tuple(semantic_fk_diagnostics),
+    )
+
+
+def _resolve_semantic_foreign_key(
+    tables: dict[str, pl.DataFrame],
+    semantic_fk: SemanticForeignKey,
+    *,
+    backend_name: str,
+) -> str | None:
+    source_df = tables.get(semantic_fk.source_table)
+    target_df = tables.get(semantic_fk.target_table)
+    if source_df is None or target_df is None:
+        return None
+    if semantic_fk.source_column not in source_df.columns:
+        return None
+
+    target_required_columns = [
+        semantic_fk.target_column,
+        *semantic_fk.target_columns,
+    ]
+    if any(column not in target_df.columns for column in target_required_columns):
+        return None
+
+    resolved_marker = f"__{semantic_fk.source_column}__resolved"
+    renamed_columns = {
+        semantic_fk.target_column: semantic_fk.source_column,
+        **{
+            column: f"{semantic_fk.source_column}__{column}"
+            for column in semantic_fk.target_columns
+        },
+    }
+    lookup_df = (
+        target_df.select(target_required_columns)
+        .unique(subset=[semantic_fk.target_column], maintain_order=True)
+        .rename(renamed_columns)
+        .with_columns(pl.lit(True).alias(resolved_marker))
+    )
+    joined_df = source_df.join(
+        lookup_df,
+        on=semantic_fk.source_column,
+        how="left",
+    )
+    unresolved_rows = joined_df.filter(
+        pl.col(semantic_fk.source_column).is_not_null()
+        & pl.col(resolved_marker).is_null()
+    ).height
+    tables[semantic_fk.source_table] = joined_df.drop(
+        semantic_fk.source_column,
+        resolved_marker,
+    )
+    if unresolved_rows == 0:
+        return None
+    return (
+        f"{backend_name} unresolved semantic_fk "
+        f"{semantic_fk.source_table}.{semantic_fk.source_column} -> "
+        f"{semantic_fk.target_table}.{semantic_fk.target_column} "
+        f"using {','.join(semantic_fk.target_columns)}: "
+        f"{unresolved_rows}/{source_df.height} source rows"
+    )
+
+
+def _canonicalise_comparison_dataframe(df: pl.DataFrame) -> pl.DataFrame:
+    if not df.columns:
+        return df
+    return df.select(sorted(df.columns)).sort(sorted(df.columns))
+
+
+def _qualified_table(table_config: TableConfig) -> str:
+    return f"{table_config.schema}.{table_config.name}"
+
+
+def _table_read_sql(
+    backend_name: str,
+    table_config: TableConfig,
+    *,
+    system_time: datetime | None = None,
+) -> str | None:
+    if backend_name == "xtdb":
+        query = f"SELECT * FROM {_qualified_table(table_config)}"
+        if table_config.is_temporal:
+            query += " FOR VALID_TIME ALL"
+        elif system_time is not None:
+            query += f" FOR VALID_TIME AS OF TIMESTAMP '{system_time.isoformat()}'"
+        if system_time is not None:
+            query += f" FOR SYSTEM_TIME AS OF TIMESTAMP '{system_time.isoformat()}'"
+        return query
+    return None
+
+
+def _normalise_backend_dataframe(
+    df: pl.DataFrame,
+    table_config: TableConfig,
+) -> pl.DataFrame:
+    primary_keys = list(table_config.primary_keys)
+    if "_id" in df.columns:
+        if len(primary_keys) == 1 and primary_keys[0] not in df.columns:
+            df = df.rename({"_id": primary_keys[0]})
+        else:
+            df = df.drop("_id")
+
+    configured_columns = [column.name for column in table_config.columns]
+    selected_columns = [column for column in configured_columns if column in df.columns]
+    df = df.select(selected_columns)
+
+    casts = {
+        column.name: PolarsType.from_sql(column.data_type)
+        for column in table_config.columns
+        if column.name in df.columns
+    }
+    if casts:
+        df = df.with_columns(
+            pl.col(column).cast(dtype) for column, dtype in casts.items()
+        )
+    df = df.pipe(PolarsType.cast_str_to_cat)
+
+    sort_columns = [column for column in primary_keys if column in df.columns]
+    if sort_columns:
+        df = df.sort(sort_columns)
+    return df
+
+
+def read_parity_tables(
+    engine: Engine,
+    config: PolarsHistDbConfig,
+    *,
+    table_names: Sequence[str] | None = None,
+    system_time: datetime | None = None,
+) -> dict[str, pl.DataFrame]:
+    backend = backend_from_config(config.db_config)
+    table_configs = list(config.tables.items)
+    selected = set(table_names) if table_names is not None else None
+    if selected is not None:
+        table_configs = [
+            table_config
+            for table_config in table_configs
+            if _qualified_table(table_config) in selected
+            or table_config.name in selected
+        ]
+
+    tables: dict[str, pl.DataFrame] = {}
+    connection_context = engine.connect if backend.name == "xtdb" else engine.begin
+    with connection_context() as connection:
+        dataframe_ops = backend.dataframes(connection)
+        for table_config in table_configs:
+            read_sql = _table_read_sql(
+                backend.name,
+                table_config,
+                system_time=system_time,
+            )
+            if read_sql is None:
+                df = dataframe_ops.from_table(table_config.schema, table_config.name)
+            else:
+                df = dataframe_ops.from_raw_sql(read_sql)
+            tables[_qualified_table(table_config)] = _normalise_backend_dataframe(
+                df,
+                table_config,
+            )
+    return tables
+
+
+def _create_config_tables(config: PolarsHistDbConfig, engine: Engine) -> None:
+    backend = backend_from_config(config.db_config)
+    connection_context = engine.connect if backend.name == "xtdb" else engine.begin
+    with connection_context() as connection:
+        if backend.name == "mariadb":
+            for schema in config.tables.schemas():
+                DbOps(connection).db_create(schema)
+        backend.table_configs(connection).drop_all(config.tables)
+        backend.table_configs(connection).create_all(config.tables)
+        if backend.name == "xtdb":
+            connection.commit()
+
+
+def _should_prepare_backend_tables(backend_name: str) -> bool:
+    return backend_name != "xtdb"
+
+
+async def run_backend_parity(
+    source_config: PolarsHistDbConfig,
+    *,
+    left: BackendParityTarget,
+    right: BackendParityTarget,
+    dataset_name: str | None = None,
+    table_names: Sequence[str] | None = None,
+    payload: str | None = None,
+    payload_time: datetime | None = None,
+    ignored_columns_by_table: Mapping[str, frozenset[str]] | None = None,
+    semantic_foreign_keys: Sequence[SemanticForeignKey] = (),
+    mismatch_sample_limit: int = 5,
+) -> BackendParityResult:
+    left_config = prepare_parity_config(
+        source_config,
+        left,
+        dataset_name=dataset_name,
+        payload=payload,
+        payload_time=payload_time,
+    )
+    right_config = prepare_parity_config(
+        source_config,
+        right,
+        dataset_name=dataset_name,
+        payload=payload,
+        payload_time=payload_time,
+    )
+
+    left_backend = backend_from_config(left_config.db_config)
+    right_backend = backend_from_config(right_config.db_config)
+    left_engine = left_backend.create_engine(left_config.db_config)
+    right_engine = right_backend.create_engine(right_config.db_config)
+    try:
+        if _should_prepare_backend_tables(left_backend.name):
+            _create_config_tables(left_config, left_engine)
+        if _should_prepare_backend_tables(right_backend.name):
+            _create_config_tables(right_config, right_engine)
+        await run_datasets(
+            left_config,
+            left_engine,
+            dataset_name,
+            raise_on_error=True,
+        )
+        await run_datasets(
+            right_config,
+            right_engine,
+            dataset_name,
+            raise_on_error=True,
+        )
+        verification_system_time = (
+            payload_time + timedelta(seconds=1) if payload_time is not None else None
+        )
+        left_tables = read_parity_tables(
+            left_engine,
+            left_config,
+            table_names=table_names,
+            system_time=verification_system_time,
+        )
+        right_tables = read_parity_tables(
+            right_engine,
+            right_config,
+            table_names=table_names,
+            system_time=verification_system_time,
+        )
+    finally:
+        left_engine.dispose()
+        right_engine.dispose()
+
+    table_order = [
+        _qualified_table(table_config)
+        for table_config in source_config.tables.items
+        if table_names is None
+        or _qualified_table(table_config) in table_names
+        or table_config.name in table_names
+    ]
+    config_ignored_columns = _group_ignored_columns(
+        _parity_ignore_columns_from_config(source_config)
+    )
+    effective_ignored_columns = _merge_ignored_columns(
+        config_ignored_columns,
+        ignored_columns_by_table or {},
+    )
+    effective_semantic_foreign_keys = (
+        *_parity_semantic_foreign_keys_from_config(source_config),
+        *semantic_foreign_keys,
+    )
+    return compare_backend_tables(
+        left_name=left.name,
+        right_name=right.name,
+        left_tables=left_tables,
+        right_tables=right_tables,
+        table_order=table_order,
+        ignored_columns_by_table=effective_ignored_columns,
+        semantic_foreign_keys=effective_semantic_foreign_keys,
+        mismatch_sample_limit=mismatch_sample_limit,
+    )
+
+
+def _parse_backend_target(value: str) -> BackendParityTarget:
+    first_part = value.split(",", 1)[0]
+    name: str
+    if "=" in first_part:
+        name, _separator, raw_config = value.partition("=")
+    else:
+        raw_config = value
+        name = first_part
+    parts = [part for part in raw_config.split(",") if part]
+    if not parts:
+        raise ValueError("Backend target cannot be empty")
+    cfg: dict[str, str] = {"backend": parts[0]}
+    for part in parts[1:]:
+        key, key_separator, parsed_value = part.partition("=")
+        if not key_separator:
+            raise ValueError(f"Invalid backend target option {part!r}")
+        cfg[key] = parsed_value
+    return BackendParityTarget(
+        name=name,
+        db_config=DbEngineConfig.from_mapping(cfg),
+    )
+
+
+def _split_qualified_column(value: str) -> tuple[str, str]:
+    table, separator, column = value.rpartition(".")
+    if not separator or "." not in table or not column:
+        raise ValueError(f"Expected a fully-qualified column, got {value!r}")
+    return table, column
+
+
+def _parse_ignore_column(value: str) -> tuple[str, str]:
+    return _split_qualified_column(value)
+
+
+def _parse_semantic_foreign_key(value: str) -> SemanticForeignKey:
+    source_column_ref, mapping_separator, target_ref = value.partition("=")
+    if not mapping_separator:
+        raise ValueError(f"Invalid semantic foreign key mapping {value!r}")
+
+    target_column_ref, target_columns_separator, raw_target_columns = (
+        target_ref.partition(":")
+    )
+    if not target_columns_separator:
+        raise ValueError(
+            f"Semantic foreign key mapping requires target columns: {value!r}"
+        )
+
+    source_table, source_column = _split_qualified_column(source_column_ref)
+    target_table, target_column = _split_qualified_column(target_column_ref)
+    target_columns = tuple(
+        column.strip() for column in raw_target_columns.split(",") if column.strip()
+    )
+    if not target_columns:
+        raise ValueError(
+            f"Semantic foreign key mapping requires target columns: {value!r}"
+        )
+    return SemanticForeignKey(
+        source_table=source_table,
+        source_column=source_column,
+        target_table=target_table,
+        target_column=target_column,
+        target_columns=target_columns,
+    )
+
+
+def _semantic_foreign_key_from_config(value: Any) -> SemanticForeignKey:
+    source_table, source_column = _split_qualified_column(str(value.source))
+    target_table, target_column = _split_qualified_column(str(value.target))
+    return SemanticForeignKey(
+        source_table=source_table,
+        source_column=source_column,
+        target_table=target_table,
+        target_column=target_column,
+        target_columns=tuple(value.columns),
+    )
+
+
+def _group_ignored_columns(
+    ignored_columns: Sequence[tuple[str, str]],
+) -> dict[str, frozenset[str]]:
+    grouped: dict[str, set[str]] = {}
+    for table, column in ignored_columns:
+        grouped.setdefault(table, set()).add(column)
+    return {table: frozenset(columns) for table, columns in grouped.items()}
+
+
+def _merge_ignored_columns(
+    *ignored_columns_by_table: Mapping[str, frozenset[str]],
+) -> dict[str, frozenset[str]]:
+    grouped: dict[str, set[str]] = {}
+    for ignored_columns in ignored_columns_by_table:
+        for table, columns in ignored_columns.items():
+            grouped.setdefault(table, set()).update(columns)
+    return {table: frozenset(columns) for table, columns in grouped.items()}
+
+
+def _parity_ignore_columns_from_config(config: Any) -> list[tuple[str, str]]:
+    parity_config = getattr(config, "parity", None)
+    if parity_config is None:
+        return []
+    return [
+        _parse_ignore_column(column)
+        for column in getattr(parity_config, "ignore_columns", ())
+    ]
+
+
+def _parity_semantic_foreign_keys_from_config(
+    config: Any,
+) -> tuple[SemanticForeignKey, ...]:
+    parity_config = getattr(config, "parity", None)
+    if parity_config is None:
+        return ()
+    return tuple(
+        _semantic_foreign_key_from_config(value)
+        for value in getattr(parity_config, "semantic_foreign_keys", ())
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compare two polars-hist-db backends")
+    parser.add_argument(
+        "--config", required=True, help="Path to polars-hist-db YAML config"
+    )
+    parser.add_argument("--dataset", help="Dataset name to ingest")
+    parser.add_argument(
+        "--table",
+        action="append",
+        dest="tables",
+        help="Table to compare, as name or schema.name. Repeatable.",
+    )
+    parser.add_argument("--payload-file", type=Path, help="Payload file to inject")
+    parser.add_argument(
+        "--payload-time",
+        help="Payload timestamp. Defaults to now only when --payload-file is used.",
+    )
+    parser.add_argument(
+        "--left",
+        default="mariadb",
+        help="Left target as backend or name=backend. Default: mariadb",
+    )
+    parser.add_argument(
+        "--right",
+        default="xtdb",
+        help="Right target as backend or name=backend. Default: xtdb",
+    )
+    parser.add_argument(
+        "--ignore-column",
+        action="append",
+        default=[],
+        type=_parse_ignore_column,
+        help="Column to ignore as schema.table.column. Repeatable.",
+    )
+    parser.add_argument(
+        "--semantic-fk",
+        action="append",
+        default=[],
+        type=_parse_semantic_foreign_key,
+        help=(
+            "Resolve a backend-local FK before comparing, as "
+            "source.schema_table.column=target.schema_table.column:semantic_col,..."
+        ),
+    )
+    parser.add_argument(
+        "--mismatch-sample-limit",
+        type=int,
+        default=5,
+        help="Maximum differing rows to print per mismatched table. Default: 5",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    config = PolarsHistDbConfig.from_yaml(args.config)
+    payload = args.payload_file.read_text() if args.payload_file else None
+    payload_time = (
+        datetime.fromisoformat(args.payload_time) if args.payload_time else None
+    )
+    result = asyncio.run(
+        run_backend_parity(
+            config,
+            left=_parse_backend_target(args.left),
+            right=_parse_backend_target(args.right),
+            dataset_name=args.dataset,
+            table_names=args.tables,
+            payload=payload,
+            payload_time=payload_time,
+            ignored_columns_by_table=_group_ignored_columns(args.ignore_column),
+            semantic_foreign_keys=tuple(args.semantic_fk),
+            mismatch_sample_limit=args.mismatch_sample_limit,
+        )
+    )
+    for line in format_backend_parity_result(result):
+        print(line)
+    if not result.is_match:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.12,<4.0"
 dependencies = [
     "nats-py>=2.14.0",
     "pandas>=3.0.2",
-    "polars[sqlalchemy]>=1.39.3",
+    "polars[sqlalchemy]>=1.41.2",
     "pyarrow>=23.0.1",
     "pymysql>=1.1.2",
     "pytz>=2026.1.post1",
@@ -22,9 +22,13 @@ dependencies = [
 [project.optional-dependencies]
 sqlalchemy = ["polars[sqlalchemy]"]
 nats = ["nats-py"]
+xtdb = ["adbc-driver-flightsql>=1.10.0", "psycopg[binary]>=3.2.2"]
 
 [project.urls]
 Repository = "https://github.com/jr200-labs/polars-hist-db"
+
+[project.scripts]
+polars-hist-db-parity = "polars_hist_db.parity:main"
 
 [dependency-groups]
 dev = [
@@ -73,6 +77,8 @@ module = [
     "scandir_rs.*",
     "nats.*",
     "nkeys.*",
+    "adbc_driver_flightsql.*",
+    "psycopg.*",
     "pyarrow.*",
 ]
 ignore_missing_imports = true

--- a/tests/backends/test_mariadb_backend.py
+++ b/tests/backends/test_mariadb_backend.py
@@ -1,0 +1,11 @@
+from polars_hist_db.backends import MariaDbBackend
+from polars_hist_db.core import DataframeOps, TableConfigOps, TableOps
+
+
+def test_mariadb_backend_returns_existing_operation_wrappers():
+    backend = MariaDbBackend()
+    connection = object()
+
+    assert isinstance(backend.dataframes(connection), DataframeOps)
+    assert isinstance(backend.table_configs(connection), TableConfigOps)
+    assert isinstance(backend.tables("schema", "table", connection), TableOps)

--- a/tests/backends/test_parity_harness.py
+++ b/tests/backends/test_parity_harness.py
@@ -1,0 +1,568 @@
+from datetime import datetime
+import asyncio
+import sys
+from types import SimpleNamespace
+
+import polars as pl
+
+from polars_hist_db.backends.config import DbEngineConfig
+from polars_hist_db.parity import (
+    BackendParityTarget,
+    BackendParityResult,
+    SemanticForeignKey,
+    TableParityMismatch,
+    format_backend_parity_result,
+    _parse_backend_target,
+    _parse_args,
+    _parse_ignore_column,
+    _parse_semantic_foreign_key,
+    _should_prepare_backend_tables,
+    _table_read_sql,
+    compare_backend_tables,
+    main,
+    prepare_parity_config,
+    run_backend_parity,
+)
+from polars_hist_db.config import TableColumnConfig, TableConfig
+
+
+class _InputConfig:
+    def __init__(self):
+        self.payload = None
+        self.payload_time = None
+
+    def set_payload(self, payload, payload_time):
+        self.payload = payload
+        self.payload_time = payload_time
+
+
+class _Config:
+    def __init__(self):
+        self.db_config = DbEngineConfig(backend="mariadb")
+        self.datasets = {"cargo_dataset": SimpleNamespace(input_config=_InputConfig())}
+
+
+def test_prepare_parity_config_overrides_backend_without_mutating_source_config():
+    source = _Config()
+    target = BackendParityTarget(
+        name="xtdb-local",
+        db_config=DbEngineConfig(backend="xtdb", hostname="127.0.0.1", port=5432),
+    )
+    payload_time = datetime(2030, 1, 1, 12, 0)
+
+    prepared = prepare_parity_config(
+        source,
+        target,
+        dataset_name="cargo_dataset",
+        payload="id,name\n1,Bonny\n",
+        payload_time=payload_time,
+    )
+
+    assert prepared is not source
+    assert prepared.db_config.backend == "xtdb"
+    assert source.db_config.backend == "mariadb"
+    assert (
+        prepared.datasets["cargo_dataset"].input_config.payload == "id,name\n1,Bonny\n"
+    )
+    assert prepared.datasets["cargo_dataset"].input_config.payload_time == payload_time
+    assert source.datasets["cargo_dataset"].input_config.payload is None
+
+
+def test_compare_backend_tables_reports_row_count_and_value_mismatches():
+    left_tables = {
+        "kpler.trades": pl.DataFrame(
+            {"id": [1, 2], "trade_status": ["Delivered", "Loaded"]}
+        ),
+        "kpler.vessel_info": pl.DataFrame({"id": [501], "name": ["A"]}),
+    }
+    right_tables = {
+        "kpler.trades": pl.DataFrame(
+            {"id": [1, 2], "trade_status": ["Delivered", "Ballast"]}
+        ),
+        "kpler.vessel_info": pl.DataFrame({"id": [501], "name": ["A"]}),
+        "kpler.location_info": pl.DataFrame({"id": [101]}),
+    }
+
+    result = compare_backend_tables(
+        left_name="mariadb",
+        right_name="xtdb",
+        left_tables=left_tables,
+        right_tables=right_tables,
+        table_order=["kpler.trades", "kpler.vessel_info", "kpler.location_info"],
+    )
+
+    assert not result.is_match
+    assert result.matches == ["kpler.vessel_info"]
+    assert result.mismatches == [
+        TableParityMismatch(
+            table="kpler.trades",
+            reason="data mismatch",
+            left_rows=2,
+            right_rows=2,
+            details=(
+                "differing_columns=trade_status",
+                "sample[0] left={'id': 2, 'trade_status': 'Loaded'} "
+                "right={'id': 2, 'trade_status': 'Ballast'}",
+            ),
+        ),
+        TableParityMismatch(
+            table="kpler.location_info",
+            reason="missing table result",
+            left_rows=None,
+            right_rows=1,
+        ),
+    ]
+
+
+def test_compare_backend_tables_caps_value_mismatch_samples():
+    result = compare_backend_tables(
+        left_name="mariadb",
+        right_name="xtdb",
+        left_tables={
+            "kpler.trades": pl.DataFrame(
+                {"id": [1, 2, 3], "trade_status": ["A", "B", "C"]}
+            )
+        },
+        right_tables={
+            "kpler.trades": pl.DataFrame(
+                {"id": [1, 2, 3], "trade_status": ["X", "Y", "Z"]}
+            )
+        },
+        table_order=["kpler.trades"],
+        mismatch_sample_limit=2,
+    )
+
+    assert result.mismatches[0].details == (
+        "differing_columns=trade_status",
+        "sample[0] left={'id': 1, 'trade_status': 'A'} "
+        "right={'id': 1, 'trade_status': 'X'}",
+        "sample[1] left={'id': 2, 'trade_status': 'B'} "
+        "right={'id': 2, 'trade_status': 'Y'}",
+        "1 additional differing rows omitted",
+    )
+
+
+def test_compare_backend_tables_reports_unresolved_semantic_foreign_keys():
+    result = compare_backend_tables(
+        left_name="mariadb",
+        right_name="xtdb",
+        left_tables={
+            "kpler.location_info": pl.DataFrame({"id": [1], "name": ["Bonny Island"]}),
+            "kpler.trades": pl.DataFrame(
+                {"id": [10, 11], "origin_location_id": [1, 999]}
+            ),
+        },
+        right_tables={
+            "kpler.location_info": pl.DataFrame({"id": [1], "name": ["Bonny Island"]}),
+            "kpler.trades": pl.DataFrame(
+                {"id": [10, 11], "origin_location_id": [1, 999]}
+            ),
+        },
+        table_order=["kpler.trades"],
+        semantic_foreign_keys=(
+            SemanticForeignKey(
+                source_table="kpler.trades",
+                source_column="origin_location_id",
+                target_table="kpler.location_info",
+                target_column="id",
+                target_columns=("name",),
+            ),
+        ),
+    )
+
+    assert result.semantic_foreign_key_diagnostics == (
+        "mariadb unresolved semantic_fk "
+        "kpler.trades.origin_location_id -> kpler.location_info.id "
+        "using name: 1/2 source rows",
+        "xtdb unresolved semantic_fk "
+        "kpler.trades.origin_location_id -> kpler.location_info.id "
+        "using name: 1/2 source rows",
+    )
+
+
+def test_format_backend_parity_result_includes_details_and_diagnostics():
+    result = BackendParityResult(
+        left_name="mariadb",
+        right_name="xtdb",
+        matches=["kpler.vessel_info"],
+        mismatches=[
+            TableParityMismatch(
+                table="kpler.trades",
+                reason="data mismatch",
+                left_rows=1,
+                right_rows=1,
+                details=("differing_columns=trade_status",),
+            )
+        ],
+        semantic_foreign_key_diagnostics=(
+            "xtdb unresolved semantic_fk "
+            "kpler.trades.origin_location_id -> kpler.location_info.id "
+            "using name: 1/2 source rows",
+        ),
+    )
+
+    assert list(format_backend_parity_result(result)) == [
+        "PASS kpler.vessel_info",
+        "WARN xtdb unresolved semantic_fk "
+        "kpler.trades.origin_location_id -> kpler.location_info.id "
+        "using name: 1/2 source rows",
+        "FAIL kpler.trades: data mismatch (mariadb=1, xtdb=1)",
+        "  differing_columns=trade_status",
+    ]
+
+
+def test_compare_backend_tables_can_resolve_backend_local_surrogate_keys():
+    left_tables = {
+        "kpler.location_info": pl.DataFrame(
+            {
+                "id": [1, 2],
+                "name": ["Bonny Island", "#Unspecified"],
+                "country": ["Nigeria", "#Unspecified"],
+            }
+        ),
+        "kpler.trades": pl.DataFrame(
+            {
+                "id": [308025, 308327],
+                "origin_location_id": [1, 2],
+                "destination_location_id": [2, 2],
+            }
+        ),
+    }
+    right_tables = {
+        "kpler.location_info": pl.DataFrame(
+            {
+                "id": [1701, -1408044658],
+                "name": ["Bonny Island", "#Unspecified"],
+                "country": ["Nigeria", "#Unspecified"],
+            }
+        ),
+        "kpler.trades": pl.DataFrame(
+            {
+                "id": [308025, 308327],
+                "origin_location_id": [1701, -1408044658],
+                "destination_location_id": [-1408044658, -1408044658],
+            }
+        ),
+    }
+
+    result = compare_backend_tables(
+        left_name="mariadb",
+        right_name="xtdb",
+        left_tables=left_tables,
+        right_tables=right_tables,
+        table_order=["kpler.location_info", "kpler.trades"],
+        ignored_columns_by_table={"kpler.location_info": frozenset({"id"})},
+        semantic_foreign_keys=(
+            SemanticForeignKey(
+                source_table="kpler.trades",
+                source_column="origin_location_id",
+                target_table="kpler.location_info",
+                target_column="id",
+                target_columns=("name", "country"),
+            ),
+            SemanticForeignKey(
+                source_table="kpler.trades",
+                source_column="destination_location_id",
+                target_table="kpler.location_info",
+                target_column="id",
+                target_columns=("name", "country"),
+            ),
+        ),
+    )
+
+    assert result.is_match
+    assert result.matches == ["kpler.location_info", "kpler.trades"]
+    assert result.mismatches == []
+
+
+def test_parse_semantic_foreign_key_accepts_cli_mapping():
+    semantic_fk = _parse_semantic_foreign_key(
+        "kpler.trades.origin_location_id=kpler.location_info.id:name,country"
+    )
+
+    assert semantic_fk == SemanticForeignKey(
+        source_table="kpler.trades",
+        source_column="origin_location_id",
+        target_table="kpler.location_info",
+        target_column="id",
+        target_columns=("name", "country"),
+    )
+
+
+def test_parse_ignore_column_accepts_qualified_column():
+    assert _parse_ignore_column("kpler.location_info.id") == (
+        "kpler.location_info",
+        "id",
+    )
+
+
+def test_parse_args_leaves_payload_time_unset_for_file_based_runs(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["polars-hist-db-parity", "--config", "configs/kpler.yaml"],
+    )
+
+    args = _parse_args()
+
+    assert args.payload_time is None
+
+
+def test_main_passes_cli_parity_rules_to_backend_parity(monkeypatch):
+    captured = {}
+
+    class _Config:
+        parity = SimpleNamespace(
+            ignore_columns=("kpler.location_info.id",),
+            semantic_foreign_keys=(
+                SimpleNamespace(
+                    source="kpler.trades.origin_location_id",
+                    target="kpler.location_info.id",
+                    columns=("name", "country"),
+                ),
+            ),
+        )
+
+    async def fake_run_backend_parity(*args, **kwargs):
+        captured.update(kwargs)
+        return BackendParityResult(
+            left_name="mariadb",
+            right_name="xtdb",
+            matches=[],
+            mismatches=[],
+        )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "polars-hist-db-parity",
+            "--config",
+            "configs/kpler.yaml",
+            "--ignore-column",
+            "kpler.location_info.created_at",
+            "--semantic-fk",
+            "kpler.trades.origin_location_id=kpler.location_info.id:name,country",
+        ],
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.parity.PolarsHistDbConfig.from_yaml",
+        lambda path: _Config(),
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.parity.run_backend_parity",
+        fake_run_backend_parity,
+    )
+
+    main()
+
+    assert captured["ignored_columns_by_table"] == {
+        "kpler.location_info": frozenset({"created_at"})
+    }
+    assert captured["semantic_foreign_keys"] == (
+        SemanticForeignKey(
+            source_table="kpler.trades",
+            source_column="origin_location_id",
+            target_table="kpler.location_info",
+            target_column="id",
+            target_columns=("name", "country"),
+        ),
+    )
+
+
+def test_run_backend_parity_uses_parity_rules_from_config(monkeypatch):
+    class _Engine:
+        def __init__(self, backend_name):
+            self.backend_name = backend_name
+            self.disposed = False
+
+        def dispose(self):
+            self.disposed = True
+
+    class _Backend:
+        def __init__(self, backend_name):
+            self.name = backend_name
+
+        def create_engine(self, db_config):
+            return _Engine(db_config.backend)
+
+    source_config = SimpleNamespace(
+        db_config=DbEngineConfig(backend="mariadb"),
+        datasets={"trades_dataset": SimpleNamespace(input_config=_InputConfig())},
+        tables=SimpleNamespace(
+            items=[
+                TableConfig(
+                    schema="kpler",
+                    name="location_info",
+                    is_temporal=False,
+                    primary_keys=["id"],
+                    columns=[
+                        TableColumnConfig("location_info", "id", "INT"),
+                        TableColumnConfig("location_info", "name", "VARCHAR"),
+                        TableColumnConfig("location_info", "country", "VARCHAR"),
+                    ],
+                ),
+                TableConfig(
+                    schema="kpler",
+                    name="trades",
+                    is_temporal=True,
+                    primary_keys=["id"],
+                    columns=[
+                        TableColumnConfig("trades", "id", "INT"),
+                        TableColumnConfig("trades", "origin_location_id", "INT"),
+                        TableColumnConfig(
+                            "trades",
+                            "destination_location_id",
+                            "INT",
+                        ),
+                    ],
+                ),
+            ]
+        ),
+        parity=SimpleNamespace(
+            ignore_columns=("kpler.location_info.id",),
+            semantic_foreign_keys=(
+                SimpleNamespace(
+                    source="kpler.trades.origin_location_id",
+                    target="kpler.location_info.id",
+                    columns=("name", "country"),
+                ),
+                SimpleNamespace(
+                    source="kpler.trades.destination_location_id",
+                    target="kpler.location_info.id",
+                    columns=("name", "country"),
+                ),
+            ),
+        ),
+    )
+    tables_by_backend = {
+        "mariadb": {
+            "kpler.location_info": pl.DataFrame(
+                {
+                    "id": [1, 2],
+                    "name": ["Bonny Island", "#Unspecified"],
+                    "country": ["Nigeria", "#Unspecified"],
+                }
+            ),
+            "kpler.trades": pl.DataFrame(
+                {
+                    "id": [308025, 308327],
+                    "origin_location_id": [1, 2],
+                    "destination_location_id": [2, 2],
+                }
+            ),
+        },
+        "xtdb": {
+            "kpler.location_info": pl.DataFrame(
+                {
+                    "id": [1701, -1408044658],
+                    "name": ["Bonny Island", "#Unspecified"],
+                    "country": ["Nigeria", "#Unspecified"],
+                }
+            ),
+            "kpler.trades": pl.DataFrame(
+                {
+                    "id": [308025, 308327],
+                    "origin_location_id": [1701, -1408044658],
+                    "destination_location_id": [-1408044658, -1408044658],
+                }
+            ),
+        },
+    }
+
+    async def fake_run_datasets(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "polars_hist_db.parity.backend_from_config",
+        lambda db_config: _Backend(db_config.backend),
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.parity._should_prepare_backend_tables",
+        lambda backend_name: False,
+    )
+    monkeypatch.setattr("polars_hist_db.parity.run_datasets", fake_run_datasets)
+    monkeypatch.setattr(
+        "polars_hist_db.parity.read_parity_tables",
+        lambda engine, *args, **kwargs: tables_by_backend[engine.backend_name],
+    )
+
+    result = asyncio.run(
+        run_backend_parity(
+            source_config,
+            left=BackendParityTarget(
+                name="mariadb",
+                db_config=DbEngineConfig(backend="mariadb"),
+            ),
+            right=BackendParityTarget(
+                name="xtdb",
+                db_config=DbEngineConfig(backend="xtdb"),
+            ),
+            dataset_name="trades_dataset",
+        )
+    )
+
+    assert result.is_match
+    assert result.matches == ["kpler.location_info", "kpler.trades"]
+
+
+def test_parse_backend_target_accepts_named_connection_options():
+    target = _parse_backend_target(
+        "left=mariadb,hostname=127.0.0.1,port=13307,username=root,password=admin"
+    )
+
+    assert target.name == "left"
+    assert target.db_config.backend == "mariadb"
+    assert target.db_config.hostname == "127.0.0.1"
+    assert target.db_config.port == 13307
+    assert target.db_config.username == "root"
+    assert target.db_config.password == "admin"
+
+
+def test_parse_backend_target_accepts_unnamed_connection_options():
+    target = _parse_backend_target("xtdb,hostname=127.0.0.1,port=33126")
+
+    assert target.name == "xtdb"
+    assert target.db_config.backend == "xtdb"
+    assert target.db_config.hostname == "127.0.0.1"
+    assert target.db_config.port == 33126
+
+
+def test_table_read_sql_uses_valid_time_all_for_xtdb_tables():
+    table_config = TableConfig(
+        schema="kpler",
+        name="trades",
+        is_temporal=True,
+        primary_keys=["id"],
+        columns=[TableColumnConfig("trades", "id", "INT")],
+    )
+
+    system_time = datetime(2035, 1, 1, 0, 0, 1)
+
+    assert _table_read_sql("xtdb", table_config, system_time=system_time) == (
+        "SELECT * FROM kpler.trades FOR VALID_TIME ALL "
+        "FOR SYSTEM_TIME AS OF TIMESTAMP '2035-01-01T00:00:01'"
+    )
+    assert _table_read_sql("mariadb", table_config, system_time=system_time) is None
+
+
+def test_table_read_sql_uses_valid_time_asof_for_xtdb_non_temporal_tables():
+    table_config = TableConfig(
+        schema="kpler",
+        name="vessel_info",
+        is_temporal=False,
+        primary_keys=["id"],
+        columns=[TableColumnConfig("vessel_info", "id", "INT")],
+    )
+    system_time = datetime(2035, 1, 1, 0, 0, 1)
+
+    assert _table_read_sql("xtdb", table_config, system_time=system_time) == (
+        "SELECT * FROM kpler.vessel_info "
+        "FOR VALID_TIME AS OF TIMESTAMP '2035-01-01T00:00:01' "
+        "FOR SYSTEM_TIME AS OF TIMESTAMP '2035-01-01T00:00:01'"
+    )
+
+
+def test_backend_table_prepare_is_skipped_for_xtdb():
+    assert not _should_prepare_backend_tables("xtdb")
+    assert _should_prepare_backend_tables("mariadb")

--- a/tests/backends/test_registry.py
+++ b/tests/backends/test_registry.py
@@ -1,0 +1,34 @@
+import pytest
+
+from polars_hist_db.backends import (
+    DbEngineConfig,
+    MariaDbBackend,
+    XtdbBackend,
+    backend_from_config,
+    get_backend,
+)
+
+
+def test_registry_returns_mariadb_backend_by_default_name():
+    backend = get_backend("mariadb")
+
+    assert isinstance(backend, MariaDbBackend)
+    assert backend.name == "mariadb"
+
+
+def test_registry_returns_xtdb_backend():
+    backend = get_backend("xtdb")
+
+    assert isinstance(backend, XtdbBackend)
+    assert backend.name == "xtdb"
+
+
+def test_registry_rejects_unknown_backend():
+    with pytest.raises(ValueError, match="Unsupported database backend 'oracle'"):
+        get_backend("oracle")
+
+
+def test_backend_from_config_uses_db_engine_config_backend():
+    backend = backend_from_config(DbEngineConfig(backend="xtdb"))
+
+    assert isinstance(backend, XtdbBackend)

--- a/tests/backends/test_temporal_hints.py
+++ b/tests/backends/test_temporal_hints.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timedelta
+
+from polars_hist_db.backends import MariaDbBackend, XtdbBackend
+from polars_hist_db.core import TimeHint
+
+
+def test_mariadb_backend_builds_existing_time_hint_clauses():
+    asof = datetime.fromisoformat("2026-01-02T03:04:05+00:00")
+
+    assert MariaDbBackend().time_hint_clause(TimeHint(mode="none")) is None
+    assert (
+        MariaDbBackend().time_hint_clause(TimeHint(mode="all")) == "FOR SYSTEM_TIME ALL"
+    )
+    assert (
+        MariaDbBackend().time_hint_clause(TimeHint(mode="asof", asof_utc=asof))
+        == "FOR SYSTEM_TIME AS OF '2026-01-02T03:04:05+00:00'"
+    )
+    assert (
+        MariaDbBackend().time_hint_clause(
+            TimeHint(mode="span", asof_utc=asof, history_span=timedelta(hours=2))
+        )
+        == "FOR SYSTEM_TIME BETWEEN '2026-01-02T01:04:05+00:00' AND '2026-01-02T03:04:05+00:00'"
+    )
+
+
+def test_xtdb_backend_builds_matching_system_time_hint_clauses():
+    asof = datetime.fromisoformat("2026-01-02T03:04:05+00:00")
+
+    assert XtdbBackend().time_hint_clause(TimeHint(mode="none")) is None
+    assert XtdbBackend().time_hint_clause(TimeHint(mode="all")) == "FOR SYSTEM_TIME ALL"
+    assert (
+        XtdbBackend().time_hint_clause(TimeHint(mode="asof", asof_utc=asof))
+        == "FOR SYSTEM_TIME AS OF '2026-01-02T03:04:05+00:00'"
+    )
+    assert (
+        XtdbBackend().time_hint_clause(
+            TimeHint(mode="span", asof_utc=asof, history_span=timedelta(hours=2))
+        )
+        == "FOR SYSTEM_TIME BETWEEN '2026-01-02T01:04:05+00:00' AND '2026-01-02T03:04:05+00:00'"
+    )

--- a/tests/backends/test_xtdb_adbc_live.py
+++ b/tests/backends/test_xtdb_adbc_live.py
@@ -1,0 +1,187 @@
+from contextlib import contextmanager
+from collections.abc import Iterator
+from datetime import datetime, timezone
+import os
+import subprocess
+import time
+from typing import Any
+
+import polars as pl
+import pytest
+
+from polars_hist_db.backends import DbEngineConfig, XtdbBackend
+from polars_hist_db.config import TableColumnConfig, TableConfig
+from polars_hist_db.core import TimeHint
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.environ.get("POLARS_HIST_DB_XTDB_LIVE") != "1",
+        reason="set POLARS_HIST_DB_XTDB_LIVE=1 to run live XTDB tests",
+    ),
+]
+
+
+try:
+    import adbc_driver_flightsql  # noqa: F401
+except ImportError:
+    pytestmark = [
+        *pytestmark,
+        pytest.mark.skip(reason="install the xtdb extra to run live XTDB ADBC tests"),
+    ]
+
+
+def _docker(args: list[str]) -> str:
+    return subprocess.check_output(["docker", *args], text=True).strip()
+
+
+def _published_port(container_id: str, container_port: str) -> int:
+    output = _docker(["port", container_id, container_port])
+    first_binding = output.splitlines()[0]
+    return int(first_binding.rsplit(":", 1)[1])
+
+
+@contextmanager
+def _xtdb_adbc_connection() -> Iterator[Any]:
+    container_id = _docker(
+        ["run", "--rm", "-d", "-p", "9832", "ghcr.io/xtdb/xtdb:nightly"]
+    )
+    connection = None
+    try:
+        backend = XtdbBackend()
+        config = DbEngineConfig(
+            backend="xtdb",
+            hostname="127.0.0.1",
+            adbc_port=_published_port(container_id, "9832/tcp"),
+        )
+        deadline = time.monotonic() + 60
+        while True:
+            try:
+                connection = backend.create_adbc_connection(config)
+                with connection.cursor() as cursor:
+                    cursor.execute("SELECT 1")
+                    cursor.fetch_arrow_table()
+                break
+            except Exception:
+                if connection is not None:
+                    connection.close()
+                    connection = None
+                if time.monotonic() > deadline:
+                    raise
+                time.sleep(1)
+
+        yield connection
+    finally:
+        if connection is not None:
+            connection.close()
+        subprocess.run(["docker", "rm", "-f", container_id], check=False)
+
+
+def test_xtdb_adbc_live_arrow_ingest_read_roundtrip():
+    table_config = TableConfig(
+        schema="public",
+        name=f"live_adbc_cargos_{int(time.time())}",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+        ],
+    )
+
+    with _xtdb_adbc_connection() as connection:
+        backend = XtdbBackend()
+        ops = backend.adbc_dataframes(connection)
+        ops.table_insert(
+            pl.DataFrame(
+                {
+                    "id": [1, 2],
+                    "destination": ["Tokyo", "Osaka"],
+                    "cargo_mcm": [10.5, 20.25],
+                }
+            ),
+            table_config.schema,
+            table_config.name,
+            table_config=table_config,
+        )
+
+        result = ops.from_table(table_config.schema, table_config.name)
+
+    assert result.sort("_id").select(["_id", "destination", "cargo_mcm"]).to_dict(
+        as_series=False
+    ) == {
+        "_id": [1, 2],
+        "destination": ["Tokyo", "Osaka"],
+        "cargo_mcm": [10.5, 20.25],
+    }
+
+
+def test_xtdb_adbc_live_temporal_upsert_supports_system_time_asof():
+    table_config = TableConfig(
+        schema="public",
+        name=f"live_adbc_temporal_cargos_{int(time.time())}",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+        ],
+    )
+
+    with _xtdb_adbc_connection() as connection:
+        backend = XtdbBackend()
+        ops = backend.adbc_dataframes(connection)
+        backend.temporal_upsert(
+            pl.DataFrame(
+                {
+                    "id": [1],
+                    "destination": ["Tokyo"],
+                    "cargo_mcm": [10.5],
+                }
+            ),
+            table_config.schema,
+            table_config.name,
+            dataframe_ops=ops,
+            table_config=table_config,
+        )
+
+        time.sleep(0.2)
+        checkpoint = datetime.now(timezone.utc)
+        time.sleep(0.2)
+
+        backend.temporal_upsert(
+            pl.DataFrame(
+                {
+                    "id": [1],
+                    "destination": ["Osaka"],
+                    "cargo_mcm": [20.25],
+                }
+            ),
+            table_config.schema,
+            table_config.name,
+            dataframe_ops=ops,
+            table_config=table_config,
+        )
+
+        latest = ops.from_table(table_config.schema, table_config.name)
+        asof_checkpoint = ops.from_table(
+            table_config.schema,
+            table_config.name,
+            time_hint=TimeHint(mode="asof", asof_utc=checkpoint),
+        )
+
+    assert latest.select(["_id", "destination", "cargo_mcm"]).to_dict(
+        as_series=False
+    ) == {
+        "_id": [1],
+        "destination": ["Osaka"],
+        "cargo_mcm": [20.25],
+    }
+    assert asof_checkpoint.select(["_id", "destination", "cargo_mcm"]).to_dict(
+        as_series=False
+    ) == {
+        "_id": [1],
+        "destination": ["Tokyo"],
+        "cargo_mcm": [10.5],
+    }

--- a/tests/backends/test_xtdb_adbc_ops.py
+++ b/tests/backends/test_xtdb_adbc_ops.py
@@ -1,0 +1,123 @@
+from unittest.mock import Mock
+
+import polars as pl
+import pyarrow as pa
+
+from polars_hist_db.backends import DbEngineConfig, XtdbBackend
+from polars_hist_db.backends.xtdb import XtdbAdbcDataframeOps
+from polars_hist_db.config import TableColumnConfig, TableConfig
+
+
+class _FakeCursor:
+    def __init__(self):
+        self.ingests = []
+        self.executed = []
+        self.arrow_result = pa.table({"_id": [1], "destination": ["Tokyo"]})
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def adbc_ingest(self, table_name, arrow_table, mode, **kwargs):
+        self.ingests.append((table_name, arrow_table, mode, kwargs))
+
+    def execute(self, query):
+        self.executed.append(query)
+
+    def fetch_arrow_table(self):
+        return self.arrow_result
+
+
+class _FakeAdbcConnection:
+    def __init__(self):
+        self.cursor_instance = _FakeCursor()
+
+    def cursor(self):
+        return self.cursor_instance
+
+
+def _cargo_config(schema="public"):
+    return TableConfig(
+        schema=schema,
+        name="cargos",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+        ],
+    )
+
+
+def test_xtdb_adbc_dataframe_ops_ingests_arrow_with_id_mapping():
+    connection = _FakeAdbcConnection()
+    ops = XtdbAdbcDataframeOps(connection)
+
+    result = ops.table_insert(
+        pl.DataFrame({"id": [1, 2], "destination": ["Tokyo", "Osaka"]}),
+        "public",
+        "cargos",
+        table_config=_cargo_config(),
+    )
+
+    assert result == 2
+    table_name, arrow_table, mode, kwargs = connection.cursor_instance.ingests[0]
+    assert table_name == "cargos"
+    assert mode == "create_append"
+    assert kwargs == {"db_schema_name": "public"}
+    assert arrow_table.schema.field("destination").type == pa.string()
+    assert arrow_table.to_pydict() == {
+        "_id": [1, 2],
+        "destination": ["Tokyo", "Osaka"],
+    }
+
+
+def test_xtdb_adbc_dataframe_ops_reads_arrow_into_polars():
+    connection = _FakeAdbcConnection()
+    ops = XtdbAdbcDataframeOps(connection)
+
+    result = ops.from_table("public", "cargos")
+
+    assert result.to_dict(as_series=False) == {"_id": [1], "destination": ["Tokyo"]}
+    assert connection.cursor_instance.executed == ["SELECT * FROM public.cargos"]
+
+
+def test_xtdb_adbc_dataframe_ops_targets_configured_schema():
+    connection = _FakeAdbcConnection()
+    ops = XtdbAdbcDataframeOps(connection)
+
+    ops.table_insert(
+        pl.DataFrame({"id": [1]}),
+        "analytics",
+        "cargos",
+        table_config=_cargo_config(schema="analytics"),
+    )
+
+    assert connection.cursor_instance.ingests[0][3] == {"db_schema_name": "analytics"}
+
+
+def test_xtdb_backend_builds_adbc_uri():
+    uri = XtdbBackend().adbc_uri(
+        DbEngineConfig(backend="xtdb", hostname="127.0.0.1", adbc_port=19832)
+    )
+
+    assert uri == "grpc://127.0.0.1:19832"
+
+
+def test_xtdb_backend_creates_adbc_connection(monkeypatch):
+    fake_flight_sql = Mock()
+    fake_flight_sql.connect.return_value = object()
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb._load_flight_sql",
+        lambda: fake_flight_sql,
+    )
+
+    config = DbEngineConfig(backend="xtdb", hostname="127.0.0.1", adbc_port=19832)
+    result = XtdbBackend().create_adbc_connection(config)
+
+    assert result is fake_flight_sql.connect.return_value
+    fake_flight_sql.connect.assert_called_once_with(
+        "grpc://127.0.0.1:19832",
+        autocommit=True,
+    )

--- a/tests/backends/test_xtdb_audit_ops.py
+++ b/tests/backends/test_xtdb_audit_ops.py
@@ -1,0 +1,181 @@
+from datetime import datetime, timezone
+
+import polars as pl
+
+from polars_hist_db.core.audit import AuditOps
+from polars_hist_db.loaders.input_source import InputSource
+
+
+class _XtdbConnection:
+    class _Dialect:
+        name = "postgresql"
+
+    dialect = _Dialect()
+
+
+class _Context:
+    def __init__(self, connection):
+        self.connection = connection
+
+    def __enter__(self):
+        return self.connection
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+
+def test_xtdb_audit_filter_items_creates_audit_table_without_sqlalchemy_inspector(
+    monkeypatch,
+):
+    created_tables = []
+
+    class _TableConfigOps:
+        def __init__(self, connection):
+            self.connection = connection
+
+        def table_exists(self, table_schema, table_name):
+            return False
+
+        def create(self, table_config):
+            created_tables.append(table_config)
+            return table_config
+
+    class _DataframeOps:
+        def __init__(self, connection):
+            self.connection = connection
+
+        def from_raw_sql(self, query, schema_overrides=None):
+            assert "FROM kpler.__audit_log" in query
+            return pl.DataFrame(
+                {
+                    "data_source": [],
+                    "data_source_ts": [],
+                },
+                schema={
+                    "data_source": pl.Utf8,
+                    "data_source_ts": pl.Datetime("us", "UTC"),
+                },
+            )
+
+    monkeypatch.setattr(
+        "polars_hist_db.core.audit._xtdb_table_config_ops",
+        _TableConfigOps,
+    )
+    monkeypatch.setattr("polars_hist_db.core.audit._xtdb_dataframe_ops", _DataframeOps)
+
+    filtered_items = AuditOps("kpler").filter_items(
+        pl.DataFrame(
+            {
+                "__path": ["trades.csv"],
+                "__created_at": [datetime(2026, 1, 1, tzinfo=timezone.utc)],
+            }
+        ),
+        "__path",
+        "__created_at",
+        "trades",
+        _XtdbConnection(),
+    )
+
+    assert filtered_items.height == 1
+    assert [table.name for table in created_tables] == ["__audit_log"]
+
+
+def test_xtdb_file_filter_uses_plain_connection_context(monkeypatch):
+    class _InputSource(InputSource):
+        async def next_df(self, engine):
+            raise NotImplementedError
+
+        async def cleanup(self):
+            raise NotImplementedError
+
+    class _AuditOps:
+        def __init__(self, schema):
+            self.schema = schema
+
+        def filter_items(self, items, *args):
+            return items
+
+        def prevalidate_new_items(self, *args):
+            return None
+
+    class _Engine:
+        class _Dialect:
+            name = "postgresql"
+
+        dialect = _Dialect()
+        connection = _XtdbConnection()
+        used_connect = False
+
+        def connect(self):
+            self.used_connect = True
+            return _Context(self.connection)
+
+        def begin(self):
+            raise AssertionError("XTDB file filtering must not use engine.begin()")
+
+    monkeypatch.setattr("polars_hist_db.loaders.input_source.AuditOps", _AuditOps)
+    source = object.__new__(_InputSource)
+    source.dataset = type("Dataset", (), {"scrape_limit": 0})()
+    engine = _Engine()
+
+    filtered = InputSource._search_and_filter_files(
+        source,
+        pl.DataFrame(
+            {
+                "__path": ["trades.csv"],
+                "__created_at": [datetime(2026, 1, 1, tzinfo=timezone.utc)],
+            }
+        ),
+        "kpler",
+        "trades",
+        engine,
+    )
+
+    assert engine.used_connect is True
+    assert filtered.height == 1
+
+
+def test_xtdb_audit_add_entry_writes_via_backend_dataframe_ops(monkeypatch):
+    inserted = []
+
+    class _TableConfigOps:
+        def __init__(self, connection):
+            self.connection = connection
+
+        def table_exists(self, table_schema, table_name):
+            return True
+
+        def from_table(self, table_schema, table_name):
+            return AuditOps(table_schema)._table_config()
+
+    class _DataframeOps:
+        def __init__(self, connection):
+            self.connection = connection
+
+        def table_insert(self, df, table_schema, table_name, table_config=None):
+            inserted.append((df, table_schema, table_name, table_config))
+            return df.height
+
+    monkeypatch.setattr(
+        "polars_hist_db.core.audit._xtdb_table_config_ops",
+        _TableConfigOps,
+    )
+    monkeypatch.setattr("polars_hist_db.core.audit._xtdb_dataframe_ops", _DataframeOps)
+
+    did_insert = AuditOps("kpler").add_entry(
+        "dsv",
+        "trades.csv",
+        "trades",
+        _XtdbConnection(),
+        datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+    assert did_insert is True
+    [(inserted_df, table_schema, table_name, table_config)] = inserted
+    assert table_schema == "kpler"
+    assert table_name == "__audit_log"
+    assert table_config.name == "__audit_log"
+    assert "audit_id" in inserted_df.columns
+    assert inserted_df.select("table_name", "data_source").rows() == [
+        ("trades", "trades.csv")
+    ]

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -1,0 +1,1066 @@
+from unittest.mock import Mock
+from datetime import date, datetime, time, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+
+import polars as pl
+import pytest
+
+from polars_hist_db.backends import DbEngineConfig, XtdbBackend
+from polars_hist_db.backends.xtdb import XtdbDataframeOps, XtdbTableConfigOps
+from polars_hist_db.config import (
+    DeltaConfig,
+    TableColumnConfig,
+    TableConfig,
+    ValidTimeConfig,
+)
+
+
+def test_xtdb_temporal_upsert_delegates_to_dataframe_insert():
+    backend = XtdbBackend()
+    ops = Mock()
+    ops.table_insert.return_value = 2
+    df = pl.DataFrame({"id": [1, 2], "destination": ["Tokyo", "Osaka"]})
+    table_config = TableConfig(
+        schema="test",
+        name="cargos",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+        ],
+    )
+
+    result = backend.temporal_upsert(
+        df,
+        table_config.schema,
+        table_config.name,
+        dataframe_ops=ops,
+        table_config=table_config,
+    )
+
+    assert result == 2
+    ops.table_insert.assert_called_once_with(
+        df,
+        "test",
+        "cargos",
+        table_config=table_config,
+    )
+
+
+def test_xtdb_temporal_upsert_passes_system_time_to_dataframe_insert():
+    backend = XtdbBackend()
+    ops = Mock()
+    ops.table_insert.return_value = 1
+    update_time = datetime(2030, 1, 1, tzinfo=timezone.utc)
+    df = pl.DataFrame({"id": [1]})
+
+    result = backend.temporal_upsert(
+        df,
+        "test",
+        "cargos",
+        dataframe_ops=ops,
+        update_time=update_time,
+    )
+
+    assert result == 1
+    ops.table_insert.assert_called_once_with(
+        df,
+        "test",
+        "cargos",
+        table_config=None,
+        update_time=update_time,
+    )
+
+
+def test_xtdb_temporal_upsert_rejects_manual_finality():
+    backend = XtdbBackend()
+
+    with pytest.raises(NotImplementedError, match="row_finality='disabled'"):
+        backend.temporal_upsert(
+            pl.DataFrame({"id": [1]}),
+            "test",
+            "cargos",
+            dataframe_ops=Mock(),
+            delta_config=DeltaConfig(row_finality="manual"),
+        )
+
+
+def test_xtdb_temporal_upsert_dropout_deletes_missing_current_keys():
+    backend = XtdbBackend()
+    driver_connection = Mock()
+    connection = Mock()
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+    ops = XtdbDataframeOps(connection)
+    ops.from_raw_sql = Mock(
+        return_value=pl.DataFrame(
+            {
+                "_id": [1, 2],
+                "destination": ["Tokyo", "Osaka"],
+            }
+        )
+    )
+    table_config = TableConfig(
+        schema="test",
+        name="cargos",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+        ],
+    )
+
+    result = backend.temporal_upsert(
+        pl.DataFrame({"id": [1], "destination": ["Tokyo"]}),
+        "test",
+        "cargos",
+        dataframe_ops=ops,
+        table_config=table_config,
+        delta_config=DeltaConfig(row_finality="dropout"),
+    )
+
+    assert result == 2
+    executed_sql = [call.args[0] for call in driver_connection.execute.call_args_list]
+    assert executed_sql[1] == "DELETE FROM test.cargos WHERE _id IN (2::BIGINT)"
+    assert executed_sql[3] == (
+        "INSERT INTO test.cargos (_id, destination) VALUES (1::BIGINT, 'Tokyo'::TEXT)"
+    )
+
+
+def test_xtdb_temporal_upsert_dropout_closes_missing_keys_at_valid_time():
+    backend = XtdbBackend()
+    driver_connection = Mock()
+    connection = Mock()
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+    ops = XtdbDataframeOps(connection)
+    ops.from_raw_sql = Mock(return_value=pl.DataFrame({"_id": [1, 2]}))
+    table_config = TableConfig(
+        schema="test",
+        name="cargos",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+        ],
+    )
+
+    result = backend.temporal_upsert(
+        pl.DataFrame(
+            {
+                "id": [1],
+                "destination": ["Tokyo"],
+                "_valid_from": [datetime(2030, 1, 2, tzinfo=timezone.utc)],
+            }
+        ),
+        "test",
+        "cargos",
+        dataframe_ops=ops,
+        table_config=table_config,
+        delta_config=DeltaConfig(row_finality="dropout"),
+    )
+
+    assert result == 2
+    executed_sql = [call.args[0] for call in driver_connection.execute.call_args_list]
+    assert executed_sql[1] == (
+        "DELETE FROM test.cargos FOR PORTION OF VALID_TIME FROM "
+        "TIMESTAMP '2030-01-02T00:00:00+00:00' TO NULL "
+        "WHERE _id IN (2::BIGINT)"
+    )
+
+
+def test_xtdb_temporal_upsert_dropout_uses_explicit_close_time_for_empty_batches():
+    backend = XtdbBackend()
+    driver_connection = Mock()
+    connection = Mock()
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+    ops = XtdbDataframeOps(connection)
+    ops.from_raw_sql = Mock(return_value=pl.DataFrame({"_id": [1, 2]}))
+    table_config = TableConfig(
+        schema="test",
+        name="cargos",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+        ],
+    )
+
+    result = backend.temporal_upsert(
+        pl.DataFrame(schema={"id": pl.Int64, "destination": pl.String}),
+        "test",
+        "cargos",
+        dataframe_ops=ops,
+        table_config=table_config,
+        delta_config=DeltaConfig(row_finality="dropout"),
+        dropout_close_time=datetime(2030, 1, 3, tzinfo=timezone.utc),
+    )
+
+    assert result == 2
+    executed_sql = [call.args[0] for call in driver_connection.execute.call_args_list]
+    assert executed_sql[1] == (
+        "DELETE FROM test.cargos FOR PORTION OF VALID_TIME FROM "
+        "TIMESTAMP '2030-01-03T00:00:00+00:00' TO NULL "
+        "WHERE _id IN (1::BIGINT, 2::BIGINT)"
+    )
+
+
+def test_xtdb_temporal_upsert_rejects_duplicate_source_keys_by_default():
+    backend = XtdbBackend()
+    table_config = TableConfig(
+        schema="test",
+        name="cargos",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="duplicate source keys"):
+        backend.temporal_upsert(
+            pl.DataFrame({"id": [1, 1], "destination": ["Tokyo", "Osaka"]}),
+            "test",
+            "cargos",
+            dataframe_ops=Mock(),
+            table_config=table_config,
+            delta_config=DeltaConfig(),
+        )
+
+
+def test_xtdb_temporal_upsert_takes_first_duplicate_source_key():
+    backend = XtdbBackend()
+    ops = Mock()
+    ops.table_insert.return_value = 1
+    table_config = TableConfig(
+        schema="test",
+        name="cargos",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+        ],
+    )
+
+    result = backend.temporal_upsert(
+        pl.DataFrame({"id": [1, 1], "destination": ["Tokyo", "Osaka"]}),
+        "test",
+        "cargos",
+        dataframe_ops=ops,
+        table_config=table_config,
+        delta_config=DeltaConfig(on_duplicate_key="take_first"),
+    )
+
+    assert result == 1
+    written_df = ops.table_insert.call_args.args[0]
+    assert written_df.to_dict(as_series=False) == {
+        "id": [1],
+        "destination": ["Tokyo"],
+    }
+
+
+def test_xtdb_temporal_upsert_takes_last_duplicate_source_key():
+    backend = XtdbBackend()
+    ops = Mock()
+    ops.table_insert.return_value = 1
+    table_config = TableConfig(
+        schema="test",
+        name="cargos",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+        ],
+    )
+
+    result = backend.temporal_upsert(
+        pl.DataFrame({"id": [1, 1], "destination": ["Tokyo", "Osaka"]}),
+        "test",
+        "cargos",
+        dataframe_ops=ops,
+        table_config=table_config,
+        delta_config=DeltaConfig(on_duplicate_key="take_last"),
+    )
+
+    assert result == 1
+    written_df = ops.table_insert.call_args.args[0]
+    assert written_df.to_dict(as_series=False) == {
+        "id": [1],
+        "destination": ["Osaka"],
+    }
+
+
+def test_xtdb_temporal_upsert_treats_explicit_valid_time_change_as_changed():
+    backend = XtdbBackend()
+    ops = Mock()
+    ops.from_raw_sql.return_value = pl.DataFrame(
+        {
+            "_id": [1],
+            "destination": ["Tokyo"],
+            "_valid_from": [datetime(2030, 1, 1, tzinfo=timezone.utc)],
+            "_valid_to": [datetime(2030, 2, 1, tzinfo=timezone.utc)],
+        }
+    )
+    ops.table_insert.return_value = 1
+    table_config = TableConfig(
+        schema="test",
+        name="cargos",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+        ],
+    )
+
+    result = backend.temporal_upsert(
+        pl.DataFrame(
+            {
+                "id": [1],
+                "destination": ["Tokyo"],
+                "_valid_from": [datetime(2030, 1, 1, tzinfo=timezone.utc)],
+                "_valid_to": [datetime(2030, 3, 1, tzinfo=timezone.utc)],
+            }
+        ),
+        "test",
+        "cargos",
+        dataframe_ops=ops,
+        table_config=table_config,
+        delta_config=DeltaConfig(drop_unchanged_rows=True),
+        update_time=datetime(2030, 1, 2, tzinfo=timezone.utc),
+    )
+
+    assert result == 1
+    written_df = ops.table_insert.call_args.args[0]
+    assert written_df.to_dict(as_series=False) == {
+        "id": [1],
+        "destination": ["Tokyo"],
+        "_valid_from": [datetime(2030, 1, 1, tzinfo=timezone.utc)],
+        "_valid_to": [datetime(2030, 3, 1, tzinfo=timezone.utc)],
+    }
+
+
+def test_xtdb_temporal_upsert_ignores_valid_from_when_filtering_unchanged_rows():
+    backend = XtdbBackend()
+    ops = Mock()
+    ops.from_raw_sql.return_value = pl.DataFrame(
+        {
+            "_id": [1],
+            "destination": ["Tokyo"],
+            "_valid_from": [datetime(2030, 1, 1, tzinfo=timezone.utc)],
+        }
+    )
+    ops.table_insert.return_value = 0
+    table_config = TableConfig(
+        schema="test",
+        name="cargos",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+        ],
+    )
+
+    result = backend.temporal_upsert(
+        pl.DataFrame(
+            {
+                "id": [1],
+                "destination": ["Tokyo"],
+                "_valid_from": [datetime(2030, 2, 1, tzinfo=timezone.utc)],
+            }
+        ),
+        "test",
+        "cargos",
+        dataframe_ops=ops,
+        table_config=table_config,
+        delta_config=DeltaConfig(drop_unchanged_rows=True),
+    )
+
+    assert result == 0
+    ops.table_insert.assert_called_once()
+    assert ops.table_insert.call_args.args[0].is_empty()
+
+
+def test_xtdb_temporal_upsert_normalizes_types_when_filtering_unchanged_rows():
+    backend = XtdbBackend()
+    ops = Mock()
+    ops.from_raw_sql.return_value = pl.DataFrame(
+        {
+            "_id": [1],
+            "destination": ["Tokyo"],
+            "float_col": [12.34],
+        }
+    )
+    ops.table_insert.return_value = 0
+    table_config = TableConfig(
+        schema="test",
+        name="cargos",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "INT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("cargos", "float_col", "FLOAT"),
+        ],
+    )
+
+    result = backend.temporal_upsert(
+        pl.DataFrame(
+            {
+                "id": [1],
+                "destination": ["Tokyo"],
+                "float_col": [12.34],
+            },
+            schema_overrides={"float_col": pl.Float32},
+        ),
+        "test",
+        "cargos",
+        dataframe_ops=ops,
+        table_config=table_config,
+        delta_config=DeltaConfig(drop_unchanged_rows=True),
+    )
+
+    assert result == 0
+    ops.table_insert.assert_called_once()
+    assert ops.table_insert.call_args.args[0].is_empty()
+
+
+def test_xtdb_temporal_upsert_prefills_configured_defaults_before_insert():
+    backend = XtdbBackend()
+    ops = Mock()
+    ops.table_insert.return_value = 1
+    table_config = TableConfig(
+        schema="test",
+        name="defaults",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("defaults", "id", "INT", nullable=False),
+            TableColumnConfig("defaults", "enabled", "BOOLEAN", default_value="0"),
+            TableColumnConfig("defaults", "as_of", "DATE", default_value="1985-10-26"),
+            TableColumnConfig("defaults", "cutoff", "TIME", default_value="01:20:00"),
+            TableColumnConfig(
+                "defaults",
+                "price",
+                "DECIMAL(10,2)",
+                default_value="2.71",
+            ),
+        ],
+    )
+
+    result = backend.temporal_upsert(
+        pl.DataFrame(
+            {
+                "id": [1],
+                "enabled": [None],
+                "as_of": [None],
+                "cutoff": [None],
+                "price": [None],
+            },
+            schema_overrides={
+                "id": pl.Int32,
+                "enabled": pl.Boolean,
+                "as_of": pl.Date,
+                "cutoff": pl.Time,
+                "price": pl.Decimal(10, 2),
+            },
+        ),
+        "test",
+        "defaults",
+        dataframe_ops=ops,
+        table_config=table_config,
+        delta_config=DeltaConfig(prefill_nulls_with_default=True),
+    )
+
+    assert result == 1
+    written_df = ops.table_insert.call_args.args[0]
+    assert written_df.to_dict(as_series=False) == {
+        "id": [1],
+        "enabled": [False],
+        "as_of": [date(1985, 10, 26)],
+        "cutoff": [time(1, 20)],
+        "price": [Decimal("2.71")],
+    }
+
+
+def test_xtdb_temporal_upsert_treats_null_to_value_as_changed():
+    backend = XtdbBackend()
+    ops = Mock()
+    ops.from_raw_sql.return_value = pl.DataFrame(
+        {
+            "_id": [1],
+            "cargo_mcm": [None],
+        },
+        schema_overrides={"cargo_mcm": pl.Float64},
+    )
+    ops.table_insert.return_value = 1
+    table_config = TableConfig(
+        schema="test",
+        name="cargos",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+        ],
+    )
+
+    result = backend.temporal_upsert(
+        pl.DataFrame({"id": [1], "cargo_mcm": [330.33]}),
+        "test",
+        "cargos",
+        dataframe_ops=ops,
+        table_config=table_config,
+        delta_config=DeltaConfig(drop_unchanged_rows=True),
+    )
+
+    assert result == 1
+    written_df = ops.table_insert.call_args.args[0]
+    assert written_df.to_dict(as_series=False) == {
+        "id": [1],
+        "cargo_mcm": [330.33],
+    }
+
+
+def test_xtdb_temporal_upsert_maps_configured_valid_time_columns():
+    backend = XtdbBackend()
+    ops = Mock()
+    ops.table_insert.return_value = 1
+    asof_time = datetime(2030, 1, 1, 12, 0, tzinfo=timezone.utc)
+    expiry_time = datetime(2030, 2, 1, 12, 0, tzinfo=timezone.utc)
+
+    result = backend.temporal_upsert(
+        pl.DataFrame(
+            {
+                "id": [1],
+                "destination": ["Tokyo"],
+                "msg_timestamp": [asof_time],
+                "valid_until": [expiry_time],
+            }
+        ),
+        "test",
+        "cargos",
+        dataframe_ops=ops,
+        valid_time=ValidTimeConfig(
+            table="cargos",
+            from_column="msg_timestamp",
+            to_column="valid_until",
+        ),
+    )
+
+    assert result == 1
+    written_df = ops.table_insert.call_args.args[0]
+    assert written_df.to_dict(as_series=False) == {
+        "id": [1],
+        "destination": ["Tokyo"],
+        "msg_timestamp": [asof_time],
+        "valid_until": [expiry_time],
+        "_valid_from": [asof_time],
+        "_valid_to": [expiry_time],
+    }
+
+
+def test_xtdb_temporal_upsert_rejects_missing_valid_time_source_column():
+    backend = XtdbBackend()
+
+    with pytest.raises(ValueError, match="missing source column"):
+        backend.temporal_upsert(
+            pl.DataFrame({"id": [1], "destination": ["Tokyo"]}),
+            "test",
+            "cargos",
+            dataframe_ops=Mock(),
+            valid_time=ValidTimeConfig(
+                table="cargos",
+                from_column="msg_timestamp",
+            ),
+        )
+
+
+def test_xtdb_temporal_upsert_rejects_valid_time_target_conflict():
+    backend = XtdbBackend()
+
+    with pytest.raises(ValueError, match="already contains that column"):
+        backend.temporal_upsert(
+            pl.DataFrame(
+                {
+                    "id": [1],
+                    "msg_timestamp": [datetime(2030, 1, 1, tzinfo=timezone.utc)],
+                    "_valid_from": [datetime(2030, 1, 2, tzinfo=timezone.utc)],
+                }
+            ),
+            "test",
+            "cargos",
+            dataframe_ops=Mock(),
+            valid_time=ValidTimeConfig(
+                table="cargos",
+                from_column="msg_timestamp",
+            ),
+        )
+
+
+def test_xtdb_table_creation_maps_mysql_compatibility_types(monkeypatch):
+    connection = Mock()
+    connection.connection = None
+    ops = XtdbTableConfigOps(connection)
+    monkeypatch.setattr(ops, "table_exists", Mock(return_value=False))
+
+    table_config = TableConfig(
+        schema="test",
+        name="compat_types",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("compat_types", "id", "INT", nullable=False),
+            TableColumnConfig("compat_types", "bool_col", "BOOL"),
+            TableColumnConfig("compat_types", "bit_col", "BIT"),
+            TableColumnConfig("compat_types", "tinyint_col", "TINYINT"),
+            TableColumnConfig("compat_types", "mediumint_col", "MEDIUMINT"),
+            TableColumnConfig("compat_types", "datetime_col", "DATETIME"),
+            TableColumnConfig("compat_types", "time_col", "TIME"),
+        ],
+    )
+
+    ops.create(table_config)
+
+    statement = connection.execute.call_args_list[0].args[0]
+    assert statement.text == (
+        "CREATE TABLE test.compat_types "
+        "(_id, bool_col, bit_col, tinyint_col, mediumint_col, "
+        "datetime_col, time_col)"
+    )
+    assert [column.data_type for column in table_config.columns[1:]] == [
+        "BOOL",
+        "BIT",
+        "TINYINT",
+        "MEDIUMINT",
+        "DATETIME",
+        "TIME",
+    ]
+
+
+def test_xtdb_backend_returns_explicit_table_config_ops():
+    connection = object()
+    ops = XtdbBackend().table_configs(connection)
+
+    assert isinstance(ops, XtdbTableConfigOps)
+
+
+def test_xtdb_table_config_ops_drop_all_erases_configured_tables(monkeypatch):
+    executed = []
+
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb._execute_xtdb_dml",
+        lambda _connection, sql, **_kwargs: executed.append(sql),
+    )
+
+    table_config = TableConfig(
+        schema="market",
+        name="prices",
+        primary_keys=["id"],
+        columns=[TableColumnConfig("prices", "id", "INT", nullable=False)],
+    )
+
+    ops = XtdbTableConfigOps(object())
+    monkeypatch.setattr(ops, "table_exists", Mock(return_value=True))
+
+    ops.drop_all(Mock(items=[table_config]))
+
+    assert executed == [
+        "ERASE FROM market.prices WHERE TRUE",
+        "DELETE FROM market.__polars_hist_db_xtdb_table_configs "
+        "WHERE _id = 'market.prices'::TEXT",
+    ]
+
+
+def test_xtdb_backend_create_engine_targets_xtdb_database_by_default(monkeypatch):
+    calls = []
+    engine = Mock()
+    engine.dialect = SimpleNamespace()
+
+    def fake_create_engine(url, **kwargs):
+        calls.append((url, kwargs))
+        return engine
+
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.create_engine", fake_create_engine
+    )
+
+    XtdbBackend().create_engine(
+        DbEngineConfig(backend="xtdb", hostname="127.0.0.1", port=15432)
+    )
+
+    assert calls[0][0] == "postgresql+psycopg://127.0.0.1:15432/xtdb"
+
+
+def test_xtdb_backend_create_engine_disables_psycopg_prepared_statements(
+    monkeypatch,
+):
+    calls = []
+    engine = Mock()
+    engine.dialect = SimpleNamespace()
+
+    def fake_create_engine(url, **kwargs):
+        calls.append((url, kwargs))
+        return engine
+
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.create_engine", fake_create_engine
+    )
+
+    result = XtdbBackend().create_engine(
+        DbEngineConfig(backend="xtdb", hostname="127.0.0.1", port=15432)
+    )
+
+    assert result is engine
+    assert calls[0][1]["connect_args"] == {"prepare_threshold": None}
+
+
+def test_xtdb_backend_create_engine_uses_configured_database(monkeypatch):
+    calls = []
+    engine = Mock()
+    engine.dialect = SimpleNamespace()
+
+    def fake_create_engine(url, **kwargs):
+        calls.append((url, kwargs))
+        return engine
+
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.create_engine", fake_create_engine
+    )
+
+    XtdbBackend().create_engine(
+        DbEngineConfig(
+            backend="xtdb",
+            hostname="127.0.0.1",
+            port=15432,
+            database="analytics",
+        )
+    )
+
+    assert calls[0][0] == "postgresql+psycopg://127.0.0.1:15432/analytics"
+
+
+def test_xtdb_table_creation_declares_configured_columns(monkeypatch):
+    connection = Mock()
+    connection.connection = None
+    ops = XtdbTableConfigOps(connection)
+    monkeypatch.setattr(ops, "table_exists", Mock(return_value=False))
+
+    table_config = TableConfig(
+        schema="test",
+        name="cargos",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("cargos", "cargo_mcm", "DECIMAL(20,6)"),
+        ],
+    )
+    result = ops.create(table_config)
+
+    assert result is table_config
+    statement = connection.execute.call_args_list[0].args[0]
+    assert statement.text == "CREATE TABLE test.cargos (_id, destination, cargo_mcm)"
+
+
+def test_xtdb_table_creation_is_idempotent_when_table_exists(monkeypatch):
+    connection = Mock()
+    ops = XtdbTableConfigOps(connection)
+    monkeypatch.setattr(ops, "table_exists", Mock(return_value=True))
+    existing_config = TableConfig(schema="test", name="cargos", columns=[])
+    monkeypatch.setattr(ops, "from_table", Mock(return_value=existing_config))
+
+    table_config = TableConfig(
+        schema="test",
+        name="cargos",
+        primary_keys=["_id"],
+        columns=[TableColumnConfig("cargos", "_id", "BIGINT", nullable=False)],
+    )
+
+    result = ops.create(table_config)
+
+    assert result is existing_config
+    connection.execute.assert_not_called()
+    ops.from_table.assert_called_once_with("test", "cargos")
+
+
+def test_xtdb_table_creation_declares_composite_primary_key_columns(monkeypatch):
+    connection = Mock()
+    connection.connection = None
+    ops = XtdbTableConfigOps(connection)
+    monkeypatch.setattr(ops, "table_exists", Mock(return_value=False))
+
+    table_config = TableConfig(
+        schema="test",
+        name="cargos",
+        primary_keys=["vessel_id", "cargo_id"],
+        columns=[
+            TableColumnConfig("cargos", "vessel_id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "cargo_id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+        ],
+    )
+
+    result = ops.create(table_config)
+
+    assert result is table_config
+    statement = connection.execute.call_args_list[0].args[0]
+    assert statement.text == (
+        "CREATE TABLE test.cargos (_id, vessel_id, cargo_id, destination)"
+    )
+
+
+def test_xtdb_table_creation_records_primary_key_metadata(monkeypatch):
+    connection = Mock()
+    connection.connection = None
+    ops = XtdbTableConfigOps(connection)
+    monkeypatch.setattr(ops, "table_exists", Mock(return_value=False))
+
+    table_config = TableConfig(
+        schema="test",
+        name="cargos",
+        primary_keys=["vessel_id", "cargo_id"],
+        columns=[
+            TableColumnConfig("cargos", "vessel_id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "cargo_id", "VARCHAR(255)", nullable=False),
+        ],
+    )
+
+    ops.create(table_config)
+
+    executed_sql = [call.args[0].text for call in connection.execute.call_args_list]
+    assert executed_sql == [
+        "CREATE TABLE test.cargos (_id, vessel_id, cargo_id)",
+        "CREATE TABLE test.__polars_hist_db_xtdb_table_configs "
+        "(_id, table_schema, table_name, primary_keys_json, id_policy, "
+        "columns_json, foreign_keys_json)",
+        "INSERT INTO test.__polars_hist_db_xtdb_table_configs "
+        "(_id, table_schema, table_name, primary_keys_json, id_policy, "
+        "columns_json, foreign_keys_json) "
+        "VALUES ('test.cargos'::TEXT, 'test'::TEXT, 'cargos'::TEXT, "
+        "'[\"vessel_id\",\"cargo_id\"]'::TEXT, 'xtdb-pk-v1'::TEXT, "
+        '\'[{"table":"cargos","name":"vessel_id","data_type":"BIGINT",'
+        '"default_value":null,"autoincrement":false,"nullable":false,'
+        '"unique_constraint":[]},{"table":"cargos","name":"cargo_id",'
+        '"data_type":"VARCHAR(255)","default_value":null,"autoincrement":false,'
+        '"nullable":false,"unique_constraint":[]}]\'::TEXT, \'[]\'::TEXT)',
+    ]
+
+
+def test_xtdb_table_reflection_builds_table_config_from_information_schema(
+    monkeypatch,
+):
+    read_database = Mock(
+        return_value=pl.DataFrame(
+            {
+                "column_name": [
+                    "_id",
+                    "destination",
+                    "cargo_mcm",
+                    "_system_from",
+                    "_system_to",
+                ],
+                "data_type": [
+                    ":i64",
+                    ":utf8",
+                    "DECIMAL(10,4)",
+                    "TIMESTAMP",
+                    "TIMESTAMP",
+                ],
+                "is_nullable": ["NO", "YES", "YES", "YES", "YES"],
+            }
+        )
+    )
+    monkeypatch.setattr(pl, "read_database", read_database)
+
+    connection = object()
+    ops = XtdbTableConfigOps(connection)
+
+    table_config = ops.from_table("test", "cargos")
+
+    assert table_config.schema == "test"
+    assert table_config.name == "cargos"
+    assert list(table_config.primary_keys) == ["_id"]
+    assert [
+        (col.name, col.data_type, col.nullable) for col in table_config.columns
+    ] == [
+        ("_id", "BIGINT", False),
+        ("destination", "VARCHAR(255)", True),
+        ("cargo_mcm", "DECIMAL(10,4)", True),
+    ]
+    assert read_database.call_args_list[0].args == (
+        """
+            SELECT column_name, data_type, is_nullable
+            FROM information_schema.columns
+            WHERE table_schema = 'test'
+              AND table_name = 'cargos'
+            ORDER BY ordinal_position
+        """,
+        connection,
+    )
+
+
+def test_xtdb_table_reflection_prefers_configured_column_metadata(monkeypatch):
+    columns_json = (
+        '[{"table":"all_types","name":"id","data_type":"INT",'
+        '"default_value":null,"autoincrement":true,"nullable":false,'
+        '"unique_constraint":[]},{"table":"all_types","name":"decimal_col",'
+        '"data_type":"DECIMAL(10,2)","default_value":null,'
+        '"autoincrement":false,"nullable":true,"unique_constraint":[]},'
+        '{"table":"all_types","name":"real_col","data_type":"REAL",'
+        '"default_value":null,"autoincrement":false,"nullable":true,'
+        '"unique_constraint":[]}]'
+    )
+    read_database = Mock(
+        side_effect=[
+            pl.DataFrame(
+                {
+                    "column_name": ["_id", "decimal_col", "real_col"],
+                    "data_type": [":i32", "[:DECIMAL 38 2]", ":f32"],
+                    "is_nullable": ["NO", "YES", "YES"],
+                }
+            ),
+            pl.DataFrame(
+                {
+                    "primary_keys_json": ['["id"]'],
+                    "id_policy": ["single-key"],
+                    "columns_json": [columns_json],
+                }
+            ),
+            pl.DataFrame(
+                {
+                    "primary_keys_json": ['["id"]'],
+                    "id_policy": ["single-key"],
+                    "columns_json": [columns_json],
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(pl, "read_database", read_database)
+
+    table_config = XtdbTableConfigOps(object()).from_table("test", "all_types")
+
+    assert list(table_config.primary_keys) == ["id"]
+    assert [(col.name, col.data_type) for col in table_config.columns] == [
+        ("id", "INT"),
+        ("decimal_col", "DECIMAL(10,2)"),
+        ("real_col", "REAL"),
+    ]
+
+
+def test_xtdb_table_reflection_restores_foreign_key_metadata(monkeypatch):
+    columns_json = (
+        '[{"table":"trading_pairs","name":"id","data_type":"INT",'
+        '"default_value":null,"autoincrement":true,"nullable":false,'
+        '"unique_constraint":[]},{"table":"trading_pairs",'
+        '"name":"exchange_id","data_type":"INT","default_value":null,'
+        '"autoincrement":false,"nullable":false,"unique_constraint":[]}]'
+    )
+    foreign_keys_json = (
+        '[{"name":"exchange_id","references":{"schema":"test",'
+        '"table":"exchanges","column":"id"}}]'
+    )
+    read_database = Mock(
+        side_effect=[
+            pl.DataFrame(
+                {
+                    "column_name": ["_id", "exchange_id"],
+                    "data_type": [":i32", ":i32"],
+                    "is_nullable": ["NO", "NO"],
+                }
+            ),
+            pl.DataFrame(
+                {
+                    "primary_keys_json": ['["id"]'],
+                    "id_policy": ["single-key"],
+                    "columns_json": [columns_json],
+                    "foreign_keys_json": [foreign_keys_json],
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(pl, "read_database", read_database)
+
+    table_config = XtdbTableConfigOps(object()).from_table("test", "trading_pairs")
+
+    assert list(table_config.primary_keys) == ["id"]
+    assert [fk.name for fk in table_config.foreign_keys] == ["exchange_id"]
+    fk = table_config.foreign_keys[0]
+    assert fk.references.schema == "test"
+    assert fk.references.table == "exchanges"
+    assert fk.references.column == "id"
+
+
+def test_xtdb_table_reflection_recovers_composite_primary_keys_from_metadata(
+    monkeypatch,
+):
+    read_database = Mock(
+        side_effect=[
+            pl.DataFrame(
+                {
+                    "column_name": [
+                        "_id",
+                        "vessel_id",
+                        "cargo_id",
+                        "destination",
+                    ],
+                    "data_type": [":utf8", ":i64", ":utf8", ":utf8"],
+                    "is_nullable": ["NO", "NO", "NO", "YES"],
+                }
+            ),
+            pl.DataFrame(
+                {
+                    "primary_keys_json": ['["vessel_id","cargo_id"]'],
+                    "id_policy": ["xtdb-pk-v1"],
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(pl, "read_database", read_database)
+
+    table_config = XtdbTableConfigOps(object()).from_table("test", "cargos")
+
+    assert table_config.schema == "test"
+    assert table_config.name == "cargos"
+    assert list(table_config.primary_keys) == ["vessel_id", "cargo_id"]
+    assert [
+        (col.name, col.data_type, col.nullable) for col in table_config.columns
+    ] == [
+        ("_id", "VARCHAR(255)", False),
+        ("vessel_id", "BIGINT", False),
+        ("cargo_id", "VARCHAR(255)", False),
+        ("destination", "VARCHAR(255)", True),
+    ]
+
+
+def test_xtdb_table_reflection_errors_when_table_has_no_metadata(monkeypatch):
+    monkeypatch.setattr(pl, "read_database", Mock(return_value=pl.DataFrame()))
+    ops = XtdbTableConfigOps(object())
+
+    with pytest.raises(
+        ValueError, match="XTDB table metadata not found for test.cargos"
+    ):
+        ops.from_table("test", "cargos")
+
+
+def test_xtdb_declared_columns_quotes_non_identifier_column_names():
+    from polars_hist_db.backends.xtdb import _xtdb_declared_columns
+
+    table_config = TableConfig(
+        schema="kpler",
+        name="__cargo_stage",
+        primary_keys=["stage_run_id", "stage_row_index"],
+        columns=[
+            TableColumnConfig("__cargo_stage", "stage_run_id", "VARCHAR(128)"),
+            TableColumnConfig("__cargo_stage", "stage_row_index", "BIGINT"),
+            TableColumnConfig("__cargo_stage", "Vessel", "VARCHAR(64)"),
+            TableColumnConfig("__cargo_stage", "IMO (vessel)", "VARCHAR(16)"),
+            TableColumnConfig("__cargo_stage", "timestamp", "DATETIME"),
+        ],
+    )
+
+    assert _xtdb_declared_columns(table_config) == [
+        "_id",
+        "stage_run_id",
+        "stage_row_index",
+        '"Vessel"',
+        '"IMO (vessel)"',
+        '"timestamp"',
+    ]

--- a/tests/backends/test_xtdb_dataframe_ops.py
+++ b/tests/backends/test_xtdb_dataframe_ops.py
@@ -1,0 +1,336 @@
+from unittest.mock import Mock
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import polars as pl
+
+from polars_hist_db.backends.xtdb import XtdbDataframeOps, _execute_xtdb_dml
+from polars_hist_db.config import TableColumnConfig, TableConfig
+from polars_hist_db.core import TimeHint
+
+
+def test_xtdb_dataframe_ops_reads_raw_sql_with_schema_overrides(monkeypatch):
+    expected_df = pl.DataFrame({"id": [1]})
+    read_database = Mock(return_value=expected_df)
+    monkeypatch.setattr(pl, "read_database", read_database)
+
+    connection = object()
+    ops = XtdbDataframeOps(connection)
+
+    result = ops.from_raw_sql("select * from test.cargos", {"id": pl.Int64})
+
+    assert result is expected_df
+    read_database.assert_called_once_with(
+        "select * from test.cargos",
+        connection,
+        schema_overrides={"id": pl.Int64},
+    )
+
+
+def test_xtdb_dml_retries_with_append_time_when_system_time_is_too_old():
+    class _DriverConnection:
+        def __init__(self):
+            self.executed = []
+            self.rollback_count = 0
+            self.commit_count = 0
+
+        def execute(self, sql):
+            self.executed.append(sql)
+
+        def commit(self):
+            self.commit_count += 1
+            if self.commit_count == 1:
+                raise RuntimeError("invalid-system-time: specified system-time older")
+
+        def rollback(self):
+            self.rollback_count += 1
+
+    class _Connection:
+        def __init__(self):
+            self.connection = SimpleNamespace(driver_connection=_DriverConnection())
+            self.info = {}
+
+        def in_transaction(self):
+            return False
+
+    connection = _Connection()
+
+    row_count = _execute_xtdb_dml(
+        connection,
+        "INSERT INTO test.cargos (_id) VALUES (1)",
+        system_time=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+    assert row_count == 0
+    assert connection.connection.driver_connection.rollback_count == 1
+    assert connection.connection.driver_connection.executed == [
+        "BEGIN READ WRITE WITH (SYSTEM_TIME = TIMESTAMP '2025-01-01T00:00:00+00:00')",
+        "INSERT INTO test.cargos (_id) VALUES (1)",
+        "BEGIN READ WRITE",
+        "INSERT INTO test.cargos (_id) VALUES (1)",
+    ]
+
+
+def test_xtdb_dataframe_ops_reads_table_as_sql():
+    connection = object()
+    ops = XtdbDataframeOps(connection)
+    ops.from_raw_sql = Mock(return_value=pl.DataFrame({"id": [1]}))
+
+    result = ops.from_table("test", "cargos", {"id": pl.Int64})
+
+    assert result.to_dict(as_series=False) == {"id": [1]}
+    ops.from_raw_sql.assert_called_once_with(
+        "SELECT * FROM test.cargos",
+        {"id": pl.Int64},
+    )
+
+
+def test_xtdb_dataframe_ops_applies_table_time_hint():
+    connection = object()
+    ops = XtdbDataframeOps(connection)
+    ops.from_raw_sql = Mock(return_value=pl.DataFrame({"id": [1]}))
+
+    result = ops.from_table(
+        "test",
+        "cargos",
+        {"id": pl.Int64},
+        time_hint=TimeHint(
+            mode="asof",
+            asof_utc=datetime.fromisoformat("2026-01-02T03:04:05+00:00"),
+        ),
+    )
+
+    assert result.to_dict(as_series=False) == {"id": [1]}
+    ops.from_raw_sql.assert_called_once_with(
+        "SELECT * FROM test.cargos FOR SYSTEM_TIME AS OF '2026-01-02T03:04:05+00:00'",
+        {"id": pl.Int64},
+    )
+
+
+def test_xtdb_dataframe_ops_writes_dataframe_via_polars_write_database():
+    df = Mock()
+    df.write_database.return_value = 7
+    connection = object()
+    ops = XtdbDataframeOps(connection)
+
+    result = ops.table_insert(df, "test", "cargos")
+
+    assert result == 7
+    df.write_database.assert_called_once_with(
+        table_name="test.cargos",
+        connection=connection,
+        if_table_exists="append",
+    )
+
+
+def test_xtdb_dataframe_ops_maps_configured_primary_key_to_id(monkeypatch):
+    captured = {}
+
+    def write_database(self, **kwargs):
+        captured["df"] = self
+        captured["kwargs"] = kwargs
+        return 2
+
+    monkeypatch.setattr(pl.DataFrame, "write_database", write_database)
+
+    df = pl.DataFrame({"id": [1, 2], "destination": ["A", "B"]})
+    table_config = TableConfig(
+        schema="test",
+        name="cargos",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+        ],
+    )
+    connection = object()
+    ops = XtdbDataframeOps(connection)
+
+    result = ops.table_insert(df, "test", "cargos", table_config=table_config)
+
+    assert result == 2
+    written_df = captured["df"]
+    assert written_df.to_dict(as_series=False) == {
+        "_id": [1, 2],
+        "destination": ["A", "B"],
+    }
+    assert captured["kwargs"] == {
+        "table_name": "test.cargos",
+        "connection": connection,
+        "if_table_exists": "append",
+    }
+
+
+def test_xtdb_dataframe_ops_maps_composite_primary_key_to_synthetic_id(monkeypatch):
+    captured = {}
+
+    def write_database(self, **kwargs):
+        captured["df"] = self
+        captured["kwargs"] = kwargs
+        return 2
+
+    monkeypatch.setattr(pl.DataFrame, "write_database", write_database)
+
+    df = pl.DataFrame(
+        {
+            "vessel_id": [10, 10],
+            "cargo_id": ["A", "B"],
+            "destination": ["Tokyo", "Osaka"],
+        }
+    )
+    table_config = TableConfig(
+        schema="test",
+        name="cargos",
+        primary_keys=["vessel_id", "cargo_id"],
+        columns=[
+            TableColumnConfig("cargos", "vessel_id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "cargo_id", "VARCHAR(255)", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+        ],
+    )
+    connection = object()
+    ops = XtdbDataframeOps(connection)
+
+    result = ops.table_insert(df, "test", "cargos", table_config=table_config)
+
+    assert result == 2
+    written_df = captured["df"]
+    assert written_df.to_dict(as_series=False) == {
+        "_id": [
+            'xtdb-pk-v1:[["vessel_id",10],["cargo_id","A"]]',
+            'xtdb-pk-v1:[["vessel_id",10],["cargo_id","B"]]',
+        ],
+        "vessel_id": [10, 10],
+        "cargo_id": ["A", "B"],
+        "destination": ["Tokyo", "Osaka"],
+    }
+    assert captured["kwargs"] == {
+        "table_name": "test.cargos",
+        "connection": connection,
+        "if_table_exists": "append",
+    }
+
+
+def test_xtdb_dataframe_ops_uses_system_time_transaction_for_update_time():
+    driver_connection = Mock()
+    connection = Mock()
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+    ops = XtdbDataframeOps(connection)
+
+    result = ops.table_insert(
+        pl.DataFrame({"_id": [1], "destination": ["Tokyo"]}),
+        "test",
+        "cargos",
+        update_time=datetime(2030, 1, 1, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert result == 1
+    assert driver_connection.execute.call_args_list[0].args == (
+        "BEGIN READ WRITE WITH (SYSTEM_TIME = TIMESTAMP '2030-01-01T12:00:00+00:00')",
+    )
+
+
+def test_xtdb_dml_advances_reused_system_time_on_same_connection():
+    from polars_hist_db.backends.xtdb import _execute_xtdb_dml
+
+    class _DriverConnection:
+        def __init__(self):
+            self.statements = []
+
+        def execute(self, sql):
+            self.statements.append(sql)
+
+        def commit(self):
+            self.statements.append("COMMIT")
+
+        def rollback(self):
+            self.statements.append("ROLLBACK")
+
+    class _Connection:
+        def __init__(self):
+            self.connection = SimpleNamespace(driver_connection=_DriverConnection())
+            self.info = {}
+
+        def in_transaction(self):
+            return False
+
+    connection = _Connection()
+    system_time = datetime(2030, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+    _execute_xtdb_dml(
+        connection, "CREATE TABLE test.one (_id)", system_time=system_time
+    )
+    _execute_xtdb_dml(
+        connection, "CREATE TABLE test.two (_id)", system_time=system_time
+    )
+
+    begin_statements = [
+        statement
+        for statement in connection.connection.driver_connection.statements
+        if statement.startswith("BEGIN READ WRITE")
+    ]
+    assert begin_statements == [
+        "BEGIN READ WRITE WITH (SYSTEM_TIME = TIMESTAMP '2030-01-01T12:00:00+00:00')",
+        "BEGIN READ WRITE WITH "
+        "(SYSTEM_TIME = TIMESTAMP '2030-01-01T12:00:00.000001+00:00')",
+    ]
+
+
+def test_xtdb_dataframe_ops_uses_native_casts_for_mysql_compatibility_types():
+    driver_connection = Mock()
+    connection = Mock()
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+    ops = XtdbDataframeOps(connection)
+    table_config = TableConfig(
+        schema="test",
+        name="compat_types",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("compat_types", "id", "INT", nullable=False),
+            TableColumnConfig("compat_types", "bool_col", "BOOL"),
+            TableColumnConfig("compat_types", "bit_col", "BIT"),
+            TableColumnConfig("compat_types", "tinyint_col", "TINYINT"),
+            TableColumnConfig("compat_types", "smallint_col", "SMALLINT"),
+            TableColumnConfig("compat_types", "mediumint_col", "MEDIUMINT"),
+            TableColumnConfig("compat_types", "datetime_col", "DATETIME"),
+            TableColumnConfig("compat_types", "time_col", "TIME"),
+        ],
+    )
+
+    ops.table_insert(
+        pl.DataFrame(
+            {
+                "id": [1],
+                "bool_col": [True],
+                "bit_col": [1],
+                "tinyint_col": [2],
+                "smallint_col": [738221],
+                "mediumint_col": [4],
+                "datetime_col": [datetime(2030, 1, 1, 12, 0)],
+                "time_col": [datetime(2030, 1, 1, 12, 30).time()],
+            }
+        ),
+        "test",
+        "compat_types",
+        table_config=table_config,
+    )
+
+    insert_sql = driver_connection.execute.call_args_list[1].args[0]
+    assert "TRUE::BOOLEAN" in insert_sql
+    assert "1::INTEGER" in insert_sql
+    assert "2::INTEGER" in insert_sql
+    assert "738221::INTEGER" in insert_sql
+    assert "4::INTEGER" in insert_sql
+    assert "'2030-01-01T12:00:00'::TIMESTAMP" in insert_sql
+    assert "'12:30:00'::TIME" in insert_sql
+
+
+def test_xtdb_backend_returns_xtdb_dataframe_ops():
+    from polars_hist_db.backends import XtdbBackend
+
+    connection = object()
+    ops = XtdbBackend().dataframes(connection)
+
+    assert isinstance(ops, XtdbDataframeOps)

--- a/tests/backends/test_xtdb_dataset_ingest.py
+++ b/tests/backends/test_xtdb_dataset_ingest.py
@@ -1,0 +1,227 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import polars as pl
+
+from polars_hist_db.config import (
+    DatasetConfig,
+    TableConfigs,
+    ValidTimeConfig,
+)
+from polars_hist_db.dataset.extract_item import scrape_extract_item
+from polars_hist_db.dataset.primary_item import scrape_primary_item
+
+
+class _FakeTableConfigOps:
+    def __init__(self):
+        self.created = []
+
+    def create(self, table_config):
+        self.created.append(table_config)
+        return table_config
+
+
+class _FakeXtdbBackend:
+    name = "xtdb"
+
+    def __init__(self):
+        self.table_config_ops = _FakeTableConfigOps()
+        self.temporal_upsert_calls = []
+
+    def table_configs(self, connection):
+        return self.table_config_ops
+
+    def temporal_upsert(self, *args, **kwargs):
+        self.temporal_upsert_calls.append((args, kwargs))
+        return 1
+
+
+class _FakeStagingOps:
+    def __init__(self, dataframe):
+        self.dataframe = dataframe
+        self.prepare_calls = []
+
+    def prepare_pipeline_item_dataframe(self, *args, **kwargs):
+        self.prepare_calls.append((args, kwargs))
+        return self.dataframe
+
+
+def test_xtdb_primary_ingest_uses_staged_dataframe_for_temporal_upsert():
+    tables = TableConfigs(
+        items=[
+            {
+                "schema": "fakedata",
+                "name": "cargos",
+                "primary_keys": ["cargo_id"],
+                "columns": [
+                    {"name": "cargo_id", "data_type": "INT", "nullable": False},
+                    {"name": "destination", "data_type": "VARCHAR(64)"},
+                ],
+                "is_temporal": True,
+            }
+        ]
+    )
+    cargo_table = tables["cargos"]
+    dataset = DatasetConfig(
+        name="cargo_stream",
+        delta_table_schema="fakedata",
+        input_config={"type": "dsv", "search_paths": []},
+        valid_time=[
+            {
+                "schema": "fakedata",
+                "table": "cargos",
+                "from_column": "msg_timestamp",
+            }
+        ],
+        pipeline=[
+            {
+                "schema": "fakedata",
+                "table": "cargos",
+                "type": "primary",
+                "columns": [
+                    {"source": "cargo_id", "target": "cargo_id"},
+                    {"source": "destination_name", "target": "destination"},
+                ],
+            }
+        ],
+    )
+    msg_timestamp = datetime(2030, 1, 1, 12, 0, tzinfo=timezone.utc)
+    update_time = datetime(2030, 1, 1, 12, 5, tzinfo=timezone.utc)
+    staged_df = pl.DataFrame(
+        {
+            "cargo_id": [1],
+            "destination": ["Tokyo"],
+            "msg_timestamp": [msg_timestamp],
+        }
+    )
+    backend = _FakeXtdbBackend()
+    staging = _FakeStagingOps(staged_df)
+
+    did_modify = scrape_primary_item(
+        0,
+        dataset,
+        tables,
+        update_time,
+        SimpleNamespace(),
+        stage_run_id="stage-1",
+        staging=staging,
+        backend=backend,
+    )
+
+    assert did_modify is True
+    assert backend.table_config_ops.created == [cargo_table]
+    assert staging.prepare_calls == [
+        (
+            ("stage-1", dataset, 0, cargo_table),
+            {
+                "valid_time": ValidTimeConfig(
+                    schema="fakedata",
+                    table="cargos",
+                    from_column="msg_timestamp",
+                )
+            },
+        )
+    ]
+    args, kwargs = backend.temporal_upsert_calls[0]
+    assert args[1:] == ("fakedata", "cargos")
+    assert args[0].to_dict(as_series=False) == {
+        "cargo_id": [1],
+        "destination": ["Tokyo"],
+        "msg_timestamp": [msg_timestamp],
+    }
+    assert kwargs["table_config"] == cargo_table
+    assert kwargs["delta_config"] == dataset.delta_config
+    assert kwargs["update_time"] == update_time
+    assert kwargs["valid_time"] == ValidTimeConfig(
+        schema="fakedata",
+        table="cargos",
+        from_column="msg_timestamp",
+    )
+
+
+def test_xtdb_extract_ingest_uses_staged_dataframe_for_temporal_upsert():
+    tables = TableConfigs(
+        items=[
+            {
+                "schema": "spire",
+                "name": "vectors",
+                "primary_keys": ["mmsi"],
+                "columns": [
+                    {"name": "mmsi", "data_type": "INT", "nullable": False},
+                    {"name": "latitude", "data_type": "DOUBLE"},
+                ],
+                "is_temporal": True,
+            },
+            {
+                "schema": "spire",
+                "name": "vessel_info",
+                "primary_keys": ["mmsi"],
+                "columns": [
+                    {"name": "mmsi", "data_type": "INT", "nullable": False},
+                    {"name": "name", "data_type": "VARCHAR(64)"},
+                ],
+            },
+        ]
+    )
+    vessel_info = tables["vessel_info"]
+    dataset = DatasetConfig(
+        name="spire_stream",
+        delta_table_schema="spire",
+        input_config={"type": "dsv", "search_paths": []},
+        pipeline=[
+            {
+                "schema": "spire",
+                "table": "vectors",
+                "type": "primary",
+                "columns": [
+                    {"source": "source_mmsi", "target": "mmsi"},
+                    {"source": "source_latitude", "target": "latitude"},
+                ],
+            },
+            {
+                "schema": "spire",
+                "table": "vessel_info",
+                "columns": [
+                    {"source": "source_mmsi", "target": "mmsi"},
+                    {"source": "source_name", "target": "name"},
+                ],
+            },
+        ],
+    )
+    update_time = datetime(2030, 1, 1, 12, 5, tzinfo=timezone.utc)
+    staged_df = pl.DataFrame(
+        {
+            "mmsi": [123],
+            "name": ["LNG Test"],
+        }
+    )
+    backend = _FakeXtdbBackend()
+    staging = _FakeStagingOps(staged_df)
+
+    did_modify = scrape_extract_item(
+        1,
+        dataset,
+        "vessel_info",
+        tables,
+        update_time,
+        SimpleNamespace(),
+        stage_run_id="stage-1",
+        staging=staging,
+        backend=backend,
+    )
+
+    assert did_modify is True
+    assert backend.table_config_ops.created == [vessel_info]
+    assert staging.prepare_calls == [
+        (("stage-1", dataset, 1, vessel_info), {"valid_time": None})
+    ]
+    args, kwargs = backend.temporal_upsert_calls[0]
+    assert args[1:] == ("spire", "vessel_info")
+    assert args[0].to_dict(as_series=False) == {
+        "mmsi": [123],
+        "name": ["LNG Test"],
+    }
+    assert kwargs["table_config"] == vessel_info
+    assert kwargs["delta_config"] == dataset.delta_config
+    assert kwargs["update_time"] == update_time
+    assert kwargs["valid_time"] is None

--- a/tests/backends/test_xtdb_live.py
+++ b/tests/backends/test_xtdb_live.py
@@ -1,0 +1,720 @@
+from contextlib import contextmanager
+from datetime import datetime, timezone
+import os
+import subprocess
+import time
+from collections.abc import Iterator
+
+import polars as pl
+import pytest
+from sqlalchemy import Engine, text
+
+from polars_hist_db.backends import DbEngineConfig, XtdbBackend
+from polars_hist_db.config import (
+    DatasetConfig,
+    DeltaConfig,
+    TableColumnConfig,
+    TableConfig,
+    ValidTimeConfig,
+)
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.environ.get("POLARS_HIST_DB_XTDB_LIVE") != "1",
+        reason="set POLARS_HIST_DB_XTDB_LIVE=1 to run live XTDB tests",
+    ),
+]
+
+
+try:
+    import psycopg  # noqa: F401
+except ImportError:
+    pytestmark = [
+        *pytestmark,
+        pytest.mark.skip(reason="install the xtdb extra to run live XTDB tests"),
+    ]
+
+
+def _docker(args: list[str]) -> str:
+    return subprocess.check_output(["docker", *args], text=True).strip()
+
+
+def _published_port(container_id: str) -> int:
+    output = _docker(["port", container_id, "5432/tcp"])
+    first_binding = output.splitlines()[0]
+    return int(first_binding.rsplit(":", 1)[1])
+
+
+@contextmanager
+def _xtdb_engine() -> Iterator[Engine]:
+    container_id = _docker(
+        ["run", "--rm", "-d", "-p", "5432", "ghcr.io/xtdb/xtdb:nightly"]
+    )
+    engine = None
+    try:
+        config = DbEngineConfig(
+            backend="xtdb",
+            hostname="127.0.0.1",
+            port=_published_port(container_id),
+        )
+        engine = XtdbBackend().create_engine(config)
+        deadline = time.monotonic() + 60
+        while True:
+            try:
+                with engine.connect() as connection:
+                    connection.execute(text("SELECT 1"))
+                break
+            except Exception:
+                if time.monotonic() > deadline:
+                    raise
+                time.sleep(1)
+
+        yield engine
+    finally:
+        if engine is not None:
+            engine.dispose()
+        subprocess.run(["docker", "rm", "-f", container_id], check=False)
+
+
+def test_xtdb_live_create_append_read_roundtrip():
+    table_config = TableConfig(
+        schema="public",
+        name=f"live_cargos_{int(time.time())}",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+        ],
+    )
+
+    with _xtdb_engine() as engine:
+        with engine.connect() as connection:
+            backend = XtdbBackend()
+            backend.table_configs(connection).create(table_config)
+
+            backend.dataframes(connection).table_insert(
+                pl.DataFrame(
+                    {
+                        "id": [1, 2],
+                        "destination": ["Tokyo", "Osaka"],
+                        "cargo_mcm": [10.5, 20.25],
+                    }
+                ),
+                table_config.schema,
+                table_config.name,
+                table_config=table_config,
+            )
+
+            result = backend.dataframes(connection).from_table(
+                table_config.schema,
+                table_config.name,
+            )
+
+    assert result.sort("_id").select(["_id", "destination", "cargo_mcm"]).to_dict(
+        as_series=False
+    ) == {
+        "_id": [1, 2],
+        "destination": ["Tokyo", "Osaka"],
+        "cargo_mcm": [10.5, 20.25],
+    }
+
+
+def test_xtdb_live_composite_primary_key_roundtrip():
+    table_config = TableConfig(
+        schema="public",
+        name=f"live_composite_cargos_{int(time.time())}",
+        primary_keys=["vessel_id", "cargo_id"],
+        columns=[
+            TableColumnConfig("cargos", "vessel_id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "cargo_id", "VARCHAR(255)", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+        ],
+    )
+
+    with _xtdb_engine() as engine:
+        with engine.connect() as connection:
+            backend = XtdbBackend()
+            backend.table_configs(connection).create(table_config)
+
+            backend.dataframes(connection).table_insert(
+                pl.DataFrame(
+                    {
+                        "vessel_id": [10, 10],
+                        "cargo_id": ["A", "B"],
+                        "destination": ["Tokyo", "Osaka"],
+                    }
+                ),
+                table_config.schema,
+                table_config.name,
+                table_config=table_config,
+            )
+
+            result = backend.dataframes(connection).from_table(
+                table_config.schema,
+                table_config.name,
+            )
+            reflected_config = backend.table_configs(connection).from_table(
+                table_config.schema,
+                table_config.name,
+            )
+
+    assert result.sort("cargo_id").select(
+        ["_id", "vessel_id", "cargo_id", "destination"]
+    ).to_dict(as_series=False) == {
+        "_id": [
+            'xtdb-pk-v1:[["vessel_id",10],["cargo_id","A"]]',
+            'xtdb-pk-v1:[["vessel_id",10],["cargo_id","B"]]',
+        ],
+        "vessel_id": [10, 10],
+        "cargo_id": ["A", "B"],
+        "destination": ["Tokyo", "Osaka"],
+    }
+    assert list(reflected_config.primary_keys) == ["vessel_id", "cargo_id"]
+
+
+def test_xtdb_live_temporal_upsert_honours_update_time_system_time():
+    table_config = TableConfig(
+        schema="public",
+        name=f"live_temporal_cargos_{int(time.time())}",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+        ],
+    )
+
+    with _xtdb_engine() as engine:
+        with engine.connect() as connection:
+            backend = XtdbBackend()
+            backend.table_configs(connection).create(table_config)
+
+            backend.temporal_upsert(
+                pl.DataFrame(
+                    {
+                        "id": [1],
+                        "destination": ["Tokyo"],
+                        "cargo_mcm": [10.5],
+                    }
+                ),
+                table_config.schema,
+                table_config.name,
+                connection=connection,
+                table_config=table_config,
+                update_time=datetime(2030, 1, 1, tzinfo=timezone.utc),
+            )
+            backend.temporal_upsert(
+                pl.DataFrame(
+                    {
+                        "id": [1],
+                        "destination": ["Osaka"],
+                        "cargo_mcm": [20.25],
+                    }
+                ),
+                table_config.schema,
+                table_config.name,
+                connection=connection,
+                table_config=table_config,
+                update_time=datetime(2030, 1, 2, tzinfo=timezone.utc),
+            )
+
+            table_sql = f"{table_config.schema}.{table_config.name}"
+
+            def read_at(asof: datetime) -> pl.DataFrame:
+                timestamp = asof.isoformat()
+                return backend.dataframes(connection).from_raw_sql(
+                    "SELECT _id, destination, cargo_mcm "
+                    f"FROM {table_sql} "
+                    f"FOR VALID_TIME AS OF TIMESTAMP '{timestamp}' "
+                    f"FOR SYSTEM_TIME AS OF TIMESTAMP '{timestamp}'"
+                )
+
+            asof_after_second = read_at(datetime(2030, 1, 3, tzinfo=timezone.utc))
+            asof_before_first = read_at(
+                datetime(2029, 12, 31, 23, 59, tzinfo=timezone.utc)
+            )
+            asof_between_updates = read_at(
+                datetime(2030, 1, 1, 12, 0, tzinfo=timezone.utc)
+            )
+
+    assert asof_before_first.is_empty()
+    assert asof_after_second.select(["_id", "destination", "cargo_mcm"]).to_dict(
+        as_series=False
+    ) == {
+        "_id": [1],
+        "destination": ["Osaka"],
+        "cargo_mcm": [20.25],
+    }
+    assert asof_between_updates.select(["_id", "destination", "cargo_mcm"]).to_dict(
+        as_series=False
+    ) == {
+        "_id": [1],
+        "destination": ["Tokyo"],
+        "cargo_mcm": [10.5],
+    }
+
+
+def test_xtdb_live_delta_upsert_drops_unchanged_rows():
+    table_config = TableConfig(
+        schema="public",
+        name=f"live_delta_cargos_{int(time.time())}",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+        ],
+    )
+    delta_config = DeltaConfig(
+        drop_unchanged_rows=True,
+        row_finality="disabled",
+    )
+
+    with _xtdb_engine() as engine:
+        with engine.connect() as connection:
+            backend = XtdbBackend()
+            backend.table_configs(connection).create(table_config)
+
+            backend.temporal_upsert(
+                pl.DataFrame(
+                    {
+                        "id": [1],
+                        "destination": ["Tokyo"],
+                        "cargo_mcm": [10.5],
+                    }
+                ),
+                table_config.schema,
+                table_config.name,
+                connection=connection,
+                table_config=table_config,
+                delta_config=delta_config,
+                update_time=datetime(2030, 1, 1, tzinfo=timezone.utc),
+            )
+            unchanged_count = backend.temporal_upsert(
+                pl.DataFrame(
+                    {
+                        "id": [1],
+                        "destination": ["Tokyo"],
+                        "cargo_mcm": [10.5],
+                    }
+                ),
+                table_config.schema,
+                table_config.name,
+                connection=connection,
+                table_config=table_config,
+                delta_config=delta_config,
+                update_time=datetime(2030, 1, 2, tzinfo=timezone.utc),
+            )
+            changed_count = backend.temporal_upsert(
+                pl.DataFrame(
+                    {
+                        "id": [1],
+                        "destination": ["Osaka"],
+                        "cargo_mcm": [20.25],
+                    }
+                ),
+                table_config.schema,
+                table_config.name,
+                connection=connection,
+                table_config=table_config,
+                delta_config=delta_config,
+                update_time=datetime(2030, 1, 3, tzinfo=timezone.utc),
+            )
+
+            history = backend.dataframes(connection).from_raw_sql(
+                "SELECT _id, destination, cargo_mcm, _system_from "
+                f"FROM {table_config.schema}.{table_config.name} "
+                "FOR VALID_TIME ALL FOR SYSTEM_TIME ALL "
+                "ORDER BY _system_from"
+            )
+            table_sql = f"{table_config.schema}.{table_config.name}"
+
+            def read_at(asof: datetime) -> pl.DataFrame:
+                timestamp = asof.isoformat()
+                return backend.dataframes(connection).from_raw_sql(
+                    "SELECT _id, destination, cargo_mcm "
+                    f"FROM {table_sql} "
+                    f"FOR VALID_TIME AS OF TIMESTAMP '{timestamp}' "
+                    f"FOR SYSTEM_TIME AS OF TIMESTAMP '{timestamp}'"
+                )
+
+            asof_after_unchanged = read_at(
+                datetime(2030, 1, 2, 12, 0, tzinfo=timezone.utc)
+            )
+            asof_after_changed = read_at(datetime(2030, 1, 4, tzinfo=timezone.utc))
+
+    assert unchanged_count == 0
+    assert changed_count == 1
+    system_from_values = [str(value) for value in history["_system_from"].to_list()]
+    assert not any(value.startswith("2030-01-02") for value in system_from_values)
+    assert asof_after_unchanged.select(["_id", "destination", "cargo_mcm"]).to_dict(
+        as_series=False
+    ) == {
+        "_id": [1],
+        "destination": ["Tokyo"],
+        "cargo_mcm": [10.5],
+    }
+    assert asof_after_changed.select(["_id", "destination", "cargo_mcm"]).to_dict(
+        as_series=False
+    ) == {
+        "_id": [1],
+        "destination": ["Osaka"],
+        "cargo_mcm": [20.25],
+    }
+
+
+def test_xtdb_live_delta_upsert_takes_last_duplicate_source_key():
+    table_config = TableConfig(
+        schema="public",
+        name=f"live_delta_duplicate_cargos_{int(time.time())}",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+        ],
+    )
+    delta_config = DeltaConfig(
+        on_duplicate_key="take_last",
+        row_finality="disabled",
+    )
+
+    with _xtdb_engine() as engine:
+        with engine.connect() as connection:
+            backend = XtdbBackend()
+            backend.table_configs(connection).create(table_config)
+
+            row_count = backend.temporal_upsert(
+                pl.DataFrame(
+                    {
+                        "id": [1, 1],
+                        "destination": ["Tokyo", "Osaka"],
+                        "cargo_mcm": [10.5, 20.25],
+                    }
+                ),
+                table_config.schema,
+                table_config.name,
+                connection=connection,
+                table_config=table_config,
+                delta_config=delta_config,
+                update_time=datetime(2030, 1, 1, tzinfo=timezone.utc),
+            )
+
+            timestamp = datetime(2030, 1, 2, tzinfo=timezone.utc).isoformat()
+            result = backend.dataframes(connection).from_raw_sql(
+                "SELECT _id, destination, cargo_mcm "
+                f"FROM {table_config.schema}.{table_config.name} "
+                f"FOR VALID_TIME AS OF TIMESTAMP '{timestamp}' "
+                f"FOR SYSTEM_TIME AS OF TIMESTAMP '{timestamp}'"
+            )
+
+    assert row_count == 1
+    assert result.select(["_id", "destination", "cargo_mcm"]).to_dict(
+        as_series=False
+    ) == {
+        "_id": [1],
+        "destination": ["Osaka"],
+        "cargo_mcm": [20.25],
+    }
+
+
+def test_xtdb_live_delta_upsert_dropout_deletes_missing_rows():
+    table_config = TableConfig(
+        schema="public",
+        name=f"live_delta_dropout_cargos_{int(time.time())}",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+        ],
+    )
+    delta_config = DeltaConfig(row_finality="dropout")
+
+    with _xtdb_engine() as engine:
+        with engine.connect() as connection:
+            backend = XtdbBackend()
+            backend.table_configs(connection).create(table_config)
+
+            backend.temporal_upsert(
+                pl.DataFrame(
+                    {
+                        "id": [1, 2],
+                        "destination": ["Tokyo", "Osaka"],
+                        "cargo_mcm": [10.5, 20.25],
+                    }
+                ),
+                table_config.schema,
+                table_config.name,
+                connection=connection,
+                table_config=table_config,
+                delta_config=delta_config,
+                update_time=datetime(2030, 1, 1, tzinfo=timezone.utc),
+            )
+            changed_count = backend.temporal_upsert(
+                pl.DataFrame(
+                    {
+                        "id": [1],
+                        "destination": ["Tokyo"],
+                        "cargo_mcm": [10.5],
+                    }
+                ),
+                table_config.schema,
+                table_config.name,
+                connection=connection,
+                table_config=table_config,
+                delta_config=delta_config,
+                update_time=datetime(2030, 1, 2, tzinfo=timezone.utc),
+            )
+
+            table_sql = f"{table_config.schema}.{table_config.name}"
+
+            def read_at(asof: datetime) -> pl.DataFrame:
+                timestamp = asof.isoformat()
+                return backend.dataframes(connection).from_raw_sql(
+                    "SELECT _id, destination, cargo_mcm "
+                    f"FROM {table_sql} "
+                    f"FOR VALID_TIME AS OF TIMESTAMP '{timestamp}' "
+                    f"FOR SYSTEM_TIME AS OF TIMESTAMP '{timestamp}' "
+                    "ORDER BY _id"
+                )
+
+            before_dropout = read_at(datetime(2030, 1, 1, 12, tzinfo=timezone.utc))
+            after_dropout = read_at(datetime(2030, 1, 3, tzinfo=timezone.utc))
+
+    assert changed_count == 2
+    assert before_dropout.select(["_id", "destination", "cargo_mcm"]).to_dict(
+        as_series=False
+    ) == {
+        "_id": [1, 2],
+        "destination": ["Tokyo", "Osaka"],
+        "cargo_mcm": [10.5, 20.25],
+    }
+    assert after_dropout.select(["_id", "destination", "cargo_mcm"]).to_dict(
+        as_series=False
+    ) == {
+        "_id": [1],
+        "destination": ["Tokyo"],
+        "cargo_mcm": [10.5],
+    }
+
+
+def test_xtdb_live_delta_upsert_dropout_closes_missing_rows_at_valid_time():
+    table_config = TableConfig(
+        schema="public",
+        name=f"live_delta_dropout_valid_close_{int(time.time())}",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+        ],
+    )
+    delta_config = DeltaConfig(row_finality="dropout")
+
+    with _xtdb_engine() as engine:
+        with engine.connect() as connection:
+            backend = XtdbBackend()
+            backend.table_configs(connection).create(table_config)
+
+            backend.temporal_upsert(
+                pl.DataFrame(
+                    {
+                        "id": [1, 2],
+                        "destination": ["Tokyo", "Osaka"],
+                        "_valid_from": [datetime(1985, 1, 1)] * 2,
+                    }
+                ),
+                table_config.schema,
+                table_config.name,
+                connection=connection,
+                table_config=table_config,
+                delta_config=delta_config,
+            )
+            backend.temporal_upsert(
+                pl.DataFrame(
+                    {
+                        "id": [1],
+                        "destination": ["Tokyo"],
+                        "_valid_from": [datetime(1986, 1, 1)],
+                    }
+                ),
+                table_config.schema,
+                table_config.name,
+                connection=connection,
+                table_config=table_config,
+                delta_config=delta_config,
+            )
+
+            history = backend.dataframes(connection).from_raw_sql(
+                f"""
+                SELECT _id, destination, _valid_from, _valid_to
+                FROM {table_config.schema}.{table_config.name}
+                FOR VALID_TIME ALL
+                WHERE _id = 2
+                ORDER BY _valid_from
+                """
+            )
+            connection.commit()
+
+    history = history.with_columns(
+        pl.col(column).dt.replace_time_zone(None)
+        for column in ["_valid_from", "_valid_to"]
+    )
+    assert history.select(["_id", "destination", "_valid_from", "_valid_to"]).to_dict(
+        as_series=False
+    ) == {
+        "_id": [2],
+        "destination": ["Osaka"],
+        "_valid_from": [datetime(1985, 1, 1)],
+        "_valid_to": [datetime(1986, 1, 1)],
+    }
+
+
+def test_xtdb_live_temporal_upsert_honours_explicit_valid_time_window():
+    table_config = TableConfig(
+        schema="public",
+        name=f"live_valid_window_cargos_{int(time.time())}",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+        ],
+    )
+
+    with _xtdb_engine() as engine:
+        with engine.connect() as connection:
+            backend = XtdbBackend()
+            backend.table_configs(connection).create(table_config)
+
+            row_count = backend.temporal_upsert(
+                pl.DataFrame(
+                    {
+                        "id": [1],
+                        "destination": ["Tokyo"],
+                        "cargo_mcm": [10.5],
+                        "_valid_from": [datetime(2030, 1, 10, tzinfo=timezone.utc)],
+                        "_valid_to": [datetime(2030, 1, 20, tzinfo=timezone.utc)],
+                    }
+                ),
+                table_config.schema,
+                table_config.name,
+                connection=connection,
+                table_config=table_config,
+                update_time=datetime(2030, 1, 1, tzinfo=timezone.utc),
+            )
+
+            table_sql = f"{table_config.schema}.{table_config.name}"
+
+            def read_valid_at(valid_asof: datetime) -> pl.DataFrame:
+                valid_timestamp = valid_asof.isoformat()
+                system_timestamp = datetime(2030, 1, 2, tzinfo=timezone.utc).isoformat()
+                return backend.dataframes(connection).from_raw_sql(
+                    "SELECT _id, destination, cargo_mcm "
+                    f"FROM {table_sql} "
+                    f"FOR VALID_TIME AS OF TIMESTAMP '{valid_timestamp}' "
+                    f"FOR SYSTEM_TIME AS OF TIMESTAMP '{system_timestamp}'"
+                )
+
+            before_window = read_valid_at(datetime(2030, 1, 5, tzinfo=timezone.utc))
+            inside_window = read_valid_at(datetime(2030, 1, 15, tzinfo=timezone.utc))
+            after_window = read_valid_at(datetime(2030, 1, 25, tzinfo=timezone.utc))
+
+    assert row_count == 1
+    assert before_window.is_empty()
+    assert inside_window.select(["_id", "destination", "cargo_mcm"]).to_dict(
+        as_series=False
+    ) == {
+        "_id": [1],
+        "destination": ["Tokyo"],
+        "cargo_mcm": [10.5],
+    }
+    assert after_window.is_empty()
+
+
+def test_xtdb_live_staging_roundtrip_projects_and_cleans_batch():
+    suffix = int(time.time())
+    delta_table_config = TableConfig(
+        schema="public",
+        name=f"live_stage_cargo_stream_{suffix}",
+        columns=[
+            TableColumnConfig("stage", "cargo_id", "BIGINT"),
+            TableColumnConfig("stage", "destination_name", "VARCHAR(255)"),
+            TableColumnConfig("stage", "msg_timestamp", "TIMESTAMP"),
+        ],
+    )
+    target_table_config = TableConfig(
+        schema="public",
+        name=f"live_stage_cargos_{suffix}",
+        primary_keys=["cargo_id"],
+        columns=[
+            TableColumnConfig("cargos", "cargo_id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+        ],
+    )
+    dataset = DatasetConfig(
+        name=delta_table_config.name,
+        delta_table_schema="public",
+        input_config={"type": "dsv", "search_paths": []},
+        pipeline=[
+            {
+                "schema": "public",
+                "table": target_table_config.name,
+                "type": "primary",
+                "columns": [
+                    {"source": "cargo_id", "target": "cargo_id"},
+                    {"source": "destination_name", "target": "destination"},
+                ],
+            }
+        ],
+    )
+    partition_time = datetime(2030, 1, 1, tzinfo=timezone.utc)
+    projected_partition_time = datetime(2030, 1, 1)
+
+    with _xtdb_engine() as engine:
+        with engine.connect() as connection:
+            backend = XtdbBackend()
+            staging = backend.staging(connection)
+
+            staging.ensure_table(delta_table_config)
+            inserted_count = staging.insert_partition(
+                pl.DataFrame(
+                    {
+                        "cargo_id": [1, 1],
+                        "destination_name": ["Osaka", "Tokyo"],
+                        "msg_timestamp": [partition_time, partition_time],
+                    }
+                ),
+                delta_table_config,
+                "stage-live-1",
+                partition_time,
+                uniqueness_col_set=["cargo_id"],
+                prefill_nulls_with_default=True,
+            )
+            projected = staging.prepare_pipeline_item_dataframe(
+                "stage-live-1",
+                dataset,
+                0,
+                target_table_config,
+                valid_time=ValidTimeConfig(
+                    table=target_table_config.name,
+                    from_column="msg_timestamp",
+                ),
+            )
+            staging.cleanup_run("stage-live-1", delta_table_config)
+            remaining = backend.dataframes(connection).from_raw_sql(
+                "SELECT * FROM "
+                f"public.__{delta_table_config.name}_stage "
+                "WHERE stage_run_id = 'stage-live-1'::TEXT"
+            )
+
+    assert inserted_count == 1
+    assert projected.to_dict(as_series=False) == {
+        "cargo_id": [1],
+        "destination": ["Tokyo"],
+        "msg_timestamp": [projected_partition_time],
+    }
+    assert remaining.is_empty()

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -1,0 +1,859 @@
+from datetime import datetime, timezone
+from unittest.mock import Mock
+
+import polars as pl
+
+from polars_hist_db.backends.xtdb import XtdbStagingOps
+from polars_hist_db.config import (
+    DatasetConfig,
+    TableColumnConfig,
+    TableConfig,
+    ValidTimeConfig,
+)
+
+
+def test_xtdb_staging_insert_partition_uses_retained_stage_table(monkeypatch):
+    created_configs = []
+    inserted = {}
+
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbTableConfigOps.create",
+        lambda self, table_config: created_configs.append(table_config) or table_config,
+    )
+
+    def table_insert(self, df, table_schema, table_name, table_config=None):
+        inserted["df"] = df
+        inserted["table_schema"] = table_schema
+        inserted["table_name"] = table_name
+        inserted["table_config"] = table_config
+        return df.height
+
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_insert",
+        table_insert,
+    )
+
+    delta_table_config = TableConfig(
+        schema="fakedata",
+        name="cargo_stream",
+        columns=[
+            TableColumnConfig("cargo_stream", "cargo_id", "INT"),
+            TableColumnConfig("cargo_stream", "destination_name", "VARCHAR(64)"),
+        ],
+    )
+    partition_time = datetime(2030, 1, 1, 12, 0, tzinfo=timezone.utc)
+    staging = XtdbStagingOps(object())
+
+    staging.ensure_table(delta_table_config)
+    inserted_count = staging.insert_partition(
+        pl.DataFrame(
+            {
+                "cargo_id": [1, 1],
+                "destination_name": ["Osaka", "Tokyo"],
+            }
+        ),
+        delta_table_config,
+        "stage-1",
+        partition_time,
+        uniqueness_col_set=["cargo_id"],
+        prefill_nulls_with_default=True,
+    )
+
+    assert inserted_count == 1
+    stage_config = created_configs[0]
+    assert stage_config.schema == "fakedata"
+    assert stage_config.name == "__cargo_stream_stage"
+    assert list(stage_config.primary_keys) == ["stage_run_id", "stage_row_index"]
+    assert inserted["table_schema"] == "fakedata"
+    assert inserted["table_name"] == "__cargo_stream_stage"
+    assert inserted["table_config"].name == "__cargo_stream_stage"
+    assert inserted["df"].to_dict(as_series=False) == {
+        "stage_row_index": [0],
+        "cargo_id": [1],
+        "destination_name": ["Tokyo"],
+        "stage_run_id": ["stage-1"],
+        "stage_partition_time": [partition_time],
+    }
+
+
+def test_xtdb_staging_projects_pipeline_item_with_valid_time_mapping(monkeypatch):
+    stage_df = pl.DataFrame(
+        {
+            "stage_run_id": ["stage-1"],
+            "stage_row_index": [0],
+            "cargo_id": [1],
+            "destination_name": ["Tokyo"],
+            "msg_timestamp": [datetime(2030, 1, 1, tzinfo=timezone.utc)],
+            "ignored": ["not written"],
+        }
+    )
+    from_raw_sql = Mock(return_value=stage_df)
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
+        from_raw_sql,
+    )
+    dataset = DatasetConfig(
+        name="cargo_stream",
+        delta_table_schema="fakedata",
+        input_config={"type": "dsv", "search_paths": []},
+        pipeline=[
+            {
+                "schema": "fakedata",
+                "table": "cargos",
+                "type": "primary",
+                "columns": [
+                    {"source": "cargo_id", "target": "cargo_id"},
+                    {"source": "destination_name", "target": "destination"},
+                ],
+            }
+        ],
+    )
+    table_config = TableConfig(
+        schema="fakedata",
+        name="cargos",
+        primary_keys=["cargo_id"],
+        columns=[
+            TableColumnConfig("cargos", "cargo_id", "INT"),
+            TableColumnConfig("cargos", "destination", "VARCHAR(64)"),
+        ],
+    )
+
+    result = XtdbStagingOps(object()).prepare_pipeline_item_dataframe(
+        "stage-1",
+        dataset,
+        0,
+        table_config,
+        valid_time=ValidTimeConfig(table="cargos", from_column="msg_timestamp"),
+    )
+
+    assert result.to_dict(as_series=False) == {
+        "cargo_id": [1],
+        "destination": ["Tokyo"],
+        "msg_timestamp": [datetime(2030, 1, 1, tzinfo=timezone.utc)],
+    }
+    from_raw_sql.assert_called_once_with(
+        "SELECT * FROM fakedata.__cargo_stream_stage "
+        "WHERE stage_run_id = 'stage-1'::TEXT"
+    )
+
+
+def test_xtdb_staging_cleanup_deletes_only_batch_run():
+    driver_connection = Mock()
+    connection = Mock()
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+    delta_table_config = TableConfig(
+        schema="fakedata",
+        name="cargo_stream",
+        columns=[
+            TableColumnConfig("cargo_stream", "cargo_id", "INT"),
+        ],
+    )
+
+    XtdbStagingOps(connection).cleanup_run("stage-1", delta_table_config)
+
+    assert driver_connection.execute.call_args.args == (
+        "DELETE FROM fakedata.__cargo_stream_stage "
+        "WHERE stage_run_id = 'stage-1'::TEXT",
+    )
+
+
+def test_xtdb_staging_deduces_foreign_keys_and_inserts_missing_parent(
+    monkeypatch,
+):
+    stage_df = pl.DataFrame(
+        {
+            "stage_run_id": ["stage-1"],
+            "stage_row_index": [0],
+            "country_id": [None],
+            "country_name": ["Japan"],
+        },
+        schema={
+            "stage_run_id": pl.String,
+            "stage_row_index": pl.Int64,
+            "country_id": pl.String,
+            "country_name": pl.String,
+        },
+    )
+    parent_df = pl.DataFrame(
+        schema={
+            "_id": pl.String,
+            "country_id": pl.String,
+            "name": pl.String,
+        }
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
+        Mock(return_value=stage_df),
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_table",
+        Mock(return_value=parent_df),
+    )
+    inserted = {}
+
+    def table_insert(self, df, table_schema, table_name, table_config=None):
+        inserted["df"] = df
+        inserted["table_schema"] = table_schema
+        inserted["table_name"] = table_name
+        inserted["table_config"] = table_config
+        return df.height
+
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_insert",
+        table_insert,
+    )
+    dataset = DatasetConfig(
+        name="country_stream",
+        delta_table_schema="ref",
+        input_config={"type": "dsv", "search_paths": []},
+        pipeline=[
+            {
+                "schema": "ref",
+                "table": "countries",
+                "type": "primary",
+                "columns": [
+                    {
+                        "source": "country_id",
+                        "target": "country_id",
+                        "deduce_foreign_key": True,
+                    },
+                    {"source": "country_name", "target": "name"},
+                ],
+            }
+        ],
+    )
+    table_config = TableConfig(
+        schema="ref",
+        name="countries",
+        primary_keys=["country_id"],
+        columns=[
+            TableColumnConfig("countries", "country_id", "VARCHAR(128)"),
+            TableColumnConfig("countries", "name", "VARCHAR(64)"),
+        ],
+    )
+
+    result = XtdbStagingOps(object()).prepare_pipeline_item_dataframe(
+        "stage-1",
+        dataset,
+        0,
+        table_config,
+        valid_time=None,
+    )
+
+    generated_id = 'xtdb-fk-v1:ref.countries:[["name","Japan"]]'
+    assert inserted["table_schema"] == "ref"
+    assert inserted["table_name"] == "countries"
+    assert inserted["table_config"] == table_config
+    assert inserted["df"].to_dict(as_series=False) == {
+        "country_id": [generated_id],
+        "name": ["Japan"],
+    }
+    assert result.to_dict(as_series=False) == {
+        "country_id": [generated_id],
+        "name": ["Japan"],
+    }
+
+
+def test_xtdb_staging_deduces_explicit_numeric_foreign_keys(monkeypatch):
+    stage_df = pl.DataFrame(
+        {
+            "stage_run_id": ["stage-1"],
+            "stage_row_index": [0],
+            "origin_location_id": [1001],
+            "origin_name": ["Bonny"],
+            "origin_country": ["Nigeria"],
+        }
+    )
+    parent_df = pl.DataFrame(
+        schema={
+            "id": pl.Int64,
+            "name": pl.String,
+            "country": pl.String,
+        }
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
+        Mock(return_value=stage_df),
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_table",
+        Mock(return_value=parent_df),
+    )
+    inserted = {}
+
+    def table_insert(self, df, table_schema, table_name, table_config=None):
+        inserted["df"] = df
+        inserted["table_schema"] = table_schema
+        inserted["table_name"] = table_name
+        inserted["table_config"] = table_config
+        return df.height
+
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_insert",
+        table_insert,
+    )
+    dataset = DatasetConfig(
+        name="cargo_stream",
+        delta_table_schema="kpler",
+        input_config={"type": "dsv", "search_paths": []},
+        pipeline=[
+            {
+                "schema": "kpler",
+                "table": "location_info",
+                "type": "extract",
+                "columns": [
+                    {
+                        "source": "origin_location_id",
+                        "target": "id",
+                        "deduce_foreign_key": True,
+                    },
+                    {"source": "origin_name", "target": "name"},
+                    {"source": "origin_country", "target": "country"},
+                ],
+            },
+            {
+                "schema": "kpler",
+                "table": "trades",
+                "type": "primary",
+                "columns": [
+                    {"source": "origin_location_id", "target": "origin_location_id"},
+                ],
+            },
+        ],
+    )
+    table_config = TableConfig(
+        schema="kpler",
+        name="location_info",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("location_info", "id", "INT", nullable=False),
+            TableColumnConfig("location_info", "name", "VARCHAR(64)"),
+            TableColumnConfig("location_info", "country", "VARCHAR(64)"),
+        ],
+    )
+
+    result = XtdbStagingOps(object()).prepare_pipeline_item_dataframe(
+        "stage-1",
+        dataset,
+        0,
+        table_config,
+        valid_time=None,
+    )
+
+    assert inserted["table_schema"] == "kpler"
+    assert inserted["table_name"] == "location_info"
+    assert inserted["table_config"] == table_config
+    assert inserted["df"].to_dict(as_series=False) == {
+        "id": [1001],
+        "name": ["Bonny"],
+        "country": ["Nigeria"],
+    }
+    assert result.to_dict(as_series=False) == {
+        "id": [1001],
+        "name": ["Bonny"],
+        "country": ["Nigeria"],
+    }
+
+
+def test_xtdb_staging_generates_numeric_foreign_key_when_source_key_is_missing(
+    monkeypatch,
+):
+    stage_df = pl.DataFrame(
+        {
+            "stage_run_id": ["stage-1"],
+            "stage_row_index": [0],
+            "destination_location_id": [None],
+            "destination_name": ["Southern Europe"],
+            "destination_country": ["#Unspecified"],
+        },
+        schema={
+            "stage_run_id": pl.String,
+            "stage_row_index": pl.Int64,
+            "destination_location_id": pl.Int64,
+            "destination_name": pl.String,
+            "destination_country": pl.String,
+        },
+    )
+    parent_df = pl.DataFrame(
+        schema={
+            "id": pl.Int64,
+            "name": pl.String,
+            "country": pl.String,
+        }
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
+        Mock(return_value=stage_df),
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_table",
+        Mock(return_value=parent_df),
+    )
+    inserted = {}
+
+    def table_insert(self, df, table_schema, table_name, table_config=None):
+        inserted["df"] = df
+        return df.height
+
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_insert",
+        table_insert,
+    )
+    dataset = DatasetConfig(
+        name="cargo_stream",
+        delta_table_schema="kpler",
+        input_config={"type": "dsv", "search_paths": []},
+        pipeline=[
+            {
+                "schema": "kpler",
+                "table": "location_info",
+                "type": "extract",
+                "columns": [
+                    {
+                        "source": "destination_location_id",
+                        "target": "id",
+                        "deduce_foreign_key": True,
+                    },
+                    {"source": "destination_name", "target": "name"},
+                    {"source": "destination_country", "target": "country"},
+                ],
+            },
+            {
+                "schema": "kpler",
+                "table": "trades",
+                "type": "primary",
+                "columns": [
+                    {
+                        "source": "destination_location_id",
+                        "target": "destination_location_id",
+                    },
+                ],
+            },
+        ],
+    )
+    table_config = TableConfig(
+        schema="kpler",
+        name="location_info",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("location_info", "id", "INT", nullable=False),
+            TableColumnConfig("location_info", "name", "VARCHAR(64)"),
+            TableColumnConfig("location_info", "country", "VARCHAR(64)"),
+        ],
+    )
+
+    result = XtdbStagingOps(object()).prepare_pipeline_item_dataframe(
+        "stage-1",
+        dataset,
+        0,
+        table_config,
+        valid_time=None,
+    )
+
+    generated_id = result[0, "id"]
+    assert isinstance(generated_id, int)
+    assert generated_id < 0
+    assert inserted["df"].to_dict(as_series=False) == {
+        "id": [generated_id],
+        "name": ["Southern Europe"],
+        "country": ["#Unspecified"],
+    }
+    assert result.to_dict(as_series=False) == {
+        "id": [generated_id],
+        "name": ["Southern Europe"],
+        "country": ["#Unspecified"],
+    }
+
+
+def test_xtdb_staging_reuses_deduced_foreign_key_for_later_primary_item(
+    monkeypatch,
+):
+    stage_df = pl.DataFrame(
+        {
+            "stage_run_id": ["stage-1"],
+            "stage_row_index": [0],
+            "trade_id": [308327],
+            "destination_location_id": [None],
+            "destination_name": ["#Unspecified"],
+            "destination_country": ["#Unspecified"],
+        },
+        schema={
+            "stage_run_id": pl.String,
+            "stage_row_index": pl.Int64,
+            "trade_id": pl.Int64,
+            "destination_location_id": pl.Int64,
+            "destination_name": pl.String,
+            "destination_country": pl.String,
+        },
+    )
+    parent_df = pl.DataFrame(
+        schema={
+            "id": pl.Int64,
+            "name": pl.String,
+            "country": pl.String,
+        }
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
+        Mock(return_value=stage_df),
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_table",
+        Mock(return_value=parent_df),
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_insert",
+        lambda self, df, table_schema, table_name, table_config=None: df.height,
+    )
+    dataset = DatasetConfig(
+        name="cargo_stream",
+        delta_table_schema="kpler",
+        input_config={"type": "dsv", "search_paths": []},
+        pipeline=[
+            {
+                "schema": "kpler",
+                "table": "location_info",
+                "type": "extract",
+                "columns": [
+                    {
+                        "source": "destination_location_id",
+                        "target": "id",
+                        "deduce_foreign_key": True,
+                    },
+                    {"source": "destination_name", "target": "name"},
+                    {"source": "destination_country", "target": "country"},
+                ],
+            },
+            {
+                "schema": "kpler",
+                "table": "trades",
+                "type": "primary",
+                "columns": [
+                    {"source": "trade_id", "target": "id"},
+                    {
+                        "source": "destination_location_id",
+                        "target": "destination_location_id",
+                    },
+                ],
+            },
+        ],
+    )
+    location_config = TableConfig(
+        schema="kpler",
+        name="location_info",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("location_info", "id", "INT", nullable=False),
+            TableColumnConfig("location_info", "name", "VARCHAR(64)"),
+            TableColumnConfig("location_info", "country", "VARCHAR(64)"),
+        ],
+    )
+    trades_config = TableConfig(
+        schema="kpler",
+        name="trades",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("trades", "id", "INT", nullable=False),
+            TableColumnConfig("trades", "destination_location_id", "INT"),
+        ],
+    )
+    staging = XtdbStagingOps(object())
+
+    location_df = staging.prepare_pipeline_item_dataframe(
+        "stage-1",
+        dataset,
+        0,
+        location_config,
+        valid_time=None,
+    )
+    trades_df = staging.prepare_pipeline_item_dataframe(
+        "stage-1",
+        dataset,
+        1,
+        trades_config,
+        valid_time=None,
+    )
+
+    generated_id = location_df[0, "id"]
+    assert trades_df.to_dict(as_series=False) == {
+        "id": [308327],
+        "destination_location_id": [generated_id],
+    }
+
+
+def test_xtdb_staging_does_not_insert_same_generated_parent_twice(
+    monkeypatch,
+):
+    stage_df = pl.DataFrame(
+        {
+            "stage_run_id": ["stage-1"],
+            "stage_row_index": [0],
+            "origin_location_id": [None],
+            "origin_name": ["#Unspecified"],
+            "origin_country": ["#Unspecified"],
+            "destination_location_id": [None],
+            "destination_name": ["#Unspecified"],
+            "destination_country": ["#Unspecified"],
+        },
+        schema={
+            "stage_run_id": pl.String,
+            "stage_row_index": pl.Int64,
+            "origin_location_id": pl.Int64,
+            "origin_name": pl.String,
+            "origin_country": pl.String,
+            "destination_location_id": pl.Int64,
+            "destination_name": pl.String,
+            "destination_country": pl.String,
+        },
+    )
+    parent_df = pl.DataFrame(
+        schema={
+            "id": pl.Int64,
+            "name": pl.String,
+            "country": pl.String,
+        }
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
+        Mock(return_value=stage_df),
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_table",
+        Mock(return_value=parent_df),
+    )
+    inserted = []
+
+    def table_insert(self, df, table_schema, table_name, table_config=None):
+        inserted.append(df)
+        return df.height
+
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_insert",
+        table_insert,
+    )
+    dataset = DatasetConfig(
+        name="cargo_stream",
+        delta_table_schema="kpler",
+        input_config={"type": "dsv", "search_paths": []},
+        pipeline=[
+            {
+                "schema": "kpler",
+                "table": "location_info",
+                "type": "extract",
+                "columns": [
+                    {
+                        "source": "origin_location_id",
+                        "target": "id",
+                        "deduce_foreign_key": True,
+                    },
+                    {"source": "origin_name", "target": "name"},
+                    {"source": "origin_country", "target": "country"},
+                ],
+            },
+            {
+                "schema": "kpler",
+                "table": "location_info",
+                "columns": [
+                    {
+                        "source": "destination_location_id",
+                        "target": "id",
+                        "deduce_foreign_key": True,
+                    },
+                    {"source": "destination_name", "target": "name"},
+                    {"source": "destination_country", "target": "country"},
+                ],
+            },
+            {
+                "schema": "kpler",
+                "table": "trades",
+                "type": "primary",
+                "columns": [
+                    {"source": "origin_location_id", "target": "origin_location_id"},
+                ],
+            },
+        ],
+    )
+    location_config = TableConfig(
+        schema="kpler",
+        name="location_info",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("location_info", "id", "INT", nullable=False),
+            TableColumnConfig("location_info", "name", "VARCHAR(64)"),
+            TableColumnConfig("location_info", "country", "VARCHAR(64)"),
+        ],
+    )
+    staging = XtdbStagingOps(object())
+
+    origin_df = staging.prepare_pipeline_item_dataframe(
+        "stage-1",
+        dataset,
+        0,
+        location_config,
+        valid_time=None,
+    )
+    destination_df = staging.prepare_pipeline_item_dataframe(
+        "stage-1",
+        dataset,
+        1,
+        location_config,
+        valid_time=None,
+    )
+
+    assert len(inserted) == 1
+    assert origin_df[0, "id"] == inserted[0][0, "id"]
+    assert destination_df.is_empty()
+
+
+def test_xtdb_staging_deduces_existing_foreign_key_without_insert(monkeypatch):
+    stage_df = pl.DataFrame(
+        {
+            "stage_run_id": ["stage-1"],
+            "stage_row_index": [0],
+            "country_id": [None],
+            "country_name": ["Japan"],
+        },
+        schema={
+            "stage_run_id": pl.String,
+            "stage_row_index": pl.Int64,
+            "country_id": pl.String,
+            "country_name": pl.String,
+        },
+    )
+    parent_df = pl.DataFrame(
+        {
+            "country_id": ["country:japan"],
+            "name": ["Japan"],
+        }
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
+        Mock(return_value=stage_df),
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_table",
+        Mock(return_value=parent_df),
+    )
+    table_insert = Mock(return_value=0)
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_insert",
+        table_insert,
+    )
+    dataset = DatasetConfig(
+        name="country_stream",
+        delta_table_schema="ref",
+        input_config={"type": "dsv", "search_paths": []},
+        pipeline=[
+            {
+                "schema": "ref",
+                "table": "countries",
+                "type": "primary",
+                "columns": [
+                    {
+                        "source": "country_id",
+                        "target": "country_id",
+                        "deduce_foreign_key": True,
+                    },
+                    {"source": "country_name", "target": "name"},
+                ],
+            }
+        ],
+    )
+    table_config = TableConfig(
+        schema="ref",
+        name="countries",
+        primary_keys=["country_id"],
+        columns=[
+            TableColumnConfig("countries", "country_id", "VARCHAR(128)"),
+            TableColumnConfig("countries", "name", "VARCHAR(64)"),
+        ],
+    )
+
+    result = XtdbStagingOps(object()).prepare_pipeline_item_dataframe(
+        "stage-1",
+        dataset,
+        0,
+        table_config,
+        valid_time=None,
+    )
+
+    table_insert.assert_not_called()
+    assert result.to_dict(as_series=False) == {
+        "country_id": ["country:japan"],
+        "name": ["Japan"],
+    }
+
+
+def test_xtdb_staging_deduces_foreign_keys_with_null_typed_empty_parent(
+    monkeypatch,
+):
+    stage_df = pl.DataFrame(
+        {
+            "stage_run_id": ["stage-1"],
+            "stage_row_index": [0],
+            "country_id": ["country:japan"],
+            "country_name": ["Japan"],
+        }
+    )
+    parent_df = pl.DataFrame(
+        {
+            "country_id": pl.Series("country_id", [], dtype=pl.Null),
+            "name": pl.Series("name", [], dtype=pl.Null),
+        }
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
+        Mock(return_value=stage_df),
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_table",
+        Mock(return_value=parent_df),
+    )
+    table_insert = Mock(return_value=1)
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_insert",
+        table_insert,
+    )
+    dataset = DatasetConfig(
+        name="country_stream",
+        delta_table_schema="ref",
+        input_config={"type": "dsv", "search_paths": []},
+        pipeline=[
+            {
+                "schema": "ref",
+                "table": "countries",
+                "type": "primary",
+                "columns": [
+                    {
+                        "source": "country_id",
+                        "target": "country_id",
+                        "deduce_foreign_key": True,
+                    },
+                    {"source": "country_name", "target": "name"},
+                ],
+            }
+        ],
+    )
+    table_config = TableConfig(
+        schema="ref",
+        name="countries",
+        primary_keys=["country_id"],
+        columns=[
+            TableColumnConfig("countries", "country_id", "VARCHAR(128)"),
+            TableColumnConfig("countries", "name", "VARCHAR(64)"),
+        ],
+    )
+
+    result = XtdbStagingOps(object()).prepare_pipeline_item_dataframe(
+        "stage-1",
+        dataset,
+        0,
+        table_config,
+        valid_time=None,
+    )
+
+    assert result.to_dict(as_series=False) == {
+        "country_id": ["country:japan"],
+        "name": ["Japan"],
+    }

--- a/tests/config/test_config_engine_factory.py
+++ b/tests/config/test_config_engine_factory.py
@@ -1,0 +1,10 @@
+from polars_hist_db.config import PolarsHistDbConfig
+
+
+def test_config_can_create_engine_from_db_backend():
+    config = PolarsHistDbConfig.from_yaml("tests/_data/config/simple.yaml")
+
+    engine = config.create_engine()
+
+    assert engine.url.drivername == "mariadb+pymysql"
+    assert engine.url.host == "127.0.0.1"

--- a/tests/config/test_db_engine_config.py
+++ b/tests/config/test_db_engine_config.py
@@ -1,0 +1,54 @@
+from polars_hist_db.backends import DbEngineConfig
+from polars_hist_db.config import PolarsHistDbConfig
+
+
+def test_config_parses_db_section():
+    config = PolarsHistDbConfig.from_yaml("tests/_data/config/simple.yaml")
+
+    assert isinstance(config.db_config, DbEngineConfig)
+    assert config.db_config.backend == "mariadb"
+    assert config.db_config.hostname == "127.0.0.1"
+    assert config.db_config.username == "root"
+    assert config.db_config.password == "admin"
+
+
+def test_config_defaults_to_mariadb_when_db_section_missing():
+    config = PolarsHistDbConfig(
+        {"table_configs": [], "datasets": []},
+        table_configs_path=["table_configs"],
+        datasets_path=["datasets"],
+    )
+
+    assert config.db_config.backend == "mariadb"
+    assert config.db_config.port == 3306
+
+
+def test_db_engine_config_parses_database_name():
+    config = DbEngineConfig.from_mapping(
+        {
+            "backend": "xtdb",
+            "hostname": "127.0.0.1",
+            "port": 15432,
+            "database": "analytics",
+        }
+    )
+
+    assert config.backend == "xtdb"
+    assert config.database == "analytics"
+
+
+def test_db_engine_config_parses_adbc_port():
+    config = DbEngineConfig.from_mapping(
+        {
+            "backend": "xtdb",
+            "adbc_port": "19832",
+        }
+    )
+
+    assert config.adbc_port == 19832
+
+
+def test_db_engine_config_defaults_xtdb_adbc_port():
+    config = DbEngineConfig.from_mapping({"backend": "xtdb"})
+
+    assert config.adbc_port == 9832

--- a/tests/config/test_valid_time_config.py
+++ b/tests/config/test_valid_time_config.py
@@ -1,0 +1,80 @@
+from polars_hist_db.config import DatasetConfig, ValidTimeConfig
+from polars_hist_db.config.config import ParityConfig
+
+
+def _dataset_config(**overrides):
+    config = {
+        "name": "cargo_stream",
+        "delta_table_schema": "fakedata",
+        "input_config": {"type": "dsv", "search_paths": []},
+        "pipeline": [
+            {
+                "table": "cargos",
+                "schema": "fakedata",
+                "type": "primary",
+                "columns": [
+                    {"source": "cargo_id", "target": "cargo_id"},
+                ],
+            }
+        ],
+    }
+    config.update(overrides)
+    return DatasetConfig(**config)
+
+
+def test_dataset_config_parses_valid_time_mappings():
+    dataset = _dataset_config(
+        valid_time=[
+            {
+                "schema": "fakedata",
+                "table": "cargos",
+                "from_column": "msg_timestamp",
+                "to_column": "valid_until",
+            }
+        ]
+    )
+
+    assert dataset.valid_time == [
+        ValidTimeConfig(
+            schema="fakedata",
+            table="cargos",
+            from_column="msg_timestamp",
+            to_column="valid_until",
+        )
+    ]
+    assert dataset.valid_time_for_table("fakedata", "cargos") == dataset.valid_time[0]
+
+
+def test_dataset_valid_time_lookup_allows_schema_omission():
+    dataset = _dataset_config(
+        valid_time=[
+            {
+                "table": "cargos",
+                "from_column": "_asof_dt",
+            }
+        ]
+    )
+
+    assert dataset.valid_time_for_table("fakedata", "cargos") == ValidTimeConfig(
+        table="cargos",
+        from_column="_asof_dt",
+    )
+    assert dataset.valid_time_for_table("other", "vessels") is None
+
+
+def test_parity_config_parses_ignore_columns_and_semantic_foreign_keys():
+    parity = ParityConfig(
+        ignore_columns=["kpler.location_info.id"],
+        semantic_foreign_keys=[
+            {
+                "source": "kpler.trades.origin_location_id",
+                "target": "kpler.location_info.id",
+                "columns": ["name", "country"],
+            }
+        ],
+    )
+
+    assert parity.ignore_columns == ("kpler.location_info.id",)
+    assert parity.semantic_foreign_keys[0].source == ("kpler.trades.origin_location_id")
+    assert parity.semantic_foreign_keys[0].target == "kpler.location_info.id"
+    assert parity.semantic_foreign_keys[0].columns == ("name", "country")

--- a/tests/dataset/test_backend_entrypoint.py
+++ b/tests/dataset/test_backend_entrypoint.py
@@ -1,0 +1,162 @@
+from types import SimpleNamespace
+
+import pytest
+
+from polars_hist_db.backends import DbEngineConfig
+from polars_hist_db.dataset import run_datasets
+from polars_hist_db.dataset.entrypoint import _create_config_tables
+
+
+class _FakeBackend:
+    def __init__(self):
+        self.created_with = None
+
+    def create_engine(self, config):
+        self.created_with = config
+        return object()
+
+
+class _ContextManager:
+    def __init__(self, value):
+        self.value = value
+
+    def __enter__(self):
+        return self.value
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeEngine:
+    def __init__(self):
+        self.connection = _FakeConnection()
+        self.used_begin = False
+        self.used_connect = False
+
+    def begin(self):
+        self.used_begin = True
+        return _ContextManager(self.connection)
+
+    def connect(self):
+        self.used_connect = True
+        return _ContextManager(self.connection)
+
+
+class _FakeConnection:
+    def __init__(self):
+        self.committed = False
+
+    def commit(self):
+        self.committed = True
+
+
+class _FakeTableConfigOps:
+    def __init__(self):
+        self.created_all = None
+
+    def create_all(self, tables):
+        self.created_all = tables
+
+
+class _FakeBackendWithTableConfigOps:
+    def __init__(self, name="mariadb"):
+        self.name = name
+        self.ops = _FakeTableConfigOps()
+        self.connection = None
+
+    def table_configs(self, connection):
+        self.connection = connection
+        return self.ops
+
+
+class _FailingInputSource:
+    cleaned = False
+
+    async def next_df(self, engine):
+        raise RuntimeError("input failed")
+
+    async def cleanup(self):
+        type(self).cleaned = True
+
+
+@pytest.mark.asyncio
+async def test_run_datasets_creates_engine_from_config_when_engine_is_omitted(
+    monkeypatch,
+):
+    fake_backend = _FakeBackend()
+
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.entrypoint.backend_from_config",
+        lambda config: fake_backend,
+    )
+
+    config = SimpleNamespace(
+        db_config=DbEngineConfig(backend="mariadb"),
+        datasets=SimpleNamespace(datasets=[]),
+    )
+
+    await run_datasets(config)
+
+    assert fake_backend.created_with == config.db_config
+
+
+@pytest.mark.asyncio
+async def test_run_datasets_can_raise_input_source_errors(monkeypatch):
+    backend = _FakeBackendWithTableConfigOps()
+    engine = _FakeEngine()
+    dataset = SimpleNamespace(
+        name="bad_dataset",
+        input_config=SimpleNamespace(type="dsv"),
+    )
+    config = SimpleNamespace(
+        db_config=DbEngineConfig(backend="mariadb"),
+        datasets=SimpleNamespace(datasets=[dataset]),
+        tables=object(),
+    )
+    _FailingInputSource.cleaned = False
+
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.entrypoint.backend_from_config",
+        lambda config: backend,
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.entrypoint._build_delta_table_config",
+        lambda tables, dataset: object(),
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.entrypoint.InputSourceFactory.create_input_source",
+        lambda *args, **kwargs: _FailingInputSource(),
+    )
+
+    with pytest.raises(RuntimeError, match="input failed"):
+        await run_datasets(config, engine, raise_on_error=True)
+
+    assert _FailingInputSource.cleaned is True
+
+
+def test_create_config_tables_uses_selected_backend_table_config_ops():
+    engine = _FakeEngine()
+    backend = _FakeBackendWithTableConfigOps()
+    tables = object()
+
+    _create_config_tables(engine, tables, backend)
+
+    assert backend.connection is engine.connection
+    assert backend.ops.created_all is tables
+    assert engine.used_begin is True
+    assert engine.used_connect is False
+    assert engine.connection.committed is False
+
+
+def test_create_config_tables_uses_plain_connection_for_xtdb():
+    engine = _FakeEngine()
+    backend = _FakeBackendWithTableConfigOps(name="xtdb")
+    tables = object()
+
+    _create_config_tables(engine, tables, backend)
+
+    assert backend.connection is engine.connection
+    assert backend.ops.created_all is tables
+    assert engine.used_begin is False
+    assert engine.used_connect is True
+    assert engine.connection.committed is True

--- a/tests/dataset/test_scrape_transactions.py
+++ b/tests/dataset/test_scrape_transactions.py
@@ -1,0 +1,47 @@
+from polars_hist_db.dataset.scrape import _pipeline_transaction_context
+
+
+class _FakeTransaction:
+    def __init__(self):
+        self.entered = False
+        self.exited = False
+
+    def __enter__(self):
+        self.entered = True
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.exited = True
+        return False
+
+
+class _FakeConnection:
+    def __init__(self):
+        self.transaction = _FakeTransaction()
+        self.begin_called = False
+
+    def begin(self):
+        self.begin_called = True
+        return self.transaction
+
+
+def test_pipeline_transaction_context_uses_sqlalchemy_transaction_for_mariadb():
+    connection = _FakeConnection()
+
+    with _pipeline_transaction_context(connection, is_xtdb=False):
+        pass
+
+    assert connection.begin_called is True
+    assert connection.transaction.entered is True
+    assert connection.transaction.exited is True
+
+
+def test_pipeline_transaction_context_uses_plain_context_for_xtdb():
+    connection = _FakeConnection()
+
+    with _pipeline_transaction_context(connection, is_xtdb=True):
+        pass
+
+    assert connection.begin_called is False
+    assert connection.transaction.entered is False
+    assert connection.transaction.exited is False

--- a/tests/sql/test_column_types.py
+++ b/tests/sql/test_column_types.py
@@ -5,6 +5,7 @@ from polars.testing import assert_frame_equal
 from polars_hist_db.utils.compare import compare_dataframes
 
 from ..utils.dsv_helper import (
+    backend_params,
     from_test_result,
     modify_and_read,
     setup_fixture_dataset,
@@ -13,14 +14,14 @@ from ..utils.dsv_helper import (
 pytestmark = pytest.mark.integration
 
 
-@pytest.fixture
-def fixture_with_nullable():
-    yield from setup_fixture_dataset("all_col_types_nullable.yaml")
+@pytest.fixture(params=backend_params())
+def fixture_with_nullable(request):
+    yield from setup_fixture_dataset("all_col_types_nullable.yaml", request.param)
 
 
-@pytest.fixture
-def fixture_with_defaults():
-    yield from setup_fixture_dataset("all_col_types_defaults.yaml")
+@pytest.fixture(params=backend_params())
+def fixture_with_defaults(request):
+    yield from setup_fixture_dataset("all_col_types_defaults.yaml", request.param)
 
 
 def test_types_nullable(fixture_with_nullable):

--- a/tests/sql/test_dataframe_join.py
+++ b/tests/sql/test_dataframe_join.py
@@ -3,23 +3,26 @@ import pytest
 import polars as pl
 from polars.testing import assert_frame_equal
 
-from polars_hist_db.core.dataframe import TimeHint, DataframeOps
+from polars_hist_db.core.dataframe import TimeHint
 
 from ..utils.dsv_helper import (
     add_random_row,
+    backend_params,
     from_test_result,
     modify_and_read,
     read_df_from_db,
     set_random_seed,
     setup_fixture_dataset,
+    connection_context_for_engine,
+    dataframe_ops_for_engine,
 )
 
 pytestmark = pytest.mark.integration
 
 
-@pytest.fixture
-def temp_table():
-    yield from setup_fixture_dataset("all_col_types_nullable.yaml")
+@pytest.fixture(params=backend_params())
+def temp_table(request):
+    yield from setup_fixture_dataset("all_col_types_nullable.yaml", request.param)
 
 
 def test_time_hints(temp_table):
@@ -54,12 +57,12 @@ def test_time_hints(temp_table):
     assert df_read_history.shape == (6, 24)
 
     # no hint -- current table only
-    with engine.begin() as connection:
+    with connection_context_for_engine(engine)() as connection:
         query_df = pl.from_dict({"id": 1}, schema_overrides={"id": pl.Int32})
         asof_utc = df_read_history[3]["__valid_from"][0]
         asof_utc = None
         df_1 = (
-            DataframeOps(connection)
+            dataframe_ops_for_engine(engine, connection)
             .table_query(  # noqa: F821
                 table_schema,
                 table_configs.items[0].name,
@@ -72,11 +75,11 @@ def test_time_hints(temp_table):
     assert_frame_equal(df_1, df_read)
 
     # asof a particualr date, no history
-    with engine.begin() as connection:
+    with connection_context_for_engine(engine)() as connection:
         query_df = pl.from_dict({"id": 1}, schema_overrides={"id": pl.Int32})
         asof_utc = df_read_history[3]["__valid_from"][0]
         df_2 = (
-            DataframeOps(connection)
+            dataframe_ops_for_engine(engine, connection)
             .table_query(
                 table_schema,
                 table_configs.items[0].name,
@@ -90,11 +93,11 @@ def test_time_hints(temp_table):
     assert_frame_equal(df_2, df_read_history[3])
 
     # asof a particualr date, 0 days history
-    with engine.begin() as connection:
+    with connection_context_for_engine(engine)() as connection:
         query_df = pl.from_dict({"id": 1}, schema_overrides={"id": pl.Int32})
         asof_utc = df_read_history[3]["__valid_from"][0]
         df_3 = (
-            DataframeOps(connection)
+            dataframe_ops_for_engine(engine, connection)
             .table_query(
                 table_schema,
                 table_configs.items[0].name,
@@ -110,11 +113,11 @@ def test_time_hints(temp_table):
     assert_frame_equal(df_3, df_read_history[3])
 
     # asof a particualr date, 2 days history
-    with engine.begin() as connection:
+    with connection_context_for_engine(engine)() as connection:
         query_df = pl.from_dict({"id": 1}, schema_overrides={"id": pl.Int32})
         asof_utc = df_read_history[5]["__valid_from"][0]
         df_4 = (
-            DataframeOps(connection)
+            dataframe_ops_for_engine(engine, connection)
             .table_query(
                 table_schema,
                 table_configs.items[0].name,

--- a/tests/sql/test_dataframe_read.py
+++ b/tests/sql/test_dataframe_read.py
@@ -1,22 +1,27 @@
 import pytest
 import polars as pl
-from sqlalchemy import select
-
-from polars_hist_db.core.dataframe import DataframeOps
-
-from polars_hist_db.core.table import TableOps
 from ..utils.dsv_helper import (
+    backend_params,
     from_test_result,
     modify_and_read,
+    read_raw_sql_from_db,
     setup_fixture_dataset,
 )
 
-pytestmark = pytest.mark.integration
-
 
 @pytest.fixture
-def fixutre_with_simple_table():
-    yield from setup_fixture_dataset("simple_nontemporal.yaml")
+def fixutre_with_simple_table(request):
+    yield from setup_fixture_dataset("simple_nontemporal.yaml", request.param)
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.parametrize(
+        "fixutre_with_simple_table",
+        backend_params(),
+        indirect=True,
+    ),
+]
 
 
 def test_select_sql(fixutre_with_simple_table):
@@ -64,8 +69,7 @@ def test_select_sql(fixutre_with_simple_table):
 
     # read using raw sql
     _sql = f"select * from {table_schema}.{table_config.name}"
-    with engine.begin() as connection:
-        df_read = DataframeOps(connection).from_raw_sql(_sql)
+    df_read = read_raw_sql_from_db(engine, _sql, table_config)
 
     df_expected = from_test_result(
         """
@@ -111,17 +115,6 @@ def test_select_sql(fixutre_with_simple_table):
 
     # read empty dataframe using raw sql
     _sql = f"select * from {table_schema}.{table_config.name} where 1=0"
-    with engine.begin() as connection:
-        df_read = DataframeOps(connection).from_raw_sql(_sql)
-
-    assert df_read.is_empty()
-
-    # read empty dataframe using selectable
-    with engine.begin() as connection:
-        tbo = TableOps(table_schema, table_config.name, connection)
-        tbl = tbo.get_table_metadata()
-        select_sql = select(tbl).where("1" == "0")
-
-        df_read = DataframeOps(connection).from_selectable(select_sql)
+    df_read = read_raw_sql_from_db(engine, _sql, table_config)
 
     assert df_read.is_empty()

--- a/tests/sql/test_finality_disabled.py
+++ b/tests/sql/test_finality_disabled.py
@@ -4,17 +4,25 @@ import polars as pl
 from polars.testing import assert_frame_equal
 
 from ..utils.dsv_helper import (
+    backend_params,
     from_test_result,
     modify_and_read,
     setup_fixture_dataset,
 )
 
-pytestmark = pytest.mark.integration
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.parametrize(
+        "fixture_with_simple_table",
+        backend_params(),
+        indirect=True,
+    ),
+]
 
 
 @pytest.fixture
-def fixture_with_simple_table():
-    yield from setup_fixture_dataset("simple.yaml")
+def fixture_with_simple_table(request):
+    yield from setup_fixture_dataset("simple.yaml", request.param)
 
 
 def test_dataframe_upsert(fixture_with_simple_table):

--- a/tests/sql/test_finality_dropoff.py
+++ b/tests/sql/test_finality_dropoff.py
@@ -4,17 +4,25 @@ import polars as pl
 from polars.testing import assert_frame_equal
 
 from ..utils.dsv_helper import (
+    backend_params,
     from_test_result,
     modify_and_read,
     setup_fixture_dataset,
 )
 
-pytestmark = pytest.mark.integration
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.parametrize(
+        "fixture_with_simple_table",
+        backend_params(),
+        indirect=True,
+    ),
+]
 
 
 @pytest.fixture
-def fixture_with_simple_table():
-    yield from setup_fixture_dataset("simple.yaml")
+def fixture_with_simple_table(request):
+    yield from setup_fixture_dataset("simple.yaml", request.param)
 
 
 def test_dataframe_reinsert(fixture_with_simple_table):

--- a/tests/sql/test_foreign_keys.py
+++ b/tests/sql/test_foreign_keys.py
@@ -1,21 +1,25 @@
 import pytest
 
-from polars_hist_db.core.table_config import TableConfigOps
 from polars_hist_db.config import TableConfig
-from polars_hist_db.core.table import TableOps
-from tests.utils.dsv_helper import setup_fixture_dataset
+from tests.utils.dsv_helper import (
+    backend_params,
+    setup_fixture_dataset,
+    connection_context_for_engine,
+    commit_xtdb_connection,
+    table_config_ops_for_engine,
+)
 
 pytestmark = pytest.mark.integration
 
 
-@pytest.fixture
-def fixture_with_column_selection():
-    yield from setup_fixture_dataset("trading_pairs.yaml")
+@pytest.fixture(params=backend_params())
+def fixture_with_column_selection(request):
+    yield from setup_fixture_dataset("trading_pairs.yaml", request.param)
 
 
-@pytest.fixture
-def fixture_with_linked_tables():
-    yield from setup_fixture_dataset("trading_pairs.yaml")
+@pytest.fixture(params=backend_params())
+def fixture_with_linked_tables(request):
+    yield from setup_fixture_dataset("trading_pairs.yaml", request.param)
 
 
 def test_foreign_keys(fixture_with_linked_tables):
@@ -27,16 +31,16 @@ def test_foreign_keys(fixture_with_linked_tables):
     expected_cryptocurrency_config = table_configs["cryptocurrencies"]
     expected_trading_pair_configs = table_configs["trading_pairs"]
 
-    with engine.begin() as connection:
-        read_exchange_config = TableConfigOps(connection).from_table(
-            table_schema, "exchanges"
-        )
-        read_cryptocurrencies_config = TableConfigOps(connection).from_table(
+    with connection_context_for_engine(engine)() as connection:
+        table_config_ops = table_config_ops_for_engine(engine, connection)
+        read_exchange_config = table_config_ops.from_table(table_schema, "exchanges")
+        read_cryptocurrencies_config = table_config_ops.from_table(
             table_schema, "cryptocurrencies"
         )
-        read_trading_pair_config = TableConfigOps(connection).from_table(
+        read_trading_pair_config = table_config_ops.from_table(
             table_schema, "trading_pairs"
         )
+        commit_xtdb_connection(engine, connection)
 
     assert isinstance(read_exchange_config, TableConfig)
     assert isinstance(read_cryptocurrencies_config, TableConfig)
@@ -72,9 +76,12 @@ def test_column_selection(fixture_with_column_selection):
 
     all_column_defs = table_config.columns
 
-    with engine.begin() as connection:
-        tbo = TableOps(table_schema, table_config.name, connection)
-        tbl = tbo.get_table_metadata()
-        read_cols = tbl.columns
+    with connection_context_for_engine(engine)() as connection:
+        read_config = table_config_ops_for_engine(engine, connection).from_table(
+            table_schema,
+            table_config.name,
+        )
+        commit_xtdb_connection(engine, connection)
+        read_cols = read_config.columns
 
     assert len(all_column_defs) == len(read_cols) == 5

--- a/tests/utils/dsv_helper.py
+++ b/tests/utils/dsv_helper.py
@@ -5,18 +5,23 @@ from io import StringIO
 import os
 from pathlib import Path
 import random
+import subprocess
 import tempfile
 import textwrap
+import time
 from types import MappingProxyType
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import polars as pl
+import pytest
 import sqlalchemy
-from sqlalchemy import Engine, Select, select
+from sqlalchemy import Engine, Select, select, text
 from sqlalchemy.dialects import mysql
 
 from sqlalchemy import create_engine
 
+from polars_hist_db.backends import DbEngineConfig, backend_from_config
+from polars_hist_db.backends.xtdb import XtdbBackend
 from polars_hist_db.config.parser_config import IngestionColumnConfig
 from polars_hist_db.loaders import load_typed_dsv
 from polars_hist_db.config import (
@@ -29,7 +34,6 @@ from polars_hist_db.core import (
     AuditOps,
     DataframeOps,
     DbOps,
-    TableConfigOps,
     TableOps,
 )
 from polars_hist_db.types import PolarsType, SQLAlchemyType
@@ -60,6 +64,61 @@ def mariadb_engine_test() -> Engine:
         pool_size=3,
         max_overflow=2,
         connect_args={"client_flag": 0},
+    )
+
+
+def backend_params():
+    return [
+        "mariadb",
+        pytest.param(
+            "xtdb",
+            marks=pytest.mark.skipif(
+                os.environ.get("POLARS_HIST_DB_XTDB_LIVE") != "1",
+                reason="set POLARS_HIST_DB_XTDB_LIVE=1 to run XTDB parity tests",
+            ),
+        ),
+    ]
+
+
+def _docker(args: list[str]) -> str:
+    return subprocess.check_output(["docker", *args], text=True).strip()
+
+
+def _published_port(container_id: str) -> int:
+    output = _docker(["port", container_id, "5432/tcp"])
+    first_binding = output.splitlines()[0]
+    return int(first_binding.rsplit(":", 1)[1])
+
+
+def xtdb_engine_test() -> tuple[Engine, str]:
+    container_id = _docker(
+        ["run", "--rm", "-d", "-p", "5432", "ghcr.io/xtdb/xtdb:nightly"]
+    )
+    config = DbEngineConfig(
+        backend="xtdb",
+        hostname="127.0.0.1",
+        port=_published_port(container_id),
+    )
+    engine = XtdbBackend().create_engine(config)
+    deadline = time.monotonic() + 60
+    while True:
+        try:
+            with engine.connect() as connection:
+                connection.execute(text("SELECT 1"))
+            break
+        except Exception:
+            if time.monotonic() > deadline:
+                engine.dispose()
+                subprocess.run(["docker", "rm", "-f", container_id], check=False)
+                raise
+            time.sleep(1)
+
+    return engine, container_id
+
+
+def _backend_from_engine(engine: Engine):
+    return getattr(
+        engine, "_polars_hist_db_backend", backend_from_config(DbEngineConfig())
     )
 
 
@@ -183,21 +242,33 @@ def from_test_result(
     return df
 
 
-def setup_fixture_dataset(test_file: str):
+def setup_fixture_dataset(test_file: str, backend_name: str = "mariadb"):
     config = PolarsHistDbConfig.from_yaml(get_test_config(test_file))
-    engine = mariadb_engine_test()
+    container_id = None
+    if backend_name == "mariadb":
+        engine = mariadb_engine_test()
+        backend = backend_from_config(DbEngineConfig(backend="mariadb"))
+    elif backend_name == "xtdb":
+        engine, container_id = xtdb_engine_test()
+        backend = backend_from_config(DbEngineConfig(backend="xtdb"))
+    else:
+        raise ValueError(f"unsupported test backend {backend_name!r}")
+    engine._polars_hist_db_backend = backend  # type: ignore[attr-defined]
 
     table_schema = config.tables.schemas()[0]
     table_configs = config.tables
     audit_table = AuditOps(table_schema)
 
-    with engine.begin() as connection:
-        TableConfigOps(connection).drop_all(table_configs)
-        audit_table.drop(connection)
+    connection_context = engine.connect if backend.name == "xtdb" else engine.begin
+    with connection_context() as connection:
+        backend.table_configs(connection).drop_all(table_configs)
+        if backend.name == "mariadb":
+            audit_table.drop(connection)
 
         for tc in table_configs.items:
-            DbOps(connection).db_create(tc.schema)
-            TableConfigOps(connection).create(tc)
+            if backend.name == "mariadb":
+                DbOps(connection).db_create(tc.schema)
+            backend.table_configs(connection).create(tc)
             if tc.schema != table_schema:
                 raise ValueError(
                     "mixed-schema tests not supported (to keep things simple)"
@@ -205,9 +276,71 @@ def setup_fixture_dataset(test_file: str):
 
     yield engine, config
 
-    with engine.begin() as connection:
-        TableConfigOps(connection).drop_all(table_configs)
-        audit_table.drop(connection)
+    try:
+        with connection_context() as connection:
+            backend.table_configs(connection).drop_all(table_configs)
+            if backend.name == "mariadb":
+                audit_table.drop(connection)
+    finally:
+        engine.dispose()
+        if container_id is not None:
+            subprocess.run(["docker", "rm", "-f", container_id], check=False)
+
+
+def _normalise_xtdb_dataframe(
+    df: pl.DataFrame,
+    table_config: TableConfig,
+    include_temporal_columns: bool,
+) -> pl.DataFrame:
+    primary_keys = list(table_config.primary_keys)
+    if "_id" in df.columns:
+        if len(primary_keys) == 1 and primary_keys[0] not in df.columns:
+            df = df.rename({"_id": primary_keys[0]})
+        else:
+            df = df.drop("_id")
+
+    if include_temporal_columns and table_config.is_temporal:
+        for column in ["_valid_from", "_valid_to"]:
+            if (
+                column in df.columns
+                and isinstance(df[column].dtype, pl.Datetime)
+                and getattr(df[column].dtype, "time_zone", None) is not None
+            ):
+                df = df.with_columns(pl.col(column).dt.replace_time_zone(None))
+        if "_valid_to" in df.columns:
+            df = df.with_columns(
+                pl.col("_valid_to").fill_null(
+                    datetime.fromisoformat("2106-02-07T06:28:15.999999")
+                )
+            )
+        df = df.rename(
+            {
+                col: f"_{col}"
+                for col in ["_valid_from", "_valid_to"]
+                if col in df.columns
+            }
+        )
+    else:
+        df = df.drop([col for col in ["_valid_from", "_valid_to"] if col in df.columns])
+
+    configured_columns = [column.name for column in table_config.columns]
+    if include_temporal_columns and table_config.is_temporal:
+        configured_columns = [*configured_columns, "__valid_from", "__valid_to"]
+    selected_columns = [column for column in configured_columns if column in df.columns]
+    df = df.select(selected_columns)
+
+    configured_dtypes = {
+        column.name: PolarsType.from_sql(column.data_type)
+        for column in table_config.columns
+        if column.name in df.columns
+    }
+    if include_temporal_columns and table_config.is_temporal:
+        for column in ["_valid_from", "_valid_to", "__valid_from", "__valid_to"]:
+            if column in df.columns:
+                configured_dtypes[column] = pl.Datetime("us")
+    return df.with_columns(
+        pl.col(column).cast(dtype) for column, dtype in configured_dtypes.items()
+    ).pipe(PolarsType.cast_str_to_cat)
 
 
 def read_df_from_db(
@@ -227,8 +360,43 @@ def read_df_from_db(
         asof_date = datetime.now(timezone.utc)
     table_name = table_config.name
     primary_keys = list(table_config.primary_keys)
+    backend = _backend_from_engine(engine)
 
-    with engine.begin() as connection:
+    connection_context = engine.connect if backend.name == "xtdb" else engine.begin
+    with connection_context() as connection:
+        if backend.name == "xtdb":
+            dataframe_ops = backend.dataframes(connection)
+            if table_config.is_temporal and not return_view:
+                df_read = dataframe_ops.from_raw_sql(
+                    f"SELECT *, _valid_from, _valid_to FROM {table_schema}.{table_name}"
+                )
+            else:
+                df_read = dataframe_ops.from_table(table_schema, table_name)
+            df_read = _normalise_xtdb_dataframe(
+                df_read,
+                table_config,
+                include_temporal_columns=table_config.is_temporal and not return_view,
+            ).sort(primary_keys)
+
+            if not table_config.is_temporal or return_view:
+                return df_read, None
+
+            df_read_history = dataframe_ops.from_raw_sql(
+                f"""
+                SELECT *, _valid_from, _valid_to
+                FROM {table_schema}.{table_name}
+                FOR VALID_TIME ALL
+                WHERE _valid_to IS NOT NULL
+                  AND _valid_to <= TIMESTAMP '{asof_date.isoformat()}'
+                """
+            )
+            df_read_history = _normalise_xtdb_dataframe(
+                df_read_history,
+                table_config,
+                include_temporal_columns=True,
+            ).sort(primary_keys + ["__valid_from"])
+            return df_read, df_read_history
+
         tbo = TableOps(table_schema, table_name, connection)
         table = tbo.get_table_metadata()
         df_read = (
@@ -257,6 +425,47 @@ def read_df_from_db(
         return df_read, df_read_history
 
 
+def read_raw_sql_from_db(
+    engine: Engine,
+    query: str,
+    table_config: Optional[TableConfig] = None,
+) -> pl.DataFrame:
+    backend = _backend_from_engine(engine)
+    connection_context = engine.connect if backend.name == "xtdb" else engine.begin
+    with connection_context() as connection:
+        df = backend.dataframes(connection).from_raw_sql(query)
+
+    if backend.name == "xtdb" and table_config is not None:
+        df = _normalise_xtdb_dataframe(
+            df,
+            table_config,
+            include_temporal_columns=False,
+        )
+    return df
+
+
+def get_test_backend_name(engine: Engine) -> str:
+    return _backend_from_engine(engine).name
+
+
+def connection_context_for_engine(engine: Engine):
+    backend = _backend_from_engine(engine)
+    return engine.connect if backend.name == "xtdb" else engine.begin
+
+
+def dataframe_ops_for_engine(engine: Engine, connection):
+    return _backend_from_engine(engine).dataframes(connection)
+
+
+def table_config_ops_for_engine(engine: Engine, connection):
+    return _backend_from_engine(engine).table_configs(connection)
+
+
+def commit_xtdb_connection(engine: Engine, connection):
+    if _backend_from_engine(engine).name == "xtdb":
+        connection.commit()
+
+
 def modify_and_read(
     engine: Engine,
     df: pl.DataFrame,
@@ -268,12 +477,34 @@ def modify_and_read(
     as_override: bool = False,
     return_view: bool = False,
 ) -> Tuple[pl.DataFrame, Optional[pl.DataFrame]]:
-    with engine.begin() as connection:
+    backend = _backend_from_engine(engine)
+    connection_context = engine.connect if backend.name == "xtdb" else engine.begin
+    with connection_context() as connection:
         # config = (
         #     table_config.generate_overrides_config() if as_override else table_config
         # )
         config = table_config
-        if operation == "delete":
+        if backend.name == "xtdb":
+            if operation == "delete":
+                raise NotImplementedError("XTDB test helper delete is not implemented")
+            assert dataset.delta_config is not None
+            if app_time is not None and "_valid_from" not in df.columns:
+                df = df.with_columns(
+                    pl.lit(app_time.replace(tzinfo=None)).alias("_valid_from")
+                )
+            backend.temporal_upsert(
+                df,
+                table_schema,
+                config.name,
+                connection=connection,
+                table_config=config,
+                delta_config=dataset.delta_config,
+                valid_time=dataset.valid_time_for_table(table_schema, config.name),
+                dropout_close_time=(
+                    app_time.replace(tzinfo=None) if app_time is not None else None
+                ),
+            )
+        elif operation == "delete":
             DataframeOps(connection).table_delete_rows_temporal(
                 df, table_schema, config.name, app_time
             )

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,58 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "adbc-driver-flightsql"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "adbc-driver-manager" },
+    { name = "importlib-resources" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/d8/b0bf88456d9acf85812b1d28568f3c3f80019d2b52d2131d28daea259d1e/adbc_driver_flightsql-1.11.0.tar.gz", hash = "sha256:75f703eef1812c3932e5f4643c5e21b5690b23df7e09e88b727f7952aa559f2a", size = 34941, upload-time = "2026-04-07T00:17:26.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/af/3e40778760257b594df4efc0b12cbfe3c182bdcb69f67a9730cfad5e9cae/adbc_driver_flightsql-1.11.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:6cceffd95af5cdf5f3be051629de6bfd65744e591177b0f8176cd6810725e8f0", size = 8014539, upload-time = "2026-04-07T00:14:57.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/6ae41136909c88fc85c913b008d3d9878683289a851ec78924ab11c9e3bc/adbc_driver_flightsql-1.11.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2e716c15bfad65c489d13a49528de5bcce72179fb8024be19353b143af5749fd", size = 7437919, upload-time = "2026-04-07T00:15:04.504Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/37/d8d12630ebbe336517b42aed9d9d4deab91e2bee153a1cba6ea9af9c5026/adbc_driver_flightsql-1.11.0-py3-none-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cabff560abcf18cebef0bf24bb2886d145bae340e8eef18cf0b6642e09fa349d", size = 14696685, upload-time = "2026-04-07T00:15:07.644Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/d2/18147e9fda30d41644ef75c9b30a19c8bc39734b3308e127b17747079e93/adbc_driver_flightsql-1.11.0-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6252f0a4c8a6240d51b61dcefed88fb3d9fa1e5bcc67cb954c94907f447b744d", size = 13471551, upload-time = "2026-04-07T00:15:10.792Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e4/343f698d0377db4a99009af3cf4ce8dbdc36f1578d9be71e128ee2e3a225/adbc_driver_flightsql-1.11.0-py3-none-win_amd64.whl", hash = "sha256:955865ed9a5746073a7b78c291ebb59aaaeaf0244e394b1e5a037c53cf61900c", size = 14475054, upload-time = "2026-04-07T00:15:14.949Z" },
+]
+
+[[package]]
+name = "adbc-driver-manager"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/5e/50aab18cb501e42d3aca3cd2cc26c6637094fcaf5b6576e350c444188f1f/adbc_driver_manager-1.11.0.tar.gz", hash = "sha256:c64aaabeb5810109ab3d2961008f1b014e9f2d87b3df4416c2a080a40237af50", size = 233059, upload-time = "2026-04-07T00:17:28.263Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/42/424980ae511ccb779ab31f80890e29294bf8f1ace23b2a4a37baa3a11aca/adbc_driver_manager-1.11.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:08d3008cd6fee3d27b6265864b134902baacf00cd441dc750fb738615290004f", size = 610890, upload-time = "2026-04-07T00:15:45.138Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/66/5522e19e7f8c653a9031806175539479a4854d52a92acf449f703dc424cf/adbc_driver_manager-1.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:08f0a6e8030676b7fda5ffe095c33a819a15114541089b8d0fa8281d2dee2079", size = 585005, upload-time = "2026-04-07T00:15:47.094Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/78/106987c8abe88feeb6c0e6e837549a77aebfd0ecb7dfbdcad953d7e8f66e/adbc_driver_manager-1.11.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb33beabe3a697a54ffcc9593b94705688f33b64741a17f7bdd37690f85a0ecf", size = 4687350, upload-time = "2026-04-07T00:15:49.743Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/bf/c203675aeaf204cbeb21b6da8d9d1a28ba78c180aa6fa7bc31a7386a7ee6/adbc_driver_manager-1.11.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dba5306b90932e8af5e4a71756eec2f717f5fe283b1ad7cc7fb094fe4ef3f0f9", size = 4769988, upload-time = "2026-04-07T00:15:51.939Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/84/b31be789afede9e7bdaffab74effe7aef5d2ac3068ef2694f36b5b7dd334/adbc_driver_manager-1.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:e5e9962e6e737e1c028cacb38c08141a8730f5c90cd397537413012ece901cc5", size = 772321, upload-time = "2026-04-07T00:15:54.365Z" },
+    { url = "https://files.pythonhosted.org/packages/57/a4/a5e1a49b88bc248a6489fd5221369aca0df06761b858af926e702f36abb7/adbc_driver_manager-1.11.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:300b07f4c1113b113e18dddcb9d96dd8b84f09fa35f8e4e3e8a2f112f291142c", size = 608355, upload-time = "2026-04-07T00:15:55.907Z" },
+    { url = "https://files.pythonhosted.org/packages/30/38/21bf51455d170199981462ecb8765153d1340dcff3f696910f44fe0535e5/adbc_driver_manager-1.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f577be7c4730a43bae08f88105317d7e1d519d02a94aaa98da694358084a4735", size = 582871, upload-time = "2026-04-07T00:15:57.605Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/aa/40bdf0f612bd88eb2fdad70e1cd3f88b8619a0ec66c312acd61170f61837/adbc_driver_manager-1.11.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c980f81730752cdb98881357c238e87110e1810e4a69c7627c2211bd576b6230", size = 4670178, upload-time = "2026-04-07T00:15:59.516Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/8dcb40ed4f4ce3ccd1bda988e8d8bd37984ba223a339433d336502966697/adbc_driver_manager-1.11.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cbc93830500a2f0db7b32501a4f88678fac14b9a9921d94d919439a5b65099e6", size = 4746822, upload-time = "2026-04-07T00:16:02.437Z" },
+    { url = "https://files.pythonhosted.org/packages/07/b9/df5ac9db38ce4b683d19d94fb8a296d48306b1712d93f38ef25d7c36c253/adbc_driver_manager-1.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:0c27cff12cdf074d9052bf8c4775ed1904053189a70497fa7b5746f0dbe326d8", size = 771492, upload-time = "2026-04-07T00:16:15.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/af/4e050e6dbb0dfed99d631351bc47b6520d073529ac619bbecb5ad4adf015/adbc_driver_manager-1.11.0-cp313-cp313t-macosx_10_15_x86_64.whl", hash = "sha256:d8fdeb10ea464dce88feffe23f35cc37a44ac6bad4e90e793416a3c60afb354f", size = 625664, upload-time = "2026-04-07T00:16:04.311Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/a009ecc7f889feb9cf3546bfb4e998ac88399eb06e2c75dd7d2972384bf7/adbc_driver_manager-1.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cc565ed5d9f8c7974bbaff60c30c8330dae5a903592618a303291db4227b3d54", size = 603642, upload-time = "2026-04-07T00:16:06.758Z" },
+    { url = "https://files.pythonhosted.org/packages/53/c4/15af4bf5a3bfb76eead95a8cd5e1117098e64d046c3bb6eea0f502266523/adbc_driver_manager-1.11.0-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9523ca4e8943aa7b43958762bc9d1cb0b5355cd84855359a91c54a4bae9a75df", size = 4733746, upload-time = "2026-04-07T00:16:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/40/72/dd76e63f8e787f2c313354e51152750f802061e21b4511e1bd9db467eca1/adbc_driver_manager-1.11.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54dc142fc8065e13c6347fb3f2acb48430e3cab6863f27276a2b53594cc055b5", size = 4773869, upload-time = "2026-04-07T00:16:13.438Z" },
+    { url = "https://files.pythonhosted.org/packages/73/98/7a94f2aa7dbf470d4933a059bd66ee830fcea64422f95513dc9ab5fab910/adbc_driver_manager-1.11.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6fcd6fe4f82f8f2fc83948ed2b0b549d0831253d449f5734603cc03850e4f47", size = 609370, upload-time = "2026-04-07T00:16:18.336Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/bd62e3094a07bb5a3eebd4e185953df02e1b3582091872457899a1a12d74/adbc_driver_manager-1.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4b4293fc88d0683b6ea9fe1b7d7498c5ae9b4f53a93369c760cfa753a22039c0", size = 585560, upload-time = "2026-04-07T00:16:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6c/4aabac7ed4d5944f544b7cf7881d50fe4b34eac908605291b633a53be875/adbc_driver_manager-1.11.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a2d6d1971ce104e41e3969afee8d5782ebcb06bf496606aa4eed2005fbead43", size = 4668783, upload-time = "2026-04-07T00:16:23.798Z" },
+    { url = "https://files.pythonhosted.org/packages/47/67/3bf52e5ec427b0b88cbaa8e059b6c79851db0742db712a5f58a0e3f666be/adbc_driver_manager-1.11.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24ef0e33bab3b0480e85d954f88664b578ea045efdc644681c5a487982818e5f", size = 4735326, upload-time = "2026-04-07T00:16:27.348Z" },
+    { url = "https://files.pythonhosted.org/packages/33/64/5247eb91f9902e7111bf7a75c1af4da7a1818e31a26a754d97d0f0df7dcb/adbc_driver_manager-1.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:830efd3f212a6360ad66c09fd95171a26a1006a51c893f72238dfb50e0f35e13", size = 789628, upload-time = "2026-04-07T00:16:42.101Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/9186febf1a550f7d8935aa9842bffbe3ff9848de2bdef066acd6a86f5bf8/adbc_driver_manager-1.11.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b5e97d4cb3f5a798e18c802dd1f3d1bf7b77d763cdc707ac295907bf223d1ae8", size = 626086, upload-time = "2026-04-07T00:16:29.184Z" },
+    { url = "https://files.pythonhosted.org/packages/11/53/6e988bfbf8292cbf59b663e1e3ba6efe94f703c74061f8c0d2b182963899/adbc_driver_manager-1.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2e4e155cae12667aa383750d879e177ada3ab0c351f8306d96e33fbe6949f6f4", size = 604608, upload-time = "2026-04-07T00:16:31.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d6/e9cb77e9840b12382da49cc22a93c224d9607969b76b0062bf6114119f61/adbc_driver_manager-1.11.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfb736661f95eb8fc185a4b9951b2e61734633c7448e8d3d937e93ef1d9e5c08", size = 4738703, upload-time = "2026-04-07T00:16:34.416Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b3/c1b800c313e4e2cb7bec4a5334d4c89329eb021317c9fb3e3794a49e02d0/adbc_driver_manager-1.11.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e87a6f2b70baf21d3c52b280a17e2e8516197a4670b9a080a07dd255f2ab6e9d", size = 4778585, upload-time = "2026-04-07T00:16:37.775Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3d/dc32f50d0ad1d748461422c7a6cad2a49b778aa4fdcbebe08e38789d7898/adbc_driver_manager-1.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b853e613c6c8afbe7a3fcea0098c88b935a4d1e1b046813aed1fe7363c7b8fc7", size = 830178, upload-time = "2026-04-07T00:16:40.247Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -593,6 +645,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "importlib-resources"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
 ]
 
 [[package]]
@@ -1457,14 +1518,14 @@ wheels = [
 
 [[package]]
 name = "polars"
-version = "1.39.3"
+version = "1.42.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "polars-runtime-32" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/ab/f19e592fce9e000da49c96bf35e77cef67f9cb4b040bfa538a2764c0263e/polars-1.39.3.tar.gz", hash = "sha256:2e016c7f3e8d14fa777ef86fe0477cec6c67023a20ba4c94d6e8431eefe4a63c", size = 728987, upload-time = "2026-03-20T11:16:24.836Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/91/a1d7809a6d399f0aa78d4d3a4f4daf411cb97ccfe7f236c08a01be5fc8a5/polars-1.42.0.tar.gz", hash = "sha256:283ddc923e47857924fbef36580d2e98d984a47c962bae4cbce9c0ebcc98989c", size = 740984, upload-time = "2026-06-24T05:20:13.727Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/db/08f4ca10c5018813e7e0b59e4472302328b3d2ab1512f5a2157a814540e0/polars-1.39.3-py3-none-any.whl", hash = "sha256:c2b955ccc0a08a2bc9259785decf3d5c007b489b523bf2390cf21cec2bb82a56", size = 823985, upload-time = "2026-03-20T11:14:23.619Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4d/094819d251f2248999cb722125fd4e44ee79b753fe535338cbf442fbf45d/polars-1.42.0-py3-none-any.whl", hash = "sha256:ab10cac3f2d28a6e22e22bcac69c0e51fb33cd25aee1f45105782d4fe55a3e6a", size = 836855, upload-time = "2026-06-24T05:18:18.204Z" },
 ]
 
 [package.optional-dependencies]
@@ -1498,6 +1559,10 @@ nats = [
 sqlalchemy = [
     { name = "polars", extra = ["sqlalchemy"] },
 ]
+xtdb = [
+    { name = "adbc-driver-flightsql" },
+    { name = "psycopg", extra = ["binary"] },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1516,11 +1581,13 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "adbc-driver-flightsql", marker = "extra == 'xtdb'", specifier = ">=1.10.0" },
     { name = "nats-py", specifier = ">=2.14.0" },
     { name = "nats-py", marker = "extra == 'nats'" },
     { name = "pandas", specifier = ">=3.0.2" },
-    { name = "polars", extras = ["sqlalchemy"], specifier = ">=1.39.3" },
+    { name = "polars", extras = ["sqlalchemy"], specifier = ">=1.41.2" },
     { name = "polars", extras = ["sqlalchemy"], marker = "extra == 'sqlalchemy'" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'xtdb'", specifier = ">=3.2.2" },
     { name = "pyarrow", specifier = ">=23.0.1" },
     { name = "pymysql", specifier = ">=1.1.2" },
     { name = "pytz", specifier = ">=2026.1.post1" },
@@ -1529,7 +1596,7 @@ requires-dist = [
     { name = "sql-metadata", specifier = ">=2.20.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.49" },
 ]
-provides-extras = ["sqlalchemy", "nats"]
+provides-extras = ["sqlalchemy", "nats", "xtdb"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1548,18 +1615,18 @@ dev = [
 
 [[package]]
 name = "polars-runtime-32"
-version = "1.39.3"
+version = "1.42.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/17/39/c8688696bc22b6c501e3b82ef3be10e543c07a785af5660f30997cd22dd2/polars_runtime_32-1.39.3.tar.gz", hash = "sha256:c728e4f469cafab501947585f36311b8fb222d3e934c6209e83791e0df20b29d", size = 2872335, upload-time = "2026-03-20T11:16:26.581Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/67/20759e9abbc61910cf948f5c28986ab25ef9e8009099b469d64d6a34a478/polars_runtime_32-1.42.0.tar.gz", hash = "sha256:c927e1930881fe0bf9629d12e5d44ebd4ecef2bfa02374dfc79feaa24054394f", size = 3042711, upload-time = "2026-06-24T05:20:15.715Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/74/1b41205f7368c9375ab1dea91178eaa20435fe3eff036390a53a7660b416/polars_runtime_32-1.39.3-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:425c0b220b573fa097b4042edff73114cc6d23432a21dfd2dc41adf329d7d2e9", size = 45273243, upload-time = "2026-03-20T11:14:26.691Z" },
-    { url = "https://files.pythonhosted.org/packages/90/bf/297716b3095fe719be20fcf7af1d2b6ab069c38199bbace2469608a69b3a/polars_runtime_32-1.39.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:ef5884711e3c617d7dc93519a7d038e242f5741cfe5fe9afd32d58845d86c562", size = 40842924, upload-time = "2026-03-20T11:14:31.154Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/3e/e65236d9d0d9babfa0ecba593413c06530fca60a8feb8f66243aa5dba92e/polars_runtime_32-1.39.3-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06b47f535eb1f97a9a1e5b0053ef50db3a4276e241178e37bbb1a38b1fa53b14", size = 43220650, upload-time = "2026-03-20T11:14:35.458Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/15/fc3e43f3fdf3f20b7dfb5abe871ab6162cf8fb4aeabf4cfad822d5dc4c79/polars_runtime_32-1.39.3-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8bc9e13dc1d2e828331f2fe8ccbc9757554dc4933a8d3e85e906b988178f95ed", size = 46877498, upload-time = "2026-03-20T11:14:40.14Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/81/bd5f895919e32c6ab0a7786cd0c0ca961cb03152c47c3645808b54383f31/polars_runtime_32-1.39.3-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:363d49e3a3e638fc943e2b9887940300a7d06789930855a178a4727949259dc2", size = 43380176, upload-time = "2026-03-20T11:14:45.566Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/3e/c86433c3b5ec0315bdfc7640d0c15d41f1216c0103a0eab9a9b5147d6c4c/polars_runtime_32-1.39.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7c206bdcc7bc62ea038d6adea8e44b02f0e675e0191a54c810703b4895208ea4", size = 46485933, upload-time = "2026-03-20T11:14:51.155Z" },
-    { url = "https://files.pythonhosted.org/packages/54/ce/200b310cf91f98e652eb6ea09fdb3a9718aa0293ebf113dce325797c8572/polars_runtime_32-1.39.3-cp310-abi3-win_amd64.whl", hash = "sha256:d66ca522517554a883446957539c40dc7b75eb0c2220357fb28bc8940d305339", size = 46995458, upload-time = "2026-03-20T11:14:56.074Z" },
-    { url = "https://files.pythonhosted.org/packages/da/76/2d48927e0aa2abbdde08cbf4a2536883b73277d47fbeca95e952de86df34/polars_runtime_32-1.39.3-cp310-abi3-win_arm64.whl", hash = "sha256:f49f51461de63f13e5dd4eb080421c8f23f856945f3f8bd5b2b1f59da52c2860", size = 41857648, upload-time = "2026-03-20T11:15:01.142Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/62/8b83fca67d478e4a2b88cbba2fbff4d533052938ff96d598b7915fd9d235/polars_runtime_32-1.42.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d235a5e8349797c16b70ad573fb9ddbd7f162796884bcbd25260908f8408affc", size = 53112358, upload-time = "2026-06-24T05:18:22.275Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/72/06d3d78b7e8e8d3c72ea9eee310950334d50986462b3c1d40f82972495a5/polars_runtime_32-1.42.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e7923db3bcb57e0edecde3be28629e0411414a15ef1a4c10c783ac5eadab2e1e", size = 47443757, upload-time = "2026-06-24T05:18:26.326Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/77/20241aaf919a0f63b946fb702bc14447db290ef918e2c2943ed90d50fcc1/polars_runtime_32-1.42.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42e27e2eb5909abcedb4ab4cc04ee67c5ec2b73a5640ebd8739b1b719383fa68", size = 51360855, upload-time = "2026-06-24T05:18:30.709Z" },
+    { url = "https://files.pythonhosted.org/packages/46/5c/ca14606a42628b04d82ac6ae5742ed24048bd43fbf48ae87fc4f4b9e759d/polars_runtime_32-1.42.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a3c43d4a76360bf912f8772b5ac1c23d5a8efef71408c63bba1bb0b4897a8ea", size = 57299346, upload-time = "2026-06-24T05:18:35.374Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/af/3ad0de43bbb97e91d605d7d76acb30be36269b8a8402890ab4f9892b6e26/polars_runtime_32-1.42.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:542a77b2b969e5157939bfb76cd0f372c4f42db6ccd58636fcefe0011162a418", size = 51512143, upload-time = "2026-06-24T05:18:39.771Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a5/d1133ba9d005532a6fb94544f5da09e497a8fe42c04e37c3da6faa80bd67/polars_runtime_32-1.42.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a13949abfce319de7fc4c1abee43bc9d4a4ed4d96bcc1a6037d022e4e9561d9f", size = 55214521, upload-time = "2026-06-24T05:18:43.916Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/54/0b8355ab29669560608b2864a5e54674dd78bbd48c04976607516e081107/polars_runtime_32-1.42.0-cp310-abi3-win_amd64.whl", hash = "sha256:91a07bd852c1d1ea19b3e27c974bc7b1b29ac948fdb2e785da3a6ec0f0683cad", size = 52718509, upload-time = "2026-06-24T05:18:48.202Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b9/7c46fdbd1dbbaaf77f9512d7665609d7e4c4d8c8849edb9a16c471041075/polars_runtime_32-1.42.0-cp310-abi3-win_arm64.whl", hash = "sha256:b7c5d7721b7bb2563d72785050ac099da1e2000d412f9c72a0cfb7b07779e75d", size = 46728464, upload-time = "2026-06-24T05:18:52.505Z" },
 ]
 
 [[package]]
@@ -1609,6 +1676,64 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
     { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
     { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add backend selection plumbing with MariaDB and experimental XTDB adapters, including XTDB schema metadata, dataframe insert/read support, temporal upsert, staging, audit, and valid-time handling.
- Add backend parity tooling for MariaDB vs XTDB comparisons, semantic foreign-key normalization, diagnostics, and CLI entry point.
- Document the backend contract and add focused backend/config/dataset/parity tests.

## Test Plan
- uv run --extra xtdb --with pytest --with pytest-asyncio python -m pytest -q
- uv run --extra xtdb --with ruff ruff check .
- uv run --extra xtdb --with mypy mypy .