### PR TITLE
fix: unblock XTDB upload smoke path

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -1335,11 +1335,11 @@ class XtdbTableConfigOps:
             self.drop(table_config)
 
     def drop(self, table_config: TableConfig) -> None:
-        if not self.table_exists(table_config.schema, table_config.name):
-            return
+        data_table_exists = self.table_exists(table_config.schema, table_config.name)
 
-        table_name = _qualified_table_name(table_config.schema, table_config.name)
-        _execute_xtdb_dml(self.connection, f"ERASE FROM {table_name} WHERE TRUE")
+        if data_table_exists:
+            table_name = _qualified_table_name(table_config.schema, table_config.name)
+            _execute_xtdb_dml(self.connection, f"ERASE FROM {table_name} WHERE TRUE")
 
         if self.table_exists(table_config.schema, _XTDB_TABLE_CONFIG_METADATA_TABLE):
             metadata_table = _xtdb_table_config_metadata_table(table_config.schema)
@@ -1360,25 +1360,10 @@ class XtdbTableConfigOps:
         if self.table_exists(table_config.schema, table_config.name):
             return self.from_table(table_config.schema, table_config.name)
 
-        table_name = _qualified_table_name(table_config.schema, table_config.name)
-        columns = ", ".join(_xtdb_declared_columns(table_config))
-        _execute_xtdb_dml(self.connection, f"CREATE TABLE {table_name} ({columns})")
         self._record_table_config_metadata(table_config)
         return table_config
 
     def _record_table_config_metadata(self, table_config: TableConfig) -> None:
-        if not self.table_exists(
-            table_config.schema,
-            _XTDB_TABLE_CONFIG_METADATA_TABLE,
-        ):
-            metadata_table = _xtdb_table_config_metadata_table(table_config.schema)
-            _execute_xtdb_dml(
-                self.connection,
-                f"CREATE TABLE {metadata_table} "
-                "(_id, table_schema, table_name, primary_keys_json, "
-                "id_policy, columns_json, foreign_keys_json)",
-            )
-
         primary_keys_json = json.dumps(
             list(table_config.primary_keys),
             separators=(",", ":"),
@@ -1566,12 +1551,15 @@ class XtdbStagingOps:
         )
 
         stage_config = self.stage_table_config(delta_table_config)
