### PR TITLE
fix: preserve xtdb null column types

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -400,6 +400,49 @@ def _xtdb_insert_casts(
     return casts
 
 
+def _xtdb_configured_column_dtypes(
+    table_config: TableConfig,
+) -> dict[str, pl.DataType]:
+    document_id_columns = _xtdb_document_id_columns(table_config)
+    uses_single_source_key = len(document_id_columns) == 1
+    dtypes: dict[str, pl.DataType] = {}
+
+    for column in table_config.columns:
+        dtype = _xtdb_polars_type_or_none(column.data_type)
+        if dtype is None:
+            continue
+        target_name = (
+            "_id"
+            if uses_single_source_key and column.name == document_id_columns[0]
+            else column.name
+        )
+        dtypes[target_name] = dtype
+
+    if len(document_id_columns) > 1:
+        dtypes["_id"] = pl.String()
+    dtypes["_valid_from"] = pl.Datetime("us", "UTC")
+    dtypes["_valid_to"] = pl.Datetime("us", "UTC")
+    return dtypes
+
+
+def _apply_xtdb_configured_column_dtypes(
+    df: pl.DataFrame,
+    table_config: Optional[TableConfig],
+) -> pl.DataFrame:
+    if table_config is None:
+        return df
+
+    configured_dtypes = _xtdb_configured_column_dtypes(table_config)
+    casts = [
+        pl.col(column).cast(dtype, strict=False)
+        for column, dtype in configured_dtypes.items()
+        if column in df.columns
+    ]
+    if not casts:
+        return df
+    return df.with_columns(casts)
+
+
 def _prepare_xtdb_insert_dataframe(
     df: pl.DataFrame,
     table_config: Optional[TableConfig],
@@ -634,7 +677,7 @@ def _execute_xtdb_dml(
 
 def _xtdb_sql_literal(value: Any, cast_type: str) -> str:
     if value is None:
-        return "NULL"
+        return f"NULL::{cast_type}"
     if isinstance(value, bool):
         return f"{'TRUE' if value else 'FALSE'}::{cast_type}"
     if isinstance(value, int):
@@ -1121,6 +1164,13 @@ class XtdbDataframeOps:
         schema_overrides: Optional[Mapping[str, pl.DataType]] = None,
         time_hint: Optional[TimeHint] = None,
     ) -> pl.DataFrame:
+        if schema_overrides is None:
+            table_config = XtdbTableConfigOps(self.connection).from_table(
+                table_schema,
+                table_name,
+            )
+            schema_overrides = _xtdb_configured_column_dtypes(table_config)
+
         hint_clause = system_time_hint_clause(time_hint)
         query = f"SELECT * FROM {table_schema}.{table_name}"
         if hint_clause:
@@ -1215,6 +1265,7 @@ class XtdbDataframeOps:
         update_time: Optional[datetime] = None,
     ) -> int:
         df = _prepare_xtdb_insert_dataframe(df, table_config)
+        df = _apply_xtdb_configured_column_dtypes(df, table_config)
         driver_connection = _driver_connection(self.connection)
         if driver_connection is not None:
             if df.is_empty():
@@ -1311,6 +1362,7 @@ class XtdbAdbcDataframeOps:
             return 0
 
         df = _prepare_xtdb_insert_dataframe(df, table_config)
+        df = _apply_xtdb_configured_column_dtypes(df, table_config)
         arrow_table = _normalize_xtdb_ingest_arrow(df.to_arrow())
         with self.connection.cursor() as cursor:
             cursor.adbc_ingest(

--- a/tests/backends/test_xtdb_adbc_ops.py
+++ b/tests/backends/test_xtdb_adbc_ops.py
@@ -73,6 +73,44 @@ def test_xtdb_adbc_dataframe_ops_ingests_arrow_with_id_mapping():
     }
 
 
+def test_xtdb_adbc_dataframe_ops_ingests_null_columns_with_configured_arrow_types():
+    connection = _FakeAdbcConnection()
+    ops = XtdbAdbcDataframeOps(connection)
+    table_config = TableConfig(
+        schema="public",
+        name="cargos",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination_date", "DATETIME"),
+            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+        ],
+    )
+
+    result = ops.table_insert(
+        pl.DataFrame(
+            {
+                "id": [1],
+                "destination_date": [None],
+                "cargo_mcm": [None],
+            }
+        ),
+        "public",
+        "cargos",
+        table_config=table_config,
+    )
+
+    assert result == 1
+    _, arrow_table, _, _ = connection.cursor_instance.ingests[0]
+    assert arrow_table.schema.field("destination_date").type == pa.timestamp("us")
+    assert arrow_table.schema.field("cargo_mcm").type == pa.float64()
+    assert arrow_table.to_pydict() == {
+        "_id": [1],
+        "destination_date": [None],
+        "cargo_mcm": [None],
+    }
+
+
 def test_xtdb_adbc_dataframe_ops_reads_arrow_into_polars():
     connection = _FakeAdbcConnection()
     ops = XtdbAdbcDataframeOps(connection)