-        return XtdbDataframeOps(self.connection).table_insert(
+        inserted_count = XtdbDataframeOps(self.connection).table_insert(
             df,
             stage_config.schema,
             stage_config.name,
             table_config=stage_config,
         )
+        if inserted_count > 0:
+            self._stage_run_cache[stage_run_id] = df
+        return inserted_count
 
     def prepare_pipeline_item_dataframe(
         self,

--- a/polars_hist_db/core/audit.py
+++ b/polars_hist_db/core/audit.py
@@ -106,6 +106,24 @@ class AuditOps:
     def _table_sql(self) -> str:
         return f"{self.schema}.{self._table_name}"
 
+    def _xtdb_data_table_exists(self, connection: Connection) -> bool:
+        return _xtdb_table_config_ops(connection).table_exists(
+            self.schema,
+            self._table_name,
+        )
+
+    def _empty_xtdb_audit_df(self) -> pl.DataFrame:
+        return pl.DataFrame(
+            schema={
+                "audit_id": pl.Int64,
+                "table_name": pl.Utf8,
+                "data_source_type": pl.Utf8,
+                "data_source": pl.Utf8,
+                "data_source_ts": pl.Datetime("us", "UTC"),
+                "upload_ts": pl.Datetime("us", "UTC"),
+            }
+        )
+
     def create(self, connection: Connection) -> Table | TableConfig:
         if _is_xtdb_connection(connection):
             table_config = self._table_config()
@@ -183,6 +201,9 @@ class AuditOps:
     ):
         if _is_xtdb_connection(connection):
             self.create(connection)
+            if not self._xtdb_data_table_exists(connection):
+                return
+
             latest_log = _xtdb_dataframe_ops(connection).from_raw_sql(
                 "SELECT data_source_ts "
                 f"FROM {self._table_sql()} "
@@ -248,6 +269,9 @@ class AuditOps:
     ) -> pl.DataFrame:
         if _is_xtdb_connection(connection):
             self.create(connection)
+            if not self._xtdb_data_table_exists(connection):
+                return data_source_items
+
             existing_tbl_entries = (
                 _xtdb_dataframe_ops(connection)
                 .from_raw_sql(
@@ -406,6 +430,8 @@ class AuditOps:
     ) -> pl.DataFrame:
         if _is_xtdb_connection(connection):
             self.create(connection)
+            if not self._xtdb_data_table_exists(connection):
+                return self._empty_xtdb_audit_df()
 
             xtdb_filters: list[str] = []
             if target_table_name is not None:

--- a/polars_hist_db/loaders/dsv_input_source.py
+++ b/polars_hist_db/loaders/dsv_input_source.py
@@ -23,6 +23,40 @@ from ..utils.clock import Clock
 LOGGER = logging.getLogger(__name__)
 
 
+def _make_dsv_file_commit_fn(
+    bound_csv_file: str,
+    bound_file_time: Any,
+) -> Callable[[Connection, List[Tuple[str, str]]], Awaitable[bool]]:
+    async def commit_fn(
+        connection: Connection,
+        modified_tables: List[Tuple[str, str]],
+    ) -> bool:
+        result = True
+        for modified_schema, modified_table in modified_tables:
+            aops = AuditOps(modified_schema)
+            path = Path(bound_csv_file).absolute()
+            result = aops.add_entry(
+                "dsv",
+                path.as_posix(),
+                modified_table,
+                connection,
+                bound_file_time,
+            )
+
+            if not result:
+                LOGGER.error(
+                    "audit for [%s.%s - %s]: FAILED",
+                    modified_schema,
+                    modified_table,
+                    path.name,
+                )
+                raise NonRetryableException("Failed to update audit log")
+
+        return result
+
+    return commit_fn
+
+
 class DsvCrawlerInputSource(InputSource[DsvCrawlerInputConfig]):
     def __init__(
         self,
@@ -113,40 +147,7 @@ class DsvCrawlerInputSource(InputSource[DsvCrawlerInputConfig]):
 
                 partitions = self._process_payload(Path(csv_file), file_time)
 
-                def _make_commit_fn(
-                    bound_csv_file: str, bound_file_time: Any
-                ) -> Callable[[Connection, List[Tuple[str, str]]], Awaitable[bool]]:
-                    async def commit_fn(
-                        connection: Connection,
-                        modified_tables: List[Tuple[str, str]],
-                    ) -> bool:
-                        for modified_schema, modified_table in modified_tables:
-                            aops = AuditOps(modified_schema)
-                            path = Path(bound_csv_file).absolute()
-                            result: bool = aops.add_entry(
-                                "dsv",
-                                path.as_posix(),
-                                modified_table,
-                                connection,
-                                bound_file_time,
-                            )
-
-                            if not result:
-                                LOGGER.error(
-                                    "audit for [%s.%s - %s]: FAILED",
-                                    modified_schema,
-                                    modified_table,
-                                    path.name,
-                                )
-                                raise NonRetryableException(
-                                    "Failed to update audit log"
-                                )
-
-                        return result
-
-                    return commit_fn
-
-                yield partitions, _make_commit_fn(csv_file, file_time)
+                yield partitions, _make_dsv_file_commit_fn(csv_file, file_time)
 
                 pipeline_time = time.perf_counter() - start_time
                 timings.add_timing("pipeline", pipeline_time)

--- a/tests/backends/test_xtdb_audit_ops.py
+++ b/tests/backends/test_xtdb_audit_ops.py
@@ -80,6 +80,118 @@ def test_xtdb_audit_filter_items_creates_audit_table_without_sqlalchemy_inspecto
     assert [table.name for table in created_tables] == ["__audit_log"]
 
 
+def test_xtdb_audit_filter_items_returns_all_items_before_audit_data_table_exists(
+    monkeypatch,
+):
+    class _TableConfigOps:
+        def __init__(self, connection):
+            self.connection = connection
+
+        def table_exists(self, table_schema, table_name):
+            return False
+
+        def create(self, table_config):
+            return table_config
+
+    class _DataframeOps:
+        def __init__(self, connection):
+            self.connection = connection
+
+        def from_raw_sql(self, query, schema_overrides=None):
+            raise AssertionError("must not query a missing XTDB audit data table")
+
+    monkeypatch.setattr(
+        "polars_hist_db.core.audit._xtdb_table_config_ops",
+        _TableConfigOps,
+    )
+    monkeypatch.setattr("polars_hist_db.core.audit._xtdb_dataframe_ops", _DataframeOps)
+
+    source_items = pl.DataFrame(
+        {
+            "__path": ["trades.csv"],
+            "__created_at": [datetime(2026, 1, 1, tzinfo=timezone.utc)],
+        }
+    )
+    filtered_items = AuditOps("kpler").filter_items(
+        source_items,
+        "__path",
+        "__created_at",
+        "trades",
+        _XtdbConnection(),
+    )
+
+    assert filtered_items.equals(source_items)
+
+
+def test_xtdb_audit_latest_entry_is_empty_before_audit_data_table_exists(
+    monkeypatch,
+):
+    class _TableConfigOps:
+        def __init__(self, connection):
+            self.connection = connection
+
+        def table_exists(self, table_schema, table_name):
+            return False
+
+        def create(self, table_config):
+            return table_config
+
+    class _DataframeOps:
+        def __init__(self, connection):
+            self.connection = connection
+
+        def from_raw_sql(self, query, schema_overrides=None):
+            raise AssertionError("must not query a missing XTDB audit data table")
+
+    monkeypatch.setattr(
+        "polars_hist_db.core.audit._xtdb_table_config_ops",
+        _TableConfigOps,
+    )
+    monkeypatch.setattr("polars_hist_db.core.audit._xtdb_dataframe_ops", _DataframeOps)
+
+    latest_entry = AuditOps("kpler").get_latest_entry(_XtdbConnection())
+
+    assert latest_entry.is_empty()
+    assert latest_entry.schema["data_source"] == pl.Utf8
+    assert latest_entry.schema["data_source_ts"] == pl.Datetime("us", "UTC")
+
+
+def test_xtdb_audit_prevalidation_noops_before_audit_data_table_exists(monkeypatch):
+    class _TableConfigOps:
+        def __init__(self, connection):
+            self.connection = connection
+
+        def table_exists(self, table_schema, table_name):
+            return False
+
+        def create(self, table_config):
+            return table_config
+
+    class _DataframeOps:
+        def __init__(self, connection):
+            self.connection = connection
+
+        def from_raw_sql(self, query, schema_overrides=None):
+            raise AssertionError("must not query a missing XTDB audit data table")
+
+    monkeypatch.setattr(
+        "polars_hist_db.core.audit._xtdb_table_config_ops",
+        _TableConfigOps,
+    )
+    monkeypatch.setattr("polars_hist_db.core.audit._xtdb_dataframe_ops", _DataframeOps)
+
+    AuditOps("kpler").prevalidate_new_items(
+        "trades",
+        pl.DataFrame(
+            {
+                "__path": ["trades.csv"],
+                "__created_at": [datetime(2026, 1, 1, tzinfo=timezone.utc)],
+            }
+        ),
+        _XtdbConnection(),
+    )
+
+
 def test_xtdb_file_filter_uses_plain_connection_context(monkeypatch):
     class _InputSource(InputSource):
         async def next_df(self, engine):

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -7,7 +7,11 @@ import polars as pl
 import pytest
 
 from polars_hist_db.backends import DbEngineConfig, XtdbBackend
-from polars_hist_db.backends.xtdb import XtdbDataframeOps, XtdbTableConfigOps
+from polars_hist_db.backends.xtdb import (
+    XtdbDataframeOps,
+    XtdbTableConfigOps,
+    _xtdb_declared_columns,
+)
 from polars_hist_db.config import (
     DeltaConfig,
     TableColumnConfig,
@@ -619,12 +623,41 @@ def test_xtdb_table_creation_maps_mysql_compatibility_types(monkeypatch):
 
     ops.create(table_config)
 
-    statement = connection.execute.call_args_list[0].args[0]
-    assert statement.text == (
-        "CREATE TABLE test.compat_types "
-        "(_id, bool_col, bit_col, tinyint_col, mediumint_col, "
-        "datetime_col, time_col)"
-    )
+    executed_sql = [call.args[0].text for call in connection.execute.call_args_list]
+    assert all(not sql.startswith("CREATE TABLE") for sql in executed_sql)
+    assert executed_sql == [
+        "INSERT INTO test.__polars_hist_db_xtdb_table_configs "
+        "(_id, table_schema, table_name, primary_keys_json, id_policy, "
+        "columns_json, foreign_keys_json) "
+        "VALUES ('test.compat_types'::TEXT, 'test'::TEXT, 'compat_types'::TEXT, "
+        "'[\"id\"]'::TEXT, 'single-key'::TEXT, "
+        '\'[{"table":"compat_types","name":"id","data_type":"INT",'
+        '"default_value":null,"autoincrement":false,"nullable":false,'
+        '"unique_constraint":[]},{"table":"compat_types","name":"bool_col",'
+        '"data_type":"BOOL","default_value":null,"autoincrement":false,'
+        '"nullable":true,"unique_constraint":[]},{"table":"compat_types",'
+        '"name":"bit_col","data_type":"BIT","default_value":null,'
+        '"autoincrement":false,"nullable":true,"unique_constraint":[]},'
+        '{"table":"compat_types","name":"tinyint_col","data_type":"TINYINT",'
+        '"default_value":null,"autoincrement":false,"nullable":true,'
+        '"unique_constraint":[]},{"table":"compat_types","name":"mediumint_col",'
+        '"data_type":"MEDIUMINT","default_value":null,"autoincrement":false,'
+        '"nullable":true,"unique_constraint":[]},{"table":"compat_types",'
+        '"name":"datetime_col","data_type":"DATETIME","default_value":null,'
+        '"autoincrement":false,"nullable":true,"unique_constraint":[]},'
+        '{"table":"compat_types","name":"time_col","data_type":"TIME",'
+        '"default_value":null,"autoincrement":false,"nullable":true,'
+        "\"unique_constraint\":[]}]'::TEXT, '[]'::TEXT)",
+    ]
+    assert _xtdb_declared_columns(table_config) == [
+        "_id",
+        "bool_col",
+        "bit_col",
+        "tinyint_col",
+        "mediumint_col",
+        "datetime_col",
+        "time_col",
+    ]
     assert [column.data_type for column in table_config.columns[1:]] == [
         "BOOL",
         "BIT",
@@ -664,6 +697,40 @@ def test_xtdb_table_config_ops_drop_all_erases_configured_tables(monkeypatch):
 
     assert executed == [
         "ERASE FROM market.prices WHERE TRUE",
+        "DELETE FROM market.__polars_hist_db_xtdb_table_configs "
+        "WHERE _id = 'market.prices'::TEXT",
+    ]
+
+
+def test_xtdb_table_config_ops_drop_removes_metadata_without_data_table(monkeypatch):
+    executed = []
+
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb._execute_xtdb_dml",
+        lambda _connection, sql, **_kwargs: executed.append(sql),
+    )
+
+    table_config = TableConfig(
+        schema="market",
+        name="prices",
+        primary_keys=["id"],
+        columns=[TableColumnConfig("prices", "id", "INT", nullable=False)],
+    )
+
+    ops = XtdbTableConfigOps(object())
+    monkeypatch.setattr(
+        ops,
+        "table_exists",
+        Mock(
+            side_effect=lambda _schema, table: (
+                table == "__polars_hist_db_xtdb_table_configs"
+            )
+        ),
+    )
+
+    ops.drop(table_config)
+
+    assert executed == [
         "DELETE FROM market.__polars_hist_db_xtdb_table_configs "
         "WHERE _id = 'market.prices'::TEXT",
     ]
@@ -737,7 +804,7 @@ def test_xtdb_backend_create_engine_uses_configured_database(monkeypatch):
     assert calls[0][0] == "postgresql+psycopg://127.0.0.1:15432/analytics"
 
 
-def test_xtdb_table_creation_declares_configured_columns(monkeypatch):
+def test_xtdb_table_creation_records_configured_columns_without_ddl(monkeypatch):
     connection = Mock()
     connection.connection = None
     ops = XtdbTableConfigOps(connection)
@@ -756,8 +823,23 @@ def test_xtdb_table_creation_declares_configured_columns(monkeypatch):
     result = ops.create(table_config)
 
     assert result is table_config
-    statement = connection.execute.call_args_list[0].args[0]
-    assert statement.text == "CREATE TABLE test.cargos (_id, destination, cargo_mcm)"
+    executed_sql = [call.args[0].text for call in connection.execute.call_args_list]
+    assert all(not sql.startswith("CREATE TABLE") for sql in executed_sql)
+    assert executed_sql == [
+        "INSERT INTO test.__polars_hist_db_xtdb_table_configs "
+        "(_id, table_schema, table_name, primary_keys_json, id_policy, "
+        "columns_json, foreign_keys_json) "
+        "VALUES ('test.cargos'::TEXT, 'test'::TEXT, 'cargos'::TEXT, "
+        "'[\"id\"]'::TEXT, 'single-key'::TEXT, "
+        '\'[{"table":"cargos","name":"id","data_type":"BIGINT",'
+        '"default_value":null,"autoincrement":false,"nullable":false,'
+        '"unique_constraint":[]},{"table":"cargos","name":"destination",'
+        '"data_type":"VARCHAR(255)","default_value":null,"autoincrement":false,'
+        '"nullable":true,"unique_constraint":[]},{"table":"cargos",'
+        '"name":"cargo_mcm","data_type":"DECIMAL(20,6)","default_value":null,'
+        '"autoincrement":false,"nullable":true,"unique_constraint":[]}]'
+        "'::TEXT, '[]'::TEXT)",
+    ]
 
 
 def test_xtdb_table_creation_is_idempotent_when_table_exists(monkeypatch):
@@ -781,7 +863,7 @@ def test_xtdb_table_creation_is_idempotent_when_table_exists(monkeypatch):
     ops.from_table.assert_called_once_with("test", "cargos")
 
 
-def test_xtdb_table_creation_declares_composite_primary_key_columns(monkeypatch):
+def test_xtdb_table_creation_records_composite_primary_key_columns(monkeypatch):
     connection = Mock()
     connection.connection = None
     ops = XtdbTableConfigOps(connection)
@@ -801,10 +883,23 @@ def test_xtdb_table_creation_declares_composite_primary_key_columns(monkeypatch)
     result = ops.create(table_config)
 
     assert result is table_config
-    statement = connection.execute.call_args_list[0].args[0]
-    assert statement.text == (
-        "CREATE TABLE test.cargos (_id, vessel_id, cargo_id, destination)"
-    )
+    executed_sql = [call.args[0].text for call in connection.execute.call_args_list]
+    assert all(not sql.startswith("CREATE TABLE") for sql in executed_sql)
+    assert executed_sql == [
+        "INSERT INTO test.__polars_hist_db_xtdb_table_configs "
+        "(_id, table_schema, table_name, primary_keys_json, id_policy, "
+        "columns_json, foreign_keys_json) "
+        "VALUES ('test.cargos'::TEXT, 'test'::TEXT, 'cargos'::TEXT, "
+        "'[\"vessel_id\",\"cargo_id\"]'::TEXT, 'xtdb-pk-v1'::TEXT, "
+        '\'[{"table":"cargos","name":"vessel_id","data_type":"BIGINT",'
+        '"default_value":null,"autoincrement":false,"nullable":false,'
+        '"unique_constraint":[]},{"table":"cargos","name":"cargo_id",'
+        '"data_type":"BIGINT","default_value":null,"autoincrement":false,'
+        '"nullable":false,"unique_constraint":[]},{"table":"cargos",'
+        '"name":"destination","data_type":"VARCHAR(255)","default_value":null,'
+        '"autoincrement":false,"nullable":true,"unique_constraint":[]}]'
+        "'::TEXT, '[]'::TEXT)",
+    ]
 
 
 def test_xtdb_table_creation_records_primary_key_metadata(monkeypatch):
@@ -827,10 +922,6 @@ def test_xtdb_table_creation_records_primary_key_metadata(monkeypatch):
 
     executed_sql = [call.args[0].text for call in connection.execute.call_args_list]
     assert executed_sql == [
-        "CREATE TABLE test.cargos (_id, vessel_id, cargo_id)",
-        "CREATE TABLE test.__polars_hist_db_xtdb_table_configs "
-        "(_id, table_schema, table_name, primary_keys_json, id_policy, "
-        "columns_json, foreign_keys_json)",
         "INSERT INTO test.__polars_hist_db_xtdb_table_configs "
         "(_id, table_schema, table_name, primary_keys_json, id_policy, "
         "columns_json, foreign_keys_json) "

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -76,6 +76,87 @@ def test_xtdb_staging_insert_partition_uses_retained_stage_table(monkeypatch):
     }
 
 
+def test_xtdb_staging_projects_from_insert_cache_after_partition_insert(monkeypatch):
+    def table_insert(self, df, table_schema, table_name, table_config=None):
+        return df.height
+
+    from_raw_sql = Mock(
+        return_value=pl.DataFrame(
+            schema={
+                "stage_run_id": pl.String,
+                "stage_row_index": pl.Int64,
+                "cargo_id": pl.Int64,
+                "destination_name": pl.String,
+            }
+        )
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_insert",
+        table_insert,
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
+        from_raw_sql,
+    )
+
+    delta_table_config = TableConfig(
+        schema="fakedata",
+        name="cargo_stream",
+        columns=[
+            TableColumnConfig("cargo_stream", "cargo_id", "INT"),
+            TableColumnConfig("cargo_stream", "destination_name", "VARCHAR(64)"),
+        ],
+    )
+    dataset = DatasetConfig(
+        name="cargo_stream",
+        delta_table_schema="fakedata",
+        input_config={"type": "dsv", "search_paths": []},
+        pipeline=[
+            {
+                "schema": "fakedata",
+                "table": "cargos",
+                "type": "primary",
+                "columns": [
+                    {"source": "cargo_id", "target": "cargo_id"},
+                    {"source": "destination_name", "target": "destination"},
+                ],
+            }
+        ],
+    )
+    table_config = TableConfig(
+        schema="fakedata",
+        name="cargos",
+        primary_keys=["cargo_id"],
+        columns=[
+            TableColumnConfig("cargos", "cargo_id", "INT"),
+            TableColumnConfig("cargos", "destination", "VARCHAR(64)"),
+        ],
+    )
+    staging = XtdbStagingOps(object())
+
+    staging.insert_partition(
+        pl.DataFrame({"cargo_id": [1], "destination_name": ["Tokyo"]}),
+        delta_table_config,
+        "stage-1",
+        datetime(2030, 1, 1, tzinfo=timezone.utc),
+        uniqueness_col_set=["cargo_id"],
+        prefill_nulls_with_default=True,
+    )
+    result = staging.prepare_pipeline_item_dataframe(
+        "stage-1",
+        dataset,
+        0,
+        table_config,
+        valid_time=None,
+    )
+
+    assert result.to_dict(as_series=False) == {
+        "cargo_id": [1],
+        "destination": ["Tokyo"],
+    }
+    from_raw_sql.assert_not_called()
+
+
 def test_xtdb_staging_projects_pipeline_item_with_valid_time_mapping(monkeypatch):
     stage_df = pl.DataFrame(
         {

--- a/tests/loaders/test_dsv_input_source.py
+++ b/tests/loaders/test_dsv_input_source.py
@@ -1,0 +1,22 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from polars_hist_db.loaders.dsv_input_source import _make_dsv_file_commit_fn
+
+
+@pytest.mark.asyncio
+async def test_dsv_file_commit_succeeds_when_no_tables_changed(monkeypatch):
+    def fail_audit_ops(schema):
+        raise AssertionError("no audit entry should be written without changes")
+
+    monkeypatch.setattr(
+        "polars_hist_db.loaders.dsv_input_source.AuditOps", fail_audit_ops
+    )
+
+    commit_fn = _make_dsv_file_commit_fn(
+        "/tmp/source.csv",
+        datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+    assert await commit_fn(object(), []) is True


### PR DESCRIPTION
## Summary
- Stop emitting unsupported XTDB CREATE TABLE DDL and rely on metadata plus schemaless inserts.
- Handle XTDB audit/config states before the first data table exists.
- Fix DSV no-change commits and cache staged XTDB partitions to avoid stale-basis read-after-write failures.

## Verification
- uv run python -m pytest tests/backends/test_xtdb_backend.py tests/backends/test_xtdb_audit_ops.py tests/backends/test_xtdb_staging_ops.py tests/loaders/test_dsv_input_source.py
- Live XTDB smoke upload via whengas-db-uploader path wrote target rows and audit history, then smoke schemas were erased.

## Notes
- Audit rows on the current smoke cluster may require FOR VALID_TIME ALL because earlier manual smoke attempts advanced XTDB system time into the near future.