--- a/tests/backends/test_xtdb_dataframe_ops.py
+++ b/tests/backends/test_xtdb_dataframe_ops.py
@@ -4,7 +4,11 @@ from types import SimpleNamespace
 
 import polars as pl
 
-from polars_hist_db.backends.xtdb import XtdbDataframeOps, _execute_xtdb_dml
+from polars_hist_db.backends.xtdb import (
+    XtdbDataframeOps,
+    XtdbTableConfigOps,
+    _execute_xtdb_dml,
+)
 from polars_hist_db.config import TableColumnConfig, TableConfig
 from polars_hist_db.core import TimeHint
 
@@ -104,6 +108,42 @@ def test_xtdb_dataframe_ops_applies_table_time_hint():
     ops.from_raw_sql.assert_called_once_with(
         "SELECT * FROM test.cargos FOR SYSTEM_TIME AS OF '2026-01-02T03:04:05+00:00'",
         {"id": pl.Int64},
+    )
+
+
+def test_xtdb_dataframe_ops_reads_table_with_configured_schema_overrides(monkeypatch):
+    read_database = Mock(return_value=pl.DataFrame())
+    monkeypatch.setattr(pl, "read_database", read_database)
+    table_config = TableConfig(
+        schema="test",
+        name="cargos",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination_date", "DATETIME"),
+            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+        ],
+    )
+    monkeypatch.setattr(
+        XtdbTableConfigOps,
+        "from_table",
+        lambda self, table_schema, table_name: table_config,
+    )
+    connection = object()
+    ops = XtdbDataframeOps(connection)
+
+    ops.from_table("test", "cargos")
+
+    read_database.assert_called_once_with(
+        "SELECT * FROM test.cargos",
+        connection,
+        schema_overrides={
+            "_id": pl.Int64,
+            "destination_date": pl.Datetime(),
+            "cargo_mcm": pl.Float64,
+            "_valid_from": pl.Datetime("us", "UTC"),
+            "_valid_to": pl.Datetime("us", "UTC"),
+        },
     )
 
 
@@ -325,6 +365,41 @@ def test_xtdb_dataframe_ops_uses_native_casts_for_mysql_compatibility_types():
     assert "4::INTEGER" in insert_sql
     assert "'2030-01-01T12:00:00'::TIMESTAMP" in insert_sql
     assert "'12:30:00'::TIME" in insert_sql
+
+
+def test_xtdb_dataframe_ops_casts_null_values_to_configured_types():
+    driver_connection = Mock()
+    connection = Mock()
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+    ops = XtdbDataframeOps(connection)
+    table_config = TableConfig(
+        schema="test",
+        name="cargos",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
+            TableColumnConfig("cargos", "destination_date", "DATETIME"),
+            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+        ],
+    )
+
+    ops.table_insert(
+        pl.DataFrame(
+            {
+                "id": [1],
+                "destination_date": [None],
+                "cargo_mcm": [None],
+            }
+        ),
+        "test",
+        "cargos",
+        table_config=table_config,
+    )
+
+    insert_sql = driver_connection.execute.call_args_list[1].args[0]
+    assert "NULL::TIMESTAMP" in insert_sql
+    assert "NULL::DOUBLE PRECISION" in insert_sql
 
 
 def test_xtdb_backend_returns_xtdb_dataframe_ops():


### PR DESCRIPTION
## Summary
- cast XTDB insert dataframes to configured table dtypes before pgwire/ADBC serialization
- emit typed NULL literals for pgwire inserts, e.g. NULL::TIMESTAMP instead of bare NULL
- derive default schema overrides for XtdbDataframeOps.from_table() from persisted table config metadata

## Why
Prod whengas-api showed a Polars Null dtype failure after the XTDB switchover. Live inspection showed XTDB has timestamp metadata for fakedata.cargos.origin_date/destination_date, but empty or null-only result paths can still infer Polars Null unless the configured schema is applied. The write path also allowed null-only columns to be serialized as untyped Arrow null fields or bare SQL NULL values.

## Verification
- red/green verified new null-type regression tests
- make check
- uv run pytest -q
- live XTDB syntax probe accepted NULL::TIMESTAMP and NULL::DOUBLE PRECISION