### PR TITLE
fix: quote reserved XTDB insert columns

### DIFF
--- a/docs/backend-contract.qmd
+++ b/docs/backend-contract.qmd
@@ -3,7 +3,7 @@ title: "Backend Contract"
 ---
 
 This document defines the storage-backend contract for `polars-hist-db`.
-The current implementation uses MariaDB system-versioned tables, but Whengas
+The current implementation uses MariaDB system-versioned tables, but the consuming application
 should treat the stable product surface as typed Polars dataframes over
 temporal tables. A second backend, such as XTDB, should be evaluated against
 this contract before any migration is attempted.
@@ -90,7 +90,7 @@ until it passes the same contract tests.
 - Map Polars dtypes to backend-native storage types.
 - Round-trip dates, datetimes, decimals, booleans, categoricals, integers,
   floats, strings, and nulls without lossy conversion.
-- Preserve decimal precision needed by finance and gas-volume data.
+- Preserve decimal precision needed by finance and commodity-volume data.
 
 ### Reads
 
@@ -139,7 +139,7 @@ Apache Arrow, and object-storage-oriented architecture:
 - <https://github.com/xtdb/xtdb>
 - <https://docs.xtdb.com/intro/what-is-xtdb.html>
 
-Those properties are directly relevant to Whengas because the data platform is
+Those properties are directly relevant to the consuming application because the data platform is
 already Polars/Arrow-oriented and needs historical views. The same materials
 also describe a strongly ordered transaction path, with writes for a database
 processed through a single leader. That is a valuable consistency model, but it
@@ -154,7 +154,7 @@ XTDB should only move beyond spike status if it passes the following gates:
 - Delta upsert parity tests pass for inserts, updates, duplicate handling,
   unchanged-row dropping, and row-finality dropout.
 - Finance-shaped data preserves decimal precision and timestamp semantics.
-- Whengas-shaped cargo and vessel tables can be read into Arrow/Polars without
+- application-shaped record and entity tables can be read into Arrow/Polars without
   row-by-row conversion becoming the bottleneck.
 - Netbacks-style high-frequency update streams can be batched without violating
   freshness requirements.
@@ -167,7 +167,7 @@ XTDB should only move beyond spike status if it passes the following gates:
 The existing `polars-xtdb` prototype is useful prior art, but it should not be
 treated as a completed backend. It already explores XTDB reads, system-time
 columns, and basic type mapping. The current gaps are the important parts for
-Whengas:
+the consuming application:
 
 - Type mapping is incomplete for the schemas now used by `polars-hist-db`.
 - Dataset ingestion, audit tracking, delta upserts, and finality are not wired
@@ -216,7 +216,7 @@ XTDB columns surface through `information_schema`, and XTDB widens column types
 from inserted data. The adapter therefore keeps Arrow/Polars and
 `TableConfig` as the typed boundary while the spike proves whether live XTDB
 ingestion preserves the precision and nullability guarantees required by
-Whengas.
+the consuming application.
 
 The first live pgwire round trip passes against `ghcr.io/xtdb/xtdb:nightly`:
 
@@ -307,11 +307,11 @@ behaviour:
   changes. A live test proves a row with an explicit valid-time window is only
   visible inside that window.
 - Dataset configs can declare per-table valid-time mappings:
-  `valid_time: [{table: cargos, from_column: msg_timestamp}]`. The XTDB
+  `valid_time: [{table: records, from_column: msg_timestamp}]`. The XTDB
   temporal upsert path copies the configured `from_column` to `_valid_from`
   and optional `to_column` to `_valid_to`, preserving the original source
-  columns. This keeps feed semantics YAML-controlled: cargo snapshots can use
-  message/as-of time, vessel vectors can use source position time, and future
+  columns. This keeps feed semantics YAML-controlled: record snapshots can use
+  message/as-of time, entity vectors can use source position time, and future
   rate feeds can use explicit validity windows.
 - Dataset ingestion keeps an explicit staging phase for XTDB. The adapter
   writes each partition to a retained internal table named
@@ -335,11 +335,11 @@ Do not start by replacing MariaDB. Start by extracting the backend contract and
 building a minimal XTDB adapter behind it. The decision to migrate should be
 based on parity tests, representative benchmarks, and operational confidence.
 
-For Whengas, the practical default is:
+For the consuming application, the practical default is:
 
 - Keep MariaDB as the production backend while the adapter boundary is created.
 - Build XTDB as an experimental backend.
-- Compare both backends with cargo, vessel, netbacks, and pipe/storage-shaped
+- Compare both backends with record, entity, netbacks, and pipe/storage-shaped
   datasets.
 - Migrate only after typed temporal reads, writes, update visibility, and
   operational recovery are proven.

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -33,7 +33,7 @@ _XTDB_STAGE_RUN_ID_COLUMN = "stage_run_id"
 _XTDB_STAGE_ROW_INDEX_COLUMN = "stage_row_index"
 _XTDB_STAGE_PARTITION_TIME_COLUMN = "stage_partition_time"
 _XTDB_LAST_SYSTEM_TIME_KEY = "polars_hist_db_xtdb_last_system_time"
-_XTDB_RESERVED_IDENTIFIERS = {"timestamp"}
+_XTDB_RESERVED_IDENTIFIERS = {"flag", "timestamp"}
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 

--- a/tests/backends/test_parity_harness.py
+++ b/tests/backends/test_parity_harness.py
@@ -39,7 +39,7 @@ class _InputConfig:
 class _Config:
     def __init__(self):
         self.db_config = DbEngineConfig(backend="mariadb")
-        self.datasets = {"cargo_dataset": SimpleNamespace(input_config=_InputConfig())}
+        self.datasets = {"sample_dataset": SimpleNamespace(input_config=_InputConfig())}
 
 
 def test_prepare_parity_config_overrides_backend_without_mutating_source_config():
@@ -53,8 +53,8 @@ def test_prepare_parity_config_overrides_backend_without_mutating_source_config(
     prepared = prepare_parity_config(
         source,
         target,
-        dataset_name="cargo_dataset",
-        payload="id,name\n1,Bonny\n",
+        dataset_name="sample_dataset",
+        payload="id,name\n1,Alpha\n",
         payload_time=payload_time,
     )
 
@@ -62,25 +62,25 @@ def test_prepare_parity_config_overrides_backend_without_mutating_source_config(
     assert prepared.db_config.backend == "xtdb"
     assert source.db_config.backend == "mariadb"
     assert (
-        prepared.datasets["cargo_dataset"].input_config.payload == "id,name\n1,Bonny\n"
+        prepared.datasets["sample_dataset"].input_config.payload == "id,name\n1,Alpha\n"
     )
-    assert prepared.datasets["cargo_dataset"].input_config.payload_time == payload_time
-    assert source.datasets["cargo_dataset"].input_config.payload is None
+    assert prepared.datasets["sample_dataset"].input_config.payload_time == payload_time
+    assert source.datasets["sample_dataset"].input_config.payload is None
 
 
 def test_compare_backend_tables_reports_row_count_and_value_mismatches():
     left_tables = {
-        "kpler.trades": pl.DataFrame(
+        "sample.trades": pl.DataFrame(
             {"id": [1, 2], "trade_status": ["Delivered", "Loaded"]}
         ),
-        "kpler.vessel_info": pl.DataFrame({"id": [501], "name": ["A"]}),
+        "sample.entity_info": pl.DataFrame({"id": [501], "name": ["A"]}),
     }
     right_tables = {
-        "kpler.trades": pl.DataFrame(
+        "sample.trades": pl.DataFrame(
             {"id": [1, 2], "trade_status": ["Delivered", "Ballast"]}
         ),
-        "kpler.vessel_info": pl.DataFrame({"id": [501], "name": ["A"]}),
-        "kpler.location_info": pl.DataFrame({"id": [101]}),
+        "sample.entity_info": pl.DataFrame({"id": [501], "name": ["A"]}),
+        "sample.location_info": pl.DataFrame({"id": [101]}),
     }
 
     result = compare_backend_tables(
@@ -88,14 +88,14 @@ def test_compare_backend_tables_reports_row_count_and_value_mismatches():
         right_name="xtdb",
         left_tables=left_tables,
         right_tables=right_tables,
-        table_order=["kpler.trades", "kpler.vessel_info", "kpler.location_info"],
+        table_order=["sample.trades", "sample.entity_info", "sample.location_info"],
     )
 
     assert not result.is_match
-    assert result.matches == ["kpler.vessel_info"]
+    assert result.matches == ["sample.entity_info"]
     assert result.mismatches == [
         TableParityMismatch(
-            table="kpler.trades",
+            table="sample.trades",
             reason="data mismatch",
             left_rows=2,
             right_rows=2,
@@ -106,7 +106,7 @@ def test_compare_backend_tables_reports_row_count_and_value_mismatches():
             ),
         ),
         TableParityMismatch(
-            table="kpler.location_info",
+            table="sample.location_info",
             reason="missing table result",
             left_rows=None,
             right_rows=1,
@@ -119,16 +119,16 @@ def test_compare_backend_tables_caps_value_mismatch_samples():
         left_name="mariadb",
         right_name="xtdb",
         left_tables={
-            "kpler.trades": pl.DataFrame(
+            "sample.trades": pl.DataFrame(
                 {"id": [1, 2, 3], "trade_status": ["A", "B", "C"]}
             )
         },
         right_tables={
-            "kpler.trades": pl.DataFrame(
+            "sample.trades": pl.DataFrame(
                 {"id": [1, 2, 3], "trade_status": ["X", "Y", "Z"]}
             )
         },
-        table_order=["kpler.trades"],
+        table_order=["sample.trades"],
         mismatch_sample_limit=2,
     )
 
@@ -147,23 +147,23 @@ def test_compare_backend_tables_reports_unresolved_semantic_foreign_keys():
         left_name="mariadb",
         right_name="xtdb",
         left_tables={
-            "kpler.location_info": pl.DataFrame({"id": [1], "name": ["Bonny Island"]}),
-            "kpler.trades": pl.DataFrame(
+            "sample.location_info": pl.DataFrame({"id": [1], "name": ["Alpha Site"]}),
+            "sample.trades": pl.DataFrame(
                 {"id": [10, 11], "origin_location_id": [1, 999]}
             ),
         },
         right_tables={
-            "kpler.location_info": pl.DataFrame({"id": [1], "name": ["Bonny Island"]}),
-            "kpler.trades": pl.DataFrame(
+            "sample.location_info": pl.DataFrame({"id": [1], "name": ["Alpha Site"]}),
+            "sample.trades": pl.DataFrame(
                 {"id": [10, 11], "origin_location_id": [1, 999]}
             ),
         },
-        table_order=["kpler.trades"],
+        table_order=["sample.trades"],
         semantic_foreign_keys=(
             SemanticForeignKey(
-                source_table="kpler.trades",
+                source_table="sample.trades",
                 source_column="origin_location_id",
-                target_table="kpler.location_info",
+                target_table="sample.location_info",
                 target_column="id",
                 target_columns=("name",),
             ),
@@ -172,10 +172,10 @@ def test_compare_backend_tables_reports_unresolved_semantic_foreign_keys():
 
     assert result.semantic_foreign_key_diagnostics == (
         "mariadb unresolved semantic_fk "
-        "kpler.trades.origin_location_id -> kpler.location_info.id "
+        "sample.trades.origin_location_id -> sample.location_info.id "
         "using name: 1/2 source rows",
         "xtdb unresolved semantic_fk "
-        "kpler.trades.origin_location_id -> kpler.location_info.id "
+        "sample.trades.origin_location_id -> sample.location_info.id "
         "using name: 1/2 source rows",
     )
 
@@ -184,10 +184,10 @@ def test_format_backend_parity_result_includes_details_and_diagnostics():
     result = BackendParityResult(
         left_name="mariadb",
         right_name="xtdb",
-        matches=["kpler.vessel_info"],
+        matches=["sample.entity_info"],
         mismatches=[
             TableParityMismatch(
-                table="kpler.trades",
+                table="sample.trades",
                 reason="data mismatch",
                 left_rows=1,
                 right_rows=1,
@@ -196,31 +196,31 @@ def test_format_backend_parity_result_includes_details_and_diagnostics():
         ],
         semantic_foreign_key_diagnostics=(
             "xtdb unresolved semantic_fk "
-            "kpler.trades.origin_location_id -> kpler.location_info.id "
+            "sample.trades.origin_location_id -> sample.location_info.id "
             "using name: 1/2 source rows",
         ),
     )
 
     assert list(format_backend_parity_result(result)) == [
-        "PASS kpler.vessel_info",
+        "PASS sample.entity_info",
         "WARN xtdb unresolved semantic_fk "
-        "kpler.trades.origin_location_id -> kpler.location_info.id "
+        "sample.trades.origin_location_id -> sample.location_info.id "
         "using name: 1/2 source rows",
-        "FAIL kpler.trades: data mismatch (mariadb=1, xtdb=1)",
+        "FAIL sample.trades: data mismatch (mariadb=1, xtdb=1)",
         "  differing_columns=trade_status",
     ]
 
 
 def test_compare_backend_tables_can_resolve_backend_local_surrogate_keys():
     left_tables = {
-        "kpler.location_info": pl.DataFrame(
+        "sample.location_info": pl.DataFrame(
             {
                 "id": [1, 2],
-                "name": ["Bonny Island", "#Unspecified"],
+                "name": ["Alpha Site", "#Unspecified"],
                 "country": ["Nigeria", "#Unspecified"],
             }
         ),
-        "kpler.trades": pl.DataFrame(
+        "sample.trades": pl.DataFrame(
             {
                 "id": [308025, 308327],
                 "origin_location_id": [1, 2],
@@ -229,14 +229,14 @@ def test_compare_backend_tables_can_resolve_backend_local_surrogate_keys():
         ),
     }
     right_tables = {
-        "kpler.location_info": pl.DataFrame(
+        "sample.location_info": pl.DataFrame(
             {
                 "id": [1701, -1408044658],
-                "name": ["Bonny Island", "#Unspecified"],
+                "name": ["Alpha Site", "#Unspecified"],
                 "country": ["Nigeria", "#Unspecified"],
             }
         ),
-        "kpler.trades": pl.DataFrame(
+        "sample.trades": pl.DataFrame(
             {
                 "id": [308025, 308327],
                 "origin_location_id": [1701, -1408044658],
@@ -250,20 +250,20 @@ def test_compare_backend_tables_can_resolve_backend_local_surrogate_keys():
         right_name="xtdb",
         left_tables=left_tables,
         right_tables=right_tables,
-        table_order=["kpler.location_info", "kpler.trades"],
-        ignored_columns_by_table={"kpler.location_info": frozenset({"id"})},
+        table_order=["sample.location_info", "sample.trades"],
+        ignored_columns_by_table={"sample.location_info": frozenset({"id"})},
         semantic_foreign_keys=(
             SemanticForeignKey(
-                source_table="kpler.trades",
+                source_table="sample.trades",
                 source_column="origin_location_id",
-                target_table="kpler.location_info",
+                target_table="sample.location_info",
                 target_column="id",
                 target_columns=("name", "country"),
             ),
             SemanticForeignKey(
-                source_table="kpler.trades",
+                source_table="sample.trades",
                 source_column="destination_location_id",
-                target_table="kpler.location_info",
+                target_table="sample.location_info",
                 target_column="id",
                 target_columns=("name", "country"),
             ),
@@ -271,27 +271,27 @@ def test_compare_backend_tables_can_resolve_backend_local_surrogate_keys():
     )
 
     assert result.is_match
-    assert result.matches == ["kpler.location_info", "kpler.trades"]
+    assert result.matches == ["sample.location_info", "sample.trades"]
     assert result.mismatches == []
 
 
 def test_parse_semantic_foreign_key_accepts_cli_mapping():
     semantic_fk = _parse_semantic_foreign_key(
-        "kpler.trades.origin_location_id=kpler.location_info.id:name,country"
+        "sample.trades.origin_location_id=sample.location_info.id:name,country"
     )
 
     assert semantic_fk == SemanticForeignKey(
-        source_table="kpler.trades",
+        source_table="sample.trades",
         source_column="origin_location_id",
-        target_table="kpler.location_info",
+        target_table="sample.location_info",
         target_column="id",
         target_columns=("name", "country"),
     )
 
 
 def test_parse_ignore_column_accepts_qualified_column():
-    assert _parse_ignore_column("kpler.location_info.id") == (
-        "kpler.location_info",
+    assert _parse_ignore_column("sample.location_info.id") == (
+        "sample.location_info",
         "id",
     )
 
@@ -300,7 +300,7 @@ def test_parse_args_leaves_payload_time_unset_for_file_based_runs(monkeypatch):
     monkeypatch.setattr(
         sys,
         "argv",
-        ["polars-hist-db-parity", "--config", "configs/kpler.yaml"],
+        ["polars-hist-db-parity", "--config", "configs/sample.yaml"],
     )
 
     args = _parse_args()
@@ -313,11 +313,11 @@ def test_main_passes_cli_parity_rules_to_backend_parity(monkeypatch):
 
     class _Config:
         parity = SimpleNamespace(
-            ignore_columns=("kpler.location_info.id",),
+            ignore_columns=("sample.location_info.id",),
             semantic_foreign_keys=(
                 SimpleNamespace(
-                    source="kpler.trades.origin_location_id",
-                    target="kpler.location_info.id",
+                    source="sample.trades.origin_location_id",
+                    target="sample.location_info.id",
                     columns=("name", "country"),
                 ),
             ),
@@ -338,11 +338,11 @@ def test_main_passes_cli_parity_rules_to_backend_parity(monkeypatch):
         [
             "polars-hist-db-parity",
             "--config",
-            "configs/kpler.yaml",
+            "configs/sample.yaml",
             "--ignore-column",
-            "kpler.location_info.created_at",
+            "sample.location_info.created_at",
             "--semantic-fk",
-            "kpler.trades.origin_location_id=kpler.location_info.id:name,country",
+            "sample.trades.origin_location_id=sample.location_info.id:name,country",
         ],
     )
     monkeypatch.setattr(
@@ -357,13 +357,13 @@ def test_main_passes_cli_parity_rules_to_backend_parity(monkeypatch):
     main()
 
     assert captured["ignored_columns_by_table"] == {
-        "kpler.location_info": frozenset({"created_at"})
+        "sample.location_info": frozenset({"created_at"})
     }
     assert captured["semantic_foreign_keys"] == (
         SemanticForeignKey(
-            source_table="kpler.trades",
+            source_table="sample.trades",
             source_column="origin_location_id",
-            target_table="kpler.location_info",
+            target_table="sample.location_info",
             target_column="id",
             target_columns=("name", "country"),
         ),
@@ -392,7 +392,7 @@ def test_run_backend_parity_uses_parity_rules_from_config(monkeypatch):
         tables=SimpleNamespace(
             items=[
                 TableConfig(
-                    schema="kpler",
+                    schema="sample",
                     name="location_info",
                     is_temporal=False,
                     primary_keys=["id"],
@@ -403,7 +403,7 @@ def test_run_backend_parity_uses_parity_rules_from_config(monkeypatch):
                     ],
                 ),
                 TableConfig(
-                    schema="kpler",
+                    schema="sample",
                     name="trades",
                     is_temporal=True,
                     primary_keys=["id"],
@@ -420,16 +420,16 @@ def test_run_backend_parity_uses_parity_rules_from_config(monkeypatch):
             ]
         ),
         parity=SimpleNamespace(
-            ignore_columns=("kpler.location_info.id",),
+            ignore_columns=("sample.location_info.id",),
             semantic_foreign_keys=(
                 SimpleNamespace(
-                    source="kpler.trades.origin_location_id",
-                    target="kpler.location_info.id",
+                    source="sample.trades.origin_location_id",
+                    target="sample.location_info.id",
                     columns=("name", "country"),
                 ),
                 SimpleNamespace(
-                    source="kpler.trades.destination_location_id",
-                    target="kpler.location_info.id",
+                    source="sample.trades.destination_location_id",
+                    target="sample.location_info.id",
                     columns=("name", "country"),
                 ),
             ),
@@ -437,14 +437,14 @@ def test_run_backend_parity_uses_parity_rules_from_config(monkeypatch):
     )
     tables_by_backend = {
         "mariadb": {
-            "kpler.location_info": pl.DataFrame(
+            "sample.location_info": pl.DataFrame(
                 {
                     "id": [1, 2],
-                    "name": ["Bonny Island", "#Unspecified"],
+                    "name": ["Alpha Site", "#Unspecified"],
                     "country": ["Nigeria", "#Unspecified"],
                 }
             ),
-            "kpler.trades": pl.DataFrame(
+            "sample.trades": pl.DataFrame(
                 {
                     "id": [308025, 308327],
                     "origin_location_id": [1, 2],
@@ -453,14 +453,14 @@ def test_run_backend_parity_uses_parity_rules_from_config(monkeypatch):
             ),
         },
         "xtdb": {
-            "kpler.location_info": pl.DataFrame(
+            "sample.location_info": pl.DataFrame(
                 {
                     "id": [1701, -1408044658],
-                    "name": ["Bonny Island", "#Unspecified"],
+                    "name": ["Alpha Site", "#Unspecified"],
                     "country": ["Nigeria", "#Unspecified"],
                 }
             ),
-            "kpler.trades": pl.DataFrame(
+            "sample.trades": pl.DataFrame(
                 {
                     "id": [308025, 308327],
                     "origin_location_id": [1701, -1408044658],
@@ -503,7 +503,7 @@ def test_run_backend_parity_uses_parity_rules_from_config(monkeypatch):
     )
 
     assert result.is_match
-    assert result.matches == ["kpler.location_info", "kpler.trades"]
+    assert result.matches == ["sample.location_info", "sample.trades"]
 
 
 def test_parse_backend_target_accepts_named_connection_options():
@@ -530,7 +530,7 @@ def test_parse_backend_target_accepts_unnamed_connection_options():
 
 def test_table_read_sql_uses_valid_time_all_for_xtdb_tables():
     table_config = TableConfig(
-        schema="kpler",
+        schema="sample",
         name="trades",
         is_temporal=True,
         primary_keys=["id"],
@@ -540,7 +540,7 @@ def test_table_read_sql_uses_valid_time_all_for_xtdb_tables():
     system_time = datetime(2035, 1, 1, 0, 0, 1)
 
     assert _table_read_sql("xtdb", table_config, system_time=system_time) == (
-        "SELECT * FROM kpler.trades FOR VALID_TIME ALL "
+        "SELECT * FROM sample.trades FOR VALID_TIME ALL "
         "FOR SYSTEM_TIME AS OF TIMESTAMP '2035-01-01T00:00:01'"
     )
     assert _table_read_sql("mariadb", table_config, system_time=system_time) is None
@@ -548,16 +548,16 @@ def test_table_read_sql_uses_valid_time_all_for_xtdb_tables():
 
 def test_table_read_sql_uses_valid_time_asof_for_xtdb_non_temporal_tables():
     table_config = TableConfig(
-        schema="kpler",
-        name="vessel_info",
+        schema="sample",
+        name="entity_info",
         is_temporal=False,
         primary_keys=["id"],
-        columns=[TableColumnConfig("vessel_info", "id", "INT")],
+        columns=[TableColumnConfig("entity_info", "id", "INT")],
     )
     system_time = datetime(2035, 1, 1, 0, 0, 1)
 
     assert _table_read_sql("xtdb", table_config, system_time=system_time) == (
-        "SELECT * FROM kpler.vessel_info "
+        "SELECT * FROM sample.entity_info "
         "FOR VALID_TIME AS OF TIMESTAMP '2035-01-01T00:00:01' "
         "FOR SYSTEM_TIME AS OF TIMESTAMP '2035-01-01T00:00:01'"
     )

--- a/tests/backends/test_xtdb_adbc_live.py
+++ b/tests/backends/test_xtdb_adbc_live.py
@@ -81,12 +81,12 @@ def _xtdb_adbc_connection() -> Iterator[Any]:
 def test_xtdb_adbc_live_arrow_ingest_read_roundtrip():
     table_config = TableConfig(
         schema="public",
-        name=f"live_adbc_cargos_{int(time.time())}",
+        name=f"live_adbc_records_{int(time.time())}",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
-            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "amount_value", "DOUBLE"),
         ],
     )
 
@@ -97,8 +97,8 @@ def test_xtdb_adbc_live_arrow_ingest_read_roundtrip():
             pl.DataFrame(
                 {
                     "id": [1, 2],
-                    "destination": ["Tokyo", "Osaka"],
-                    "cargo_mcm": [10.5, 20.25],
+                    "destination": ["Alpha", "Beta"],
+                    "amount_value": [10.5, 20.25],
                 }
             ),
             table_config.schema,
@@ -108,24 +108,24 @@ def test_xtdb_adbc_live_arrow_ingest_read_roundtrip():
 
         result = ops.from_table(table_config.schema, table_config.name)
 
-    assert result.sort("_id").select(["_id", "destination", "cargo_mcm"]).to_dict(
+    assert result.sort("_id").select(["_id", "destination", "amount_value"]).to_dict(
         as_series=False
     ) == {
         "_id": [1, 2],
-        "destination": ["Tokyo", "Osaka"],
-        "cargo_mcm": [10.5, 20.25],
+        "destination": ["Alpha", "Beta"],
+        "amount_value": [10.5, 20.25],
     }
 
 
 def test_xtdb_adbc_live_temporal_upsert_supports_system_time_asof():
     table_config = TableConfig(
         schema="public",
-        name=f"live_adbc_temporal_cargos_{int(time.time())}",
+        name=f"live_adbc_temporal_records_{int(time.time())}",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
-            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "amount_value", "DOUBLE"),
         ],
     )
 
@@ -136,8 +136,8 @@ def test_xtdb_adbc_live_temporal_upsert_supports_system_time_asof():
             pl.DataFrame(
                 {
                     "id": [1],
-                    "destination": ["Tokyo"],
-                    "cargo_mcm": [10.5],
+                    "destination": ["Alpha"],
+                    "amount_value": [10.5],
                 }
             ),
             table_config.schema,
@@ -154,8 +154,8 @@ def test_xtdb_adbc_live_temporal_upsert_supports_system_time_asof():
             pl.DataFrame(
                 {
                     "id": [1],
-                    "destination": ["Osaka"],
-                    "cargo_mcm": [20.25],
+                    "destination": ["Beta"],
+                    "amount_value": [20.25],
                 }
             ),
             table_config.schema,
@@ -171,17 +171,17 @@ def test_xtdb_adbc_live_temporal_upsert_supports_system_time_asof():
             time_hint=TimeHint(mode="asof", asof_utc=checkpoint),
         )
 
-    assert latest.select(["_id", "destination", "cargo_mcm"]).to_dict(
+    assert latest.select(["_id", "destination", "amount_value"]).to_dict(
         as_series=False
     ) == {
         "_id": [1],
-        "destination": ["Osaka"],
-        "cargo_mcm": [20.25],
+        "destination": ["Beta"],
+        "amount_value": [20.25],
     }
-    assert asof_checkpoint.select(["_id", "destination", "cargo_mcm"]).to_dict(
+    assert asof_checkpoint.select(["_id", "destination", "amount_value"]).to_dict(
         as_series=False
     ) == {
         "_id": [1],
-        "destination": ["Tokyo"],
-        "cargo_mcm": [10.5],
+        "destination": ["Alpha"],
+        "amount_value": [10.5],
     }

--- a/tests/backends/test_xtdb_adbc_ops.py
+++ b/tests/backends/test_xtdb_adbc_ops.py
@@ -12,7 +12,7 @@ class _FakeCursor:
     def __init__(self):
         self.ingests = []
         self.executed = []
-        self.arrow_result = pa.table({"_id": [1], "destination": ["Tokyo"]})
+        self.arrow_result = pa.table({"_id": [1], "destination": ["Alpha"]})
 
     def __enter__(self):
         return self
@@ -38,14 +38,14 @@ class _FakeAdbcConnection:
         return self.cursor_instance
 
 
-def _cargo_config(schema="public"):
+def _record_config(schema="public"):
     return TableConfig(
         schema=schema,
-        name="cargos",
+        name="records",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
         ],
     )
 
@@ -55,21 +55,21 @@ def test_xtdb_adbc_dataframe_ops_ingests_arrow_with_id_mapping():
     ops = XtdbAdbcDataframeOps(connection)
 
     result = ops.table_insert(
-        pl.DataFrame({"id": [1, 2], "destination": ["Tokyo", "Osaka"]}),
+        pl.DataFrame({"id": [1, 2], "destination": ["Alpha", "Beta"]}),
         "public",
-        "cargos",
-        table_config=_cargo_config(),
+        "records",
+        table_config=_record_config(),
     )
 
     assert result == 2
     table_name, arrow_table, mode, kwargs = connection.cursor_instance.ingests[0]
-    assert table_name == "cargos"
+    assert table_name == "records"
     assert mode == "create_append"
     assert kwargs == {"db_schema_name": "public"}
     assert arrow_table.schema.field("destination").type == pa.string()
     assert arrow_table.to_pydict() == {
         "_id": [1, 2],
-        "destination": ["Tokyo", "Osaka"],
+        "destination": ["Alpha", "Beta"],
     }
 
 
@@ -78,12 +78,12 @@ def test_xtdb_adbc_dataframe_ops_ingests_null_columns_with_configured_arrow_type
     ops = XtdbAdbcDataframeOps(connection)
     table_config = TableConfig(
         schema="public",
-        name="cargos",
+        name="records",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination_date", "DATETIME"),
-            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination_date", "DATETIME"),
+            TableColumnConfig("records", "amount_value", "DOUBLE"),
         ],
     )
 
@@ -92,22 +92,22 @@ def test_xtdb_adbc_dataframe_ops_ingests_null_columns_with_configured_arrow_type
             {
                 "id": [1],
                 "destination_date": [None],
-                "cargo_mcm": [None],
+                "amount_value": [None],
             }
         ),
         "public",
-        "cargos",
+        "records",
         table_config=table_config,
     )
 
     assert result == 1
     _, arrow_table, _, _ = connection.cursor_instance.ingests[0]
     assert arrow_table.schema.field("destination_date").type == pa.timestamp("us")
-    assert arrow_table.schema.field("cargo_mcm").type == pa.float64()
+    assert arrow_table.schema.field("amount_value").type == pa.float64()
     assert arrow_table.to_pydict() == {
         "_id": [1],
         "destination_date": [None],
-        "cargo_mcm": [None],
+        "amount_value": [None],
     }
 
 
@@ -115,10 +115,10 @@ def test_xtdb_adbc_dataframe_ops_reads_arrow_into_polars():
     connection = _FakeAdbcConnection()
     ops = XtdbAdbcDataframeOps(connection)
 
-    result = ops.from_table("public", "cargos")
+    result = ops.from_table("public", "records")
 
-    assert result.to_dict(as_series=False) == {"_id": [1], "destination": ["Tokyo"]}
-    assert connection.cursor_instance.executed == ["SELECT * FROM public.cargos"]
+    assert result.to_dict(as_series=False) == {"_id": [1], "destination": ["Alpha"]}
+    assert connection.cursor_instance.executed == ["SELECT * FROM public.records"]
 
 
 def test_xtdb_adbc_dataframe_ops_targets_configured_schema():
@@ -128,8 +128,8 @@ def test_xtdb_adbc_dataframe_ops_targets_configured_schema():
     ops.table_insert(
         pl.DataFrame({"id": [1]}),
         "analytics",
-        "cargos",
-        table_config=_cargo_config(schema="analytics"),
+        "records",
+        table_config=_record_config(schema="analytics"),
     )
 
     assert connection.cursor_instance.ingests[0][3] == {"db_schema_name": "analytics"}

--- a/tests/backends/test_xtdb_audit_ops.py
+++ b/tests/backends/test_xtdb_audit_ops.py
@@ -45,7 +45,7 @@ def test_xtdb_audit_filter_items_creates_audit_table_without_sqlalchemy_inspecto
             self.connection = connection
 
         def from_raw_sql(self, query, schema_overrides=None):
-            assert "FROM kpler.__audit_log" in query
+            assert "FROM sample.__audit_log" in query
             return pl.DataFrame(
                 {
                     "data_source": [],
@@ -63,7 +63,7 @@ def test_xtdb_audit_filter_items_creates_audit_table_without_sqlalchemy_inspecto
     )
     monkeypatch.setattr("polars_hist_db.core.audit._xtdb_dataframe_ops", _DataframeOps)
 
-    filtered_items = AuditOps("kpler").filter_items(
+    filtered_items = AuditOps("sample").filter_items(
         pl.DataFrame(
             {
                 "__path": ["trades.csv"],
@@ -112,7 +112,7 @@ def test_xtdb_audit_filter_items_returns_all_items_before_audit_data_table_exist
             "__created_at": [datetime(2026, 1, 1, tzinfo=timezone.utc)],
         }
     )
-    filtered_items = AuditOps("kpler").filter_items(
+    filtered_items = AuditOps("sample").filter_items(
         source_items,
         "__path",
         "__created_at",
@@ -149,7 +149,7 @@ def test_xtdb_audit_latest_entry_is_empty_before_audit_data_table_exists(
     )
     monkeypatch.setattr("polars_hist_db.core.audit._xtdb_dataframe_ops", _DataframeOps)
 
-    latest_entry = AuditOps("kpler").get_latest_entry(_XtdbConnection())
+    latest_entry = AuditOps("sample").get_latest_entry(_XtdbConnection())
 
     assert latest_entry.is_empty()
     assert latest_entry.schema["data_source"] == pl.Utf8
@@ -180,7 +180,7 @@ def test_xtdb_audit_prevalidation_noops_before_audit_data_table_exists(monkeypat
     )
     monkeypatch.setattr("polars_hist_db.core.audit._xtdb_dataframe_ops", _DataframeOps)
 
-    AuditOps("kpler").prevalidate_new_items(
+    AuditOps("sample").prevalidate_new_items(
         "trades",
         pl.DataFrame(
             {
@@ -238,7 +238,7 @@ def test_xtdb_file_filter_uses_plain_connection_context(monkeypatch):
                 "__created_at": [datetime(2026, 1, 1, tzinfo=timezone.utc)],
             }
         ),
-        "kpler",
+        "sample",
         "trades",
         engine,
     )
@@ -274,7 +274,7 @@ def test_xtdb_audit_add_entry_writes_via_backend_dataframe_ops(monkeypatch):
     )
     monkeypatch.setattr("polars_hist_db.core.audit._xtdb_dataframe_ops", _DataframeOps)
 
-    did_insert = AuditOps("kpler").add_entry(
+    did_insert = AuditOps("sample").add_entry(
         "dsv",
         "trades.csv",
         "trades",
@@ -284,7 +284,7 @@ def test_xtdb_audit_add_entry_writes_via_backend_dataframe_ops(monkeypatch):
 
     assert did_insert is True
     [(inserted_df, table_schema, table_name, table_config)] = inserted
-    assert table_schema == "kpler"
+    assert table_schema == "sample"
     assert table_name == "__audit_log"
     assert table_config.name == "__audit_log"
     assert "audit_id" in inserted_df.columns

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -24,14 +24,14 @@ def test_xtdb_temporal_upsert_delegates_to_dataframe_insert():
     backend = XtdbBackend()
     ops = Mock()
     ops.table_insert.return_value = 2
-    df = pl.DataFrame({"id": [1, 2], "destination": ["Tokyo", "Osaka"]})
+    df = pl.DataFrame({"id": [1, 2], "destination": ["Alpha", "Beta"]})
     table_config = TableConfig(
         schema="test",
-        name="cargos",
+        name="records",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
         ],
     )
 
@@ -47,7 +47,7 @@ def test_xtdb_temporal_upsert_delegates_to_dataframe_insert():
     ops.table_insert.assert_called_once_with(
         df,
         "test",
-        "cargos",
+        "records",
         table_config=table_config,
     )
 
@@ -62,7 +62,7 @@ def test_xtdb_temporal_upsert_passes_system_time_to_dataframe_insert():
     result = backend.temporal_upsert(
         df,
         "test",
-        "cargos",
+        "records",
         dataframe_ops=ops,
         update_time=update_time,
     )
@@ -71,7 +71,7 @@ def test_xtdb_temporal_upsert_passes_system_time_to_dataframe_insert():
     ops.table_insert.assert_called_once_with(
         df,
         "test",
-        "cargos",
+        "records",
         table_config=None,
         update_time=update_time,
     )
@@ -84,7 +84,7 @@ def test_xtdb_temporal_upsert_rejects_manual_finality():
         backend.temporal_upsert(
             pl.DataFrame({"id": [1]}),
             "test",
-            "cargos",
+            "records",
             dataframe_ops=Mock(),
             delta_config=DeltaConfig(row_finality="manual"),
         )
@@ -101,24 +101,24 @@ def test_xtdb_temporal_upsert_dropout_deletes_missing_current_keys():
         return_value=pl.DataFrame(
             {
                 "_id": [1, 2],
-                "destination": ["Tokyo", "Osaka"],
+                "destination": ["Alpha", "Beta"],
             }
         )
     )
     table_config = TableConfig(
         schema="test",
-        name="cargos",
+        name="records",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
         ],
     )
 
     result = backend.temporal_upsert(
-        pl.DataFrame({"id": [1], "destination": ["Tokyo"]}),
+        pl.DataFrame({"id": [1], "destination": ["Alpha"]}),
         "test",
-        "cargos",
+        "records",
         dataframe_ops=ops,
         table_config=table_config,
         delta_config=DeltaConfig(row_finality="dropout"),
@@ -126,9 +126,9 @@ def test_xtdb_temporal_upsert_dropout_deletes_missing_current_keys():
 
     assert result == 2
     executed_sql = [call.args[0] for call in driver_connection.execute.call_args_list]
-    assert executed_sql[1] == "DELETE FROM test.cargos WHERE _id IN (2::BIGINT)"
+    assert executed_sql[1] == "DELETE FROM test.records WHERE _id IN (2::BIGINT)"
     assert executed_sql[3] == (
-        "INSERT INTO test.cargos (_id, destination) VALUES (1::BIGINT, 'Tokyo'::TEXT)"
+        "INSERT INTO test.records (_id, destination) VALUES (1::BIGINT, 'Alpha'::TEXT)"
     )
 
 
@@ -142,11 +142,11 @@ def test_xtdb_temporal_upsert_dropout_closes_missing_keys_at_valid_time():
     ops.from_raw_sql = Mock(return_value=pl.DataFrame({"_id": [1, 2]}))
     table_config = TableConfig(
         schema="test",
-        name="cargos",
+        name="records",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
         ],
     )
 
@@ -154,12 +154,12 @@ def test_xtdb_temporal_upsert_dropout_closes_missing_keys_at_valid_time():
         pl.DataFrame(
             {
                 "id": [1],
-                "destination": ["Tokyo"],
+                "destination": ["Alpha"],
                 "_valid_from": [datetime(2030, 1, 2, tzinfo=timezone.utc)],
             }
         ),
         "test",
-        "cargos",
+        "records",
         dataframe_ops=ops,
         table_config=table_config,
         delta_config=DeltaConfig(row_finality="dropout"),
@@ -168,7 +168,7 @@ def test_xtdb_temporal_upsert_dropout_closes_missing_keys_at_valid_time():
     assert result == 2
     executed_sql = [call.args[0] for call in driver_connection.execute.call_args_list]
     assert executed_sql[1] == (
-        "DELETE FROM test.cargos FOR PORTION OF VALID_TIME FROM "
+        "DELETE FROM test.records FOR PORTION OF VALID_TIME FROM "
         "TIMESTAMP '2030-01-02T00:00:00+00:00' TO NULL "
         "WHERE _id IN (2::BIGINT)"
     )
@@ -184,18 +184,18 @@ def test_xtdb_temporal_upsert_dropout_uses_explicit_close_time_for_empty_batches
     ops.from_raw_sql = Mock(return_value=pl.DataFrame({"_id": [1, 2]}))
     table_config = TableConfig(
         schema="test",
-        name="cargos",
+        name="records",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
         ],
     )
 
     result = backend.temporal_upsert(
         pl.DataFrame(schema={"id": pl.Int64, "destination": pl.String}),
         "test",
-        "cargos",
+        "records",
         dataframe_ops=ops,
         table_config=table_config,
         delta_config=DeltaConfig(row_finality="dropout"),
@@ -205,7 +205,7 @@ def test_xtdb_temporal_upsert_dropout_uses_explicit_close_time_for_empty_batches
     assert result == 2
     executed_sql = [call.args[0] for call in driver_connection.execute.call_args_list]
     assert executed_sql[1] == (
-        "DELETE FROM test.cargos FOR PORTION OF VALID_TIME FROM "
+        "DELETE FROM test.records FOR PORTION OF VALID_TIME FROM "
         "TIMESTAMP '2030-01-03T00:00:00+00:00' TO NULL "
         "WHERE _id IN (1::BIGINT, 2::BIGINT)"
     )
@@ -215,19 +215,19 @@ def test_xtdb_temporal_upsert_rejects_duplicate_source_keys_by_default():
     backend = XtdbBackend()
     table_config = TableConfig(
         schema="test",
-        name="cargos",
+        name="records",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
         ],
     )
 
     with pytest.raises(ValueError, match="duplicate source keys"):
         backend.temporal_upsert(
-            pl.DataFrame({"id": [1, 1], "destination": ["Tokyo", "Osaka"]}),
+            pl.DataFrame({"id": [1, 1], "destination": ["Alpha", "Beta"]}),
             "test",
-            "cargos",
+            "records",
             dataframe_ops=Mock(),
             table_config=table_config,
             delta_config=DeltaConfig(),
@@ -240,18 +240,18 @@ def test_xtdb_temporal_upsert_takes_first_duplicate_source_key():
     ops.table_insert.return_value = 1
     table_config = TableConfig(
         schema="test",
-        name="cargos",
+        name="records",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
         ],
     )
 
     result = backend.temporal_upsert(
-        pl.DataFrame({"id": [1, 1], "destination": ["Tokyo", "Osaka"]}),
+        pl.DataFrame({"id": [1, 1], "destination": ["Alpha", "Beta"]}),
         "test",
-        "cargos",
+        "records",
         dataframe_ops=ops,
         table_config=table_config,
         delta_config=DeltaConfig(on_duplicate_key="take_first"),
@@ -261,7 +261,7 @@ def test_xtdb_temporal_upsert_takes_first_duplicate_source_key():
     written_df = ops.table_insert.call_args.args[0]
     assert written_df.to_dict(as_series=False) == {
         "id": [1],
-        "destination": ["Tokyo"],
+        "destination": ["Alpha"],
     }
 
 
@@ -271,18 +271,18 @@ def test_xtdb_temporal_upsert_takes_last_duplicate_source_key():
     ops.table_insert.return_value = 1
     table_config = TableConfig(
         schema="test",
-        name="cargos",
+        name="records",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
         ],
     )
 
     result = backend.temporal_upsert(
-        pl.DataFrame({"id": [1, 1], "destination": ["Tokyo", "Osaka"]}),
+        pl.DataFrame({"id": [1, 1], "destination": ["Alpha", "Beta"]}),
         "test",
-        "cargos",
+        "records",
         dataframe_ops=ops,
         table_config=table_config,
         delta_config=DeltaConfig(on_duplicate_key="take_last"),
@@ -292,7 +292,7 @@ def test_xtdb_temporal_upsert_takes_last_duplicate_source_key():
     written_df = ops.table_insert.call_args.args[0]
     assert written_df.to_dict(as_series=False) == {
         "id": [1],
-        "destination": ["Osaka"],
+        "destination": ["Beta"],
     }
 
 
@@ -302,7 +302,7 @@ def test_xtdb_temporal_upsert_treats_explicit_valid_time_change_as_changed():
     ops.from_raw_sql.return_value = pl.DataFrame(
         {
             "_id": [1],
-            "destination": ["Tokyo"],
+            "destination": ["Alpha"],
             "_valid_from": [datetime(2030, 1, 1, tzinfo=timezone.utc)],
             "_valid_to": [datetime(2030, 2, 1, tzinfo=timezone.utc)],
         }
@@ -310,11 +310,11 @@ def test_xtdb_temporal_upsert_treats_explicit_valid_time_change_as_changed():
     ops.table_insert.return_value = 1
     table_config = TableConfig(
         schema="test",
-        name="cargos",
+        name="records",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
         ],
     )
 
@@ -322,13 +322,13 @@ def test_xtdb_temporal_upsert_treats_explicit_valid_time_change_as_changed():
         pl.DataFrame(
             {
                 "id": [1],
-                "destination": ["Tokyo"],
+                "destination": ["Alpha"],
                 "_valid_from": [datetime(2030, 1, 1, tzinfo=timezone.utc)],
                 "_valid_to": [datetime(2030, 3, 1, tzinfo=timezone.utc)],
             }
         ),
         "test",
-        "cargos",
+        "records",
         dataframe_ops=ops,
         table_config=table_config,
         delta_config=DeltaConfig(drop_unchanged_rows=True),
@@ -339,7 +339,7 @@ def test_xtdb_temporal_upsert_treats_explicit_valid_time_change_as_changed():
     written_df = ops.table_insert.call_args.args[0]
     assert written_df.to_dict(as_series=False) == {
         "id": [1],
-        "destination": ["Tokyo"],
+        "destination": ["Alpha"],
         "_valid_from": [datetime(2030, 1, 1, tzinfo=timezone.utc)],
         "_valid_to": [datetime(2030, 3, 1, tzinfo=timezone.utc)],
     }
@@ -351,18 +351,18 @@ def test_xtdb_temporal_upsert_ignores_valid_from_when_filtering_unchanged_rows()
     ops.from_raw_sql.return_value = pl.DataFrame(
         {
             "_id": [1],
-            "destination": ["Tokyo"],
+            "destination": ["Alpha"],
             "_valid_from": [datetime(2030, 1, 1, tzinfo=timezone.utc)],
         }
     )
     ops.table_insert.return_value = 0
     table_config = TableConfig(
         schema="test",
-        name="cargos",
+        name="records",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
         ],
     )
 
@@ -370,12 +370,12 @@ def test_xtdb_temporal_upsert_ignores_valid_from_when_filtering_unchanged_rows()
         pl.DataFrame(
             {
                 "id": [1],
-                "destination": ["Tokyo"],
+                "destination": ["Alpha"],
                 "_valid_from": [datetime(2030, 2, 1, tzinfo=timezone.utc)],
             }
         ),
         "test",
-        "cargos",
+        "records",
         dataframe_ops=ops,
         table_config=table_config,
         delta_config=DeltaConfig(drop_unchanged_rows=True),
@@ -392,19 +392,19 @@ def test_xtdb_temporal_upsert_normalizes_types_when_filtering_unchanged_rows():
     ops.from_raw_sql.return_value = pl.DataFrame(
         {
             "_id": [1],
-            "destination": ["Tokyo"],
+            "destination": ["Alpha"],
             "float_col": [12.34],
         }
     )
     ops.table_insert.return_value = 0
     table_config = TableConfig(
         schema="test",
-        name="cargos",
+        name="records",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "INT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
-            TableColumnConfig("cargos", "float_col", "FLOAT"),
+            TableColumnConfig("records", "id", "INT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "float_col", "FLOAT"),
         ],
     )
 
@@ -412,13 +412,13 @@ def test_xtdb_temporal_upsert_normalizes_types_when_filtering_unchanged_rows():
         pl.DataFrame(
             {
                 "id": [1],
-                "destination": ["Tokyo"],
+                "destination": ["Alpha"],
                 "float_col": [12.34],
             },
             schema_overrides={"float_col": pl.Float32},
         ),
         "test",
-        "cargos",
+        "records",
         dataframe_ops=ops,
         table_config=table_config,
         delta_config=DeltaConfig(drop_unchanged_rows=True),
@@ -492,25 +492,25 @@ def test_xtdb_temporal_upsert_treats_null_to_value_as_changed():
     ops.from_raw_sql.return_value = pl.DataFrame(
         {
             "_id": [1],
-            "cargo_mcm": [None],
+            "amount_value": [None],
         },
-        schema_overrides={"cargo_mcm": pl.Float64},
+        schema_overrides={"amount_value": pl.Float64},
     )
     ops.table_insert.return_value = 1
     table_config = TableConfig(
         schema="test",
-        name="cargos",
+        name="records",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "amount_value", "DOUBLE"),
         ],
     )
 
     result = backend.temporal_upsert(
-        pl.DataFrame({"id": [1], "cargo_mcm": [330.33]}),
+        pl.DataFrame({"id": [1], "amount_value": [330.33]}),
         "test",
-        "cargos",
+        "records",
         dataframe_ops=ops,
         table_config=table_config,
         delta_config=DeltaConfig(drop_unchanged_rows=True),
@@ -520,7 +520,7 @@ def test_xtdb_temporal_upsert_treats_null_to_value_as_changed():
     written_df = ops.table_insert.call_args.args[0]
     assert written_df.to_dict(as_series=False) == {
         "id": [1],
-        "cargo_mcm": [330.33],
+        "amount_value": [330.33],
     }
 
 
@@ -535,16 +535,16 @@ def test_xtdb_temporal_upsert_maps_configured_valid_time_columns():
         pl.DataFrame(
             {
                 "id": [1],
-                "destination": ["Tokyo"],
+                "destination": ["Alpha"],
                 "msg_timestamp": [asof_time],
                 "valid_until": [expiry_time],
             }
         ),
         "test",
-        "cargos",
+        "records",
         dataframe_ops=ops,
         valid_time=ValidTimeConfig(
-            table="cargos",
+            table="records",
             from_column="msg_timestamp",
             to_column="valid_until",
         ),
@@ -554,7 +554,7 @@ def test_xtdb_temporal_upsert_maps_configured_valid_time_columns():
     written_df = ops.table_insert.call_args.args[0]
     assert written_df.to_dict(as_series=False) == {
         "id": [1],
-        "destination": ["Tokyo"],
+        "destination": ["Alpha"],
         "msg_timestamp": [asof_time],
         "valid_until": [expiry_time],
         "_valid_from": [asof_time],
@@ -567,12 +567,12 @@ def test_xtdb_temporal_upsert_rejects_missing_valid_time_source_column():
 
     with pytest.raises(ValueError, match="missing source column"):
         backend.temporal_upsert(
-            pl.DataFrame({"id": [1], "destination": ["Tokyo"]}),
+            pl.DataFrame({"id": [1], "destination": ["Alpha"]}),
             "test",
-            "cargos",
+            "records",
             dataframe_ops=Mock(),
             valid_time=ValidTimeConfig(
-                table="cargos",
+                table="records",
                 from_column="msg_timestamp",
             ),
         )
@@ -591,10 +591,10 @@ def test_xtdb_temporal_upsert_rejects_valid_time_target_conflict():
                 }
             ),
             "test",
-            "cargos",
+            "records",
             dataframe_ops=Mock(),
             valid_time=ValidTimeConfig(
-                table="cargos",
+                table="records",
                 from_column="msg_timestamp",
             ),
         )
@@ -812,12 +812,12 @@ def test_xtdb_table_creation_records_configured_columns_without_ddl(monkeypatch)
 
     table_config = TableConfig(
         schema="test",
-        name="cargos",
+        name="records",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
-            TableColumnConfig("cargos", "cargo_mcm", "DECIMAL(20,6)"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "amount_value", "DECIMAL(20,6)"),
         ],
     )
     result = ops.create(table_config)
@@ -829,14 +829,14 @@ def test_xtdb_table_creation_records_configured_columns_without_ddl(monkeypatch)
         "INSERT INTO test.__polars_hist_db_xtdb_table_configs "
         "(_id, table_schema, table_name, primary_keys_json, id_policy, "
         "columns_json, foreign_keys_json) "
-        "VALUES ('test.cargos'::TEXT, 'test'::TEXT, 'cargos'::TEXT, "
+        "VALUES ('test.records'::TEXT, 'test'::TEXT, 'records'::TEXT, "
         "'[\"id\"]'::TEXT, 'single-key'::TEXT, "
-        '\'[{"table":"cargos","name":"id","data_type":"BIGINT",'
+        '\'[{"table":"records","name":"id","data_type":"BIGINT",'
         '"default_value":null,"autoincrement":false,"nullable":false,'
-        '"unique_constraint":[]},{"table":"cargos","name":"destination",'
+        '"unique_constraint":[]},{"table":"records","name":"destination",'
         '"data_type":"VARCHAR(255)","default_value":null,"autoincrement":false,'
-        '"nullable":true,"unique_constraint":[]},{"table":"cargos",'
-        '"name":"cargo_mcm","data_type":"DECIMAL(20,6)","default_value":null,'
+        '"nullable":true,"unique_constraint":[]},{"table":"records",'
+        '"name":"amount_value","data_type":"DECIMAL(20,6)","default_value":null,'
         '"autoincrement":false,"nullable":true,"unique_constraint":[]}]'
         "'::TEXT, '[]'::TEXT)",
     ]
@@ -846,21 +846,21 @@ def test_xtdb_table_creation_is_idempotent_when_table_exists(monkeypatch):
     connection = Mock()
     ops = XtdbTableConfigOps(connection)
     monkeypatch.setattr(ops, "table_exists", Mock(return_value=True))
-    existing_config = TableConfig(schema="test", name="cargos", columns=[])
+    existing_config = TableConfig(schema="test", name="records", columns=[])
     monkeypatch.setattr(ops, "from_table", Mock(return_value=existing_config))
 
     table_config = TableConfig(
         schema="test",
-        name="cargos",
+        name="records",
         primary_keys=["_id"],
-        columns=[TableColumnConfig("cargos", "_id", "BIGINT", nullable=False)],
+        columns=[TableColumnConfig("records", "_id", "BIGINT", nullable=False)],
     )
 
     result = ops.create(table_config)
 
     assert result is existing_config
     connection.execute.assert_not_called()
-    ops.from_table.assert_called_once_with("test", "cargos")
+    ops.from_table.assert_called_once_with("test", "records")
 
 
 def test_xtdb_table_creation_records_composite_primary_key_columns(monkeypatch):
@@ -871,12 +871,12 @@ def test_xtdb_table_creation_records_composite_primary_key_columns(monkeypatch):
 
     table_config = TableConfig(
         schema="test",
-        name="cargos",
-        primary_keys=["vessel_id", "cargo_id"],
+        name="records",
+        primary_keys=["entity_id", "record_id"],
         columns=[
-            TableColumnConfig("cargos", "vessel_id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "cargo_id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "entity_id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "record_id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
         ],
     )
 
@@ -889,13 +889,13 @@ def test_xtdb_table_creation_records_composite_primary_key_columns(monkeypatch):
         "INSERT INTO test.__polars_hist_db_xtdb_table_configs "
         "(_id, table_schema, table_name, primary_keys_json, id_policy, "
         "columns_json, foreign_keys_json) "
-        "VALUES ('test.cargos'::TEXT, 'test'::TEXT, 'cargos'::TEXT, "
-        "'[\"vessel_id\",\"cargo_id\"]'::TEXT, 'xtdb-pk-v1'::TEXT, "
-        '\'[{"table":"cargos","name":"vessel_id","data_type":"BIGINT",'
+        "VALUES ('test.records'::TEXT, 'test'::TEXT, 'records'::TEXT, "
+        "'[\"entity_id\",\"record_id\"]'::TEXT, 'xtdb-pk-v1'::TEXT, "
+        '\'[{"table":"records","name":"entity_id","data_type":"BIGINT",'
         '"default_value":null,"autoincrement":false,"nullable":false,'
-        '"unique_constraint":[]},{"table":"cargos","name":"cargo_id",'
+        '"unique_constraint":[]},{"table":"records","name":"record_id",'
         '"data_type":"BIGINT","default_value":null,"autoincrement":false,'
-        '"nullable":false,"unique_constraint":[]},{"table":"cargos",'
+        '"nullable":false,"unique_constraint":[]},{"table":"records",'
         '"name":"destination","data_type":"VARCHAR(255)","default_value":null,'
         '"autoincrement":false,"nullable":true,"unique_constraint":[]}]'
         "'::TEXT, '[]'::TEXT)",
@@ -910,11 +910,11 @@ def test_xtdb_table_creation_records_primary_key_metadata(monkeypatch):
 
     table_config = TableConfig(
         schema="test",
-        name="cargos",
-        primary_keys=["vessel_id", "cargo_id"],
+        name="records",
+        primary_keys=["entity_id", "record_id"],
         columns=[
-            TableColumnConfig("cargos", "vessel_id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "cargo_id", "VARCHAR(255)", nullable=False),
+            TableColumnConfig("records", "entity_id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "record_id", "VARCHAR(255)", nullable=False),
         ],
     )
 
@@ -925,11 +925,11 @@ def test_xtdb_table_creation_records_primary_key_metadata(monkeypatch):
         "INSERT INTO test.__polars_hist_db_xtdb_table_configs "
         "(_id, table_schema, table_name, primary_keys_json, id_policy, "
         "columns_json, foreign_keys_json) "
-        "VALUES ('test.cargos'::TEXT, 'test'::TEXT, 'cargos'::TEXT, "
-        "'[\"vessel_id\",\"cargo_id\"]'::TEXT, 'xtdb-pk-v1'::TEXT, "
-        '\'[{"table":"cargos","name":"vessel_id","data_type":"BIGINT",'
+        "VALUES ('test.records'::TEXT, 'test'::TEXT, 'records'::TEXT, "
+        "'[\"entity_id\",\"record_id\"]'::TEXT, 'xtdb-pk-v1'::TEXT, "
+        '\'[{"table":"records","name":"entity_id","data_type":"BIGINT",'
         '"default_value":null,"autoincrement":false,"nullable":false,'
-        '"unique_constraint":[]},{"table":"cargos","name":"cargo_id",'
+        '"unique_constraint":[]},{"table":"records","name":"record_id",'
         '"data_type":"VARCHAR(255)","default_value":null,"autoincrement":false,'
         '"nullable":false,"unique_constraint":[]}]\'::TEXT, \'[]\'::TEXT)',
     ]
@@ -944,7 +944,7 @@ def test_xtdb_table_reflection_builds_table_config_from_information_schema(
                 "column_name": [
                     "_id",
                     "destination",
-                    "cargo_mcm",
+                    "amount_value",
                     "_system_from",
                     "_system_to",
                 ],
@@ -964,24 +964,24 @@ def test_xtdb_table_reflection_builds_table_config_from_information_schema(
     connection = object()
     ops = XtdbTableConfigOps(connection)
 
-    table_config = ops.from_table("test", "cargos")
+    table_config = ops.from_table("test", "records")
 
     assert table_config.schema == "test"
-    assert table_config.name == "cargos"
+    assert table_config.name == "records"
     assert list(table_config.primary_keys) == ["_id"]
     assert [
         (col.name, col.data_type, col.nullable) for col in table_config.columns
     ] == [
         ("_id", "BIGINT", False),
         ("destination", "VARCHAR(255)", True),
-        ("cargo_mcm", "DECIMAL(10,4)", True),
+        ("amount_value", "DECIMAL(10,4)", True),
     ]
     assert read_database.call_args_list[0].args == (
         """
             SELECT column_name, data_type, is_nullable
             FROM information_schema.columns
             WHERE table_schema = 'test'
-              AND table_name = 'cargos'
+              AND table_name = 'records'
             ORDER BY ordinal_position
         """,
         connection,
@@ -1088,8 +1088,8 @@ def test_xtdb_table_reflection_recovers_composite_primary_keys_from_metadata(
                 {
                     "column_name": [
                         "_id",
-                        "vessel_id",
-                        "cargo_id",
+                        "entity_id",
+                        "record_id",
                         "destination",
                     ],
                     "data_type": [":utf8", ":i64", ":utf8", ":utf8"],
@@ -1098,7 +1098,7 @@ def test_xtdb_table_reflection_recovers_composite_primary_keys_from_metadata(
             ),
             pl.DataFrame(
                 {
-                    "primary_keys_json": ['["vessel_id","cargo_id"]'],
+                    "primary_keys_json": ['["entity_id","record_id"]'],
                     "id_policy": ["xtdb-pk-v1"],
                 }
             ),
@@ -1106,17 +1106,17 @@ def test_xtdb_table_reflection_recovers_composite_primary_keys_from_metadata(
     )
     monkeypatch.setattr(pl, "read_database", read_database)
 
-    table_config = XtdbTableConfigOps(object()).from_table("test", "cargos")
+    table_config = XtdbTableConfigOps(object()).from_table("test", "records")
 
     assert table_config.schema == "test"
-    assert table_config.name == "cargos"
-    assert list(table_config.primary_keys) == ["vessel_id", "cargo_id"]
+    assert table_config.name == "records"
+    assert list(table_config.primary_keys) == ["entity_id", "record_id"]
     assert [
         (col.name, col.data_type, col.nullable) for col in table_config.columns
     ] == [
         ("_id", "VARCHAR(255)", False),
-        ("vessel_id", "BIGINT", False),
-        ("cargo_id", "VARCHAR(255)", False),
+        ("entity_id", "BIGINT", False),
+        ("record_id", "VARCHAR(255)", False),
         ("destination", "VARCHAR(255)", True),
     ]
 
@@ -1126,24 +1126,24 @@ def test_xtdb_table_reflection_errors_when_table_has_no_metadata(monkeypatch):
     ops = XtdbTableConfigOps(object())
 
     with pytest.raises(
-        ValueError, match="XTDB table metadata not found for test.cargos"
+        ValueError, match="XTDB table metadata not found for test.records"
     ):
-        ops.from_table("test", "cargos")
+        ops.from_table("test", "records")
 
 
 def test_xtdb_declared_columns_quotes_non_identifier_column_names():
     from polars_hist_db.backends.xtdb import _xtdb_declared_columns
 
     table_config = TableConfig(
-        schema="kpler",
-        name="__cargo_stage",
+        schema="sample",
+        name="__record_stage",
         primary_keys=["stage_run_id", "stage_row_index"],
         columns=[
-            TableColumnConfig("__cargo_stage", "stage_run_id", "VARCHAR(128)"),
-            TableColumnConfig("__cargo_stage", "stage_row_index", "BIGINT"),
-            TableColumnConfig("__cargo_stage", "Vessel", "VARCHAR(64)"),
-            TableColumnConfig("__cargo_stage", "IMO (vessel)", "VARCHAR(16)"),
-            TableColumnConfig("__cargo_stage", "timestamp", "DATETIME"),
+            TableColumnConfig("__record_stage", "stage_run_id", "VARCHAR(128)"),
+            TableColumnConfig("__record_stage", "stage_row_index", "BIGINT"),
+            TableColumnConfig("__record_stage", "Entity", "VARCHAR(64)"),
+            TableColumnConfig("__record_stage", "External Ref (entity)", "VARCHAR(16)"),
+            TableColumnConfig("__record_stage", "timestamp", "DATETIME"),
         ],
     )
 
@@ -1151,7 +1151,7 @@ def test_xtdb_declared_columns_quotes_non_identifier_column_names():
         "_id",
         "stage_run_id",
         "stage_row_index",
-        '"Vessel"',
-        '"IMO (vessel)"',
+        '"Entity"',
+        '"External Ref (entity)"',
         '"timestamp"',
     ]

--- a/tests/backends/test_xtdb_dataframe_ops.py
+++ b/tests/backends/test_xtdb_dataframe_ops.py
@@ -21,11 +21,11 @@ def test_xtdb_dataframe_ops_reads_raw_sql_with_schema_overrides(monkeypatch):
     connection = object()
     ops = XtdbDataframeOps(connection)
 
-    result = ops.from_raw_sql("select * from test.cargos", {"id": pl.Int64})
+    result = ops.from_raw_sql("select * from test.records", {"id": pl.Int64})
 
     assert result is expected_df
     read_database.assert_called_once_with(
-        "select * from test.cargos",
+        "select * from test.records",
         connection,
         schema_overrides={"id": pl.Int64},
     )
@@ -61,7 +61,7 @@ def test_xtdb_dml_retries_with_append_time_when_system_time_is_too_old():
 
     row_count = _execute_xtdb_dml(
         connection,
-        "INSERT INTO test.cargos (_id) VALUES (1)",
+        "INSERT INTO test.records (_id) VALUES (1)",
         system_time=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
@@ -69,9 +69,9 @@ def test_xtdb_dml_retries_with_append_time_when_system_time_is_too_old():
     assert connection.connection.driver_connection.rollback_count == 1
     assert connection.connection.driver_connection.executed == [
         "BEGIN READ WRITE WITH (SYSTEM_TIME = TIMESTAMP '2025-01-01T00:00:00+00:00')",
-        "INSERT INTO test.cargos (_id) VALUES (1)",
+        "INSERT INTO test.records (_id) VALUES (1)",
         "BEGIN READ WRITE",
-        "INSERT INTO test.cargos (_id) VALUES (1)",
+        "INSERT INTO test.records (_id) VALUES (1)",
     ]
 
 
@@ -80,11 +80,11 @@ def test_xtdb_dataframe_ops_reads_table_as_sql():
     ops = XtdbDataframeOps(connection)
     ops.from_raw_sql = Mock(return_value=pl.DataFrame({"id": [1]}))
 
-    result = ops.from_table("test", "cargos", {"id": pl.Int64})
+    result = ops.from_table("test", "records", {"id": pl.Int64})
 
     assert result.to_dict(as_series=False) == {"id": [1]}
     ops.from_raw_sql.assert_called_once_with(
-        "SELECT * FROM test.cargos",
+        "SELECT * FROM test.records",
         {"id": pl.Int64},
     )
 
@@ -96,7 +96,7 @@ def test_xtdb_dataframe_ops_applies_table_time_hint():
 
     result = ops.from_table(
         "test",
-        "cargos",
+        "records",
         {"id": pl.Int64},
         time_hint=TimeHint(
             mode="asof",
@@ -106,7 +106,7 @@ def test_xtdb_dataframe_ops_applies_table_time_hint():
 
     assert result.to_dict(as_series=False) == {"id": [1]}
     ops.from_raw_sql.assert_called_once_with(
-        "SELECT * FROM test.cargos FOR SYSTEM_TIME AS OF '2026-01-02T03:04:05+00:00'",
+        "SELECT * FROM test.records FOR SYSTEM_TIME AS OF '2026-01-02T03:04:05+00:00'",
         {"id": pl.Int64},
     )
 
@@ -116,12 +116,12 @@ def test_xtdb_dataframe_ops_reads_table_with_configured_schema_overrides(monkeyp
     monkeypatch.setattr(pl, "read_database", read_database)
     table_config = TableConfig(
         schema="test",
-        name="cargos",
+        name="records",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination_date", "DATETIME"),
-            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination_date", "DATETIME"),
+            TableColumnConfig("records", "amount_value", "DOUBLE"),
         ],
     )
     monkeypatch.setattr(
@@ -132,15 +132,15 @@ def test_xtdb_dataframe_ops_reads_table_with_configured_schema_overrides(monkeyp
     connection = object()
     ops = XtdbDataframeOps(connection)
 
-    ops.from_table("test", "cargos")
+    ops.from_table("test", "records")
 
     read_database.assert_called_once_with(
-        "SELECT * FROM test.cargos",
+        "SELECT * FROM test.records",
         connection,
         schema_overrides={
             "_id": pl.Int64,
             "destination_date": pl.Datetime(),
-            "cargo_mcm": pl.Float64,
+            "amount_value": pl.Float64,
             "_valid_from": pl.Datetime("us", "UTC"),
             "_valid_to": pl.Datetime("us", "UTC"),
         },
@@ -153,11 +153,11 @@ def test_xtdb_dataframe_ops_writes_dataframe_via_polars_write_database():
     connection = object()
     ops = XtdbDataframeOps(connection)
 
-    result = ops.table_insert(df, "test", "cargos")
+    result = ops.table_insert(df, "test", "records")
 
     assert result == 7
     df.write_database.assert_called_once_with(
-        table_name="test.cargos",
+        table_name="test.records",
         connection=connection,
         if_table_exists="append",
     )
@@ -176,17 +176,17 @@ def test_xtdb_dataframe_ops_maps_configured_primary_key_to_id(monkeypatch):
     df = pl.DataFrame({"id": [1, 2], "destination": ["A", "B"]})
     table_config = TableConfig(
         schema="test",
-        name="cargos",
+        name="records",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
         ],
     )
     connection = object()
     ops = XtdbDataframeOps(connection)
 
-    result = ops.table_insert(df, "test", "cargos", table_config=table_config)
+    result = ops.table_insert(df, "test", "records", table_config=table_config)
 
     assert result == 2
     written_df = captured["df"]
@@ -195,7 +195,7 @@ def test_xtdb_dataframe_ops_maps_configured_primary_key_to_id(monkeypatch):
         "destination": ["A", "B"],
     }
     assert captured["kwargs"] == {
-        "table_name": "test.cargos",
+        "table_name": "test.records",
         "connection": connection,
         "if_table_exists": "append",
     }
@@ -213,39 +213,39 @@ def test_xtdb_dataframe_ops_maps_composite_primary_key_to_synthetic_id(monkeypat
 
     df = pl.DataFrame(
         {
-            "vessel_id": [10, 10],
-            "cargo_id": ["A", "B"],
-            "destination": ["Tokyo", "Osaka"],
+            "entity_id": [10, 10],
+            "record_id": ["A", "B"],
+            "destination": ["Alpha", "Beta"],
         }
     )
     table_config = TableConfig(
         schema="test",
-        name="cargos",
-        primary_keys=["vessel_id", "cargo_id"],
+        name="records",
+        primary_keys=["entity_id", "record_id"],
         columns=[
-            TableColumnConfig("cargos", "vessel_id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "cargo_id", "VARCHAR(255)", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "entity_id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "record_id", "VARCHAR(255)", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
         ],
     )
     connection = object()
     ops = XtdbDataframeOps(connection)
 
-    result = ops.table_insert(df, "test", "cargos", table_config=table_config)
+    result = ops.table_insert(df, "test", "records", table_config=table_config)
 
     assert result == 2
     written_df = captured["df"]
     assert written_df.to_dict(as_series=False) == {
         "_id": [
-            'xtdb-pk-v1:[["vessel_id",10],["cargo_id","A"]]',
-            'xtdb-pk-v1:[["vessel_id",10],["cargo_id","B"]]',
+            'xtdb-pk-v1:[["entity_id",10],["record_id","A"]]',
+            'xtdb-pk-v1:[["entity_id",10],["record_id","B"]]',
         ],
-        "vessel_id": [10, 10],
-        "cargo_id": ["A", "B"],
-        "destination": ["Tokyo", "Osaka"],
+        "entity_id": [10, 10],
+        "record_id": ["A", "B"],
+        "destination": ["Alpha", "Beta"],
     }
     assert captured["kwargs"] == {
-        "table_name": "test.cargos",
+        "table_name": "test.records",
         "connection": connection,
         "if_table_exists": "append",
     }
@@ -259,9 +259,9 @@ def test_xtdb_dataframe_ops_uses_system_time_transaction_for_update_time():
     ops = XtdbDataframeOps(connection)
 
     result = ops.table_insert(
-        pl.DataFrame({"_id": [1], "destination": ["Tokyo"]}),
+        pl.DataFrame({"_id": [1], "destination": ["Alpha"]}),
         "test",
-        "cargos",
+        "records",
         update_time=datetime(2030, 1, 1, 12, 0, tzinfo=timezone.utc),
     )
 
@@ -375,12 +375,12 @@ def test_xtdb_dataframe_ops_casts_null_values_to_configured_types():
     ops = XtdbDataframeOps(connection)
     table_config = TableConfig(
         schema="test",
-        name="cargos",
+        name="records",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination_date", "DATETIME"),
-            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination_date", "DATETIME"),
+            TableColumnConfig("records", "amount_value", "DOUBLE"),
         ],
     )
 
@@ -389,17 +389,51 @@ def test_xtdb_dataframe_ops_casts_null_values_to_configured_types():
             {
                 "id": [1],
                 "destination_date": [None],
-                "cargo_mcm": [None],
+                "amount_value": [None],
             }
         ),
         "test",
-        "cargos",
+        "records",
         table_config=table_config,
     )
 
     insert_sql = driver_connection.execute.call_args_list[1].args[0]
     assert "NULL::TIMESTAMP" in insert_sql
     assert "NULL::DOUBLE PRECISION" in insert_sql
+
+
+def test_xtdb_dataframe_ops_quotes_reserved_insert_columns():
+    driver_connection = Mock()
+    connection = Mock()
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+    ops = XtdbDataframeOps(connection)
+    table_config = TableConfig(
+        schema="source_a",
+        name="entity_info",
+        primary_keys=["entity_id"],
+        columns=[
+            TableColumnConfig("entity_info", "entity_id", "INT", nullable=False),
+            TableColumnConfig("entity_info", "name", "VARCHAR(64)"),
+            TableColumnConfig("entity_info", "flag", "VARCHAR(64)"),
+        ],
+    )
+
+    ops.table_insert(
+        pl.DataFrame(
+            {
+                "entity_id": [311038700],
+                "name": ["ALPHA"],
+                "flag": ["BS"],
+            }
+        ),
+        "source_a",
+        "entity_info",
+        table_config=table_config,
+    )
+
+    insert_sql = driver_connection.execute.call_args_list[1].args[0]
+    assert 'INSERT INTO source_a.entity_info (_id, name, "flag")' in insert_sql
 
 
 def test_xtdb_backend_returns_xtdb_dataframe_ops():

--- a/tests/backends/test_xtdb_dataset_ingest.py
+++ b/tests/backends/test_xtdb_dataset_ingest.py
@@ -51,35 +51,35 @@ def test_xtdb_primary_ingest_uses_staged_dataframe_for_temporal_upsert():
         items=[
             {
                 "schema": "fakedata",
-                "name": "cargos",
-                "primary_keys": ["cargo_id"],
+                "name": "records",
+                "primary_keys": ["record_id"],
                 "columns": [
-                    {"name": "cargo_id", "data_type": "INT", "nullable": False},
+                    {"name": "record_id", "data_type": "INT", "nullable": False},
                     {"name": "destination", "data_type": "VARCHAR(64)"},
                 ],
                 "is_temporal": True,
             }
         ]
     )
-    cargo_table = tables["cargos"]
+    record_table = tables["records"]
     dataset = DatasetConfig(
-        name="cargo_stream",
+        name="record_stream",
         delta_table_schema="fakedata",
         input_config={"type": "dsv", "search_paths": []},
         valid_time=[
             {
                 "schema": "fakedata",
-                "table": "cargos",
+                "table": "records",
                 "from_column": "msg_timestamp",
             }
         ],
         pipeline=[
             {
                 "schema": "fakedata",
-                "table": "cargos",
+                "table": "records",
                 "type": "primary",
                 "columns": [
-                    {"source": "cargo_id", "target": "cargo_id"},
+                    {"source": "record_id", "target": "record_id"},
                     {"source": "destination_name", "target": "destination"},
                 ],
             }
@@ -89,8 +89,8 @@ def test_xtdb_primary_ingest_uses_staged_dataframe_for_temporal_upsert():
     update_time = datetime(2030, 1, 1, 12, 5, tzinfo=timezone.utc)
     staged_df = pl.DataFrame(
         {
-            "cargo_id": [1],
-            "destination": ["Tokyo"],
+            "record_id": [1],
+            "destination": ["Alpha"],
             "msg_timestamp": [msg_timestamp],
         }
     )
@@ -109,32 +109,32 @@ def test_xtdb_primary_ingest_uses_staged_dataframe_for_temporal_upsert():
     )
 
     assert did_modify is True
-    assert backend.table_config_ops.created == [cargo_table]
+    assert backend.table_config_ops.created == [record_table]
     assert staging.prepare_calls == [
         (
-            ("stage-1", dataset, 0, cargo_table),
+            ("stage-1", dataset, 0, record_table),
             {
                 "valid_time": ValidTimeConfig(
                     schema="fakedata",
-                    table="cargos",
+                    table="records",
                     from_column="msg_timestamp",
                 )
             },
         )
     ]
     args, kwargs = backend.temporal_upsert_calls[0]
-    assert args[1:] == ("fakedata", "cargos")
+    assert args[1:] == ("fakedata", "records")
     assert args[0].to_dict(as_series=False) == {
-        "cargo_id": [1],
-        "destination": ["Tokyo"],
+        "record_id": [1],
+        "destination": ["Alpha"],
         "msg_timestamp": [msg_timestamp],
     }
-    assert kwargs["table_config"] == cargo_table
+    assert kwargs["table_config"] == record_table
     assert kwargs["delta_config"] == dataset.delta_config
     assert kwargs["update_time"] == update_time
     assert kwargs["valid_time"] == ValidTimeConfig(
         schema="fakedata",
-        table="cargos",
+        table="records",
         from_column="msg_timestamp",
     )
 
@@ -143,46 +143,46 @@ def test_xtdb_extract_ingest_uses_staged_dataframe_for_temporal_upsert():
     tables = TableConfigs(
         items=[
             {
-                "schema": "spire",
+                "schema": "source_a",
                 "name": "vectors",
-                "primary_keys": ["mmsi"],
+                "primary_keys": ["entity_id"],
                 "columns": [
-                    {"name": "mmsi", "data_type": "INT", "nullable": False},
+                    {"name": "entity_id", "data_type": "INT", "nullable": False},
                     {"name": "latitude", "data_type": "DOUBLE"},
                 ],
                 "is_temporal": True,
             },
             {
-                "schema": "spire",
-                "name": "vessel_info",
-                "primary_keys": ["mmsi"],
+                "schema": "source_a",
+                "name": "entity_info",
+                "primary_keys": ["entity_id"],
                 "columns": [
-                    {"name": "mmsi", "data_type": "INT", "nullable": False},
+                    {"name": "entity_id", "data_type": "INT", "nullable": False},
                     {"name": "name", "data_type": "VARCHAR(64)"},
                 ],
             },
         ]
     )
-    vessel_info = tables["vessel_info"]
+    entity_info = tables["entity_info"]
     dataset = DatasetConfig(
-        name="spire_stream",
-        delta_table_schema="spire",
+        name="source_a_stream",
+        delta_table_schema="source_a",
         input_config={"type": "dsv", "search_paths": []},
         pipeline=[
             {
-                "schema": "spire",
+                "schema": "source_a",
                 "table": "vectors",
                 "type": "primary",
                 "columns": [
-                    {"source": "source_mmsi", "target": "mmsi"},
+                    {"source": "source_entity_id", "target": "entity_id"},
                     {"source": "source_latitude", "target": "latitude"},
                 ],
             },
             {
-                "schema": "spire",
-                "table": "vessel_info",
+                "schema": "source_a",
+                "table": "entity_info",
                 "columns": [
-                    {"source": "source_mmsi", "target": "mmsi"},
+                    {"source": "source_entity_id", "target": "entity_id"},
                     {"source": "source_name", "target": "name"},
                 ],
             },
@@ -191,8 +191,8 @@ def test_xtdb_extract_ingest_uses_staged_dataframe_for_temporal_upsert():
     update_time = datetime(2030, 1, 1, 12, 5, tzinfo=timezone.utc)
     staged_df = pl.DataFrame(
         {
-            "mmsi": [123],
-            "name": ["LNG Test"],
+            "entity_id": [123],
+            "name": ["Commodity Test"],
         }
     )
     backend = _FakeXtdbBackend()
@@ -201,7 +201,7 @@ def test_xtdb_extract_ingest_uses_staged_dataframe_for_temporal_upsert():
     did_modify = scrape_extract_item(
         1,
         dataset,
-        "vessel_info",
+        "entity_info",
         tables,
         update_time,
         SimpleNamespace(),
@@ -211,17 +211,17 @@ def test_xtdb_extract_ingest_uses_staged_dataframe_for_temporal_upsert():
     )
 
     assert did_modify is True
-    assert backend.table_config_ops.created == [vessel_info]
+    assert backend.table_config_ops.created == [entity_info]
     assert staging.prepare_calls == [
-        (("stage-1", dataset, 1, vessel_info), {"valid_time": None})
+        (("stage-1", dataset, 1, entity_info), {"valid_time": None})
     ]
     args, kwargs = backend.temporal_upsert_calls[0]
-    assert args[1:] == ("spire", "vessel_info")
+    assert args[1:] == ("source_a", "entity_info")
     assert args[0].to_dict(as_series=False) == {
-        "mmsi": [123],
-        "name": ["LNG Test"],
+        "entity_id": [123],
+        "name": ["Commodity Test"],
     }
-    assert kwargs["table_config"] == vessel_info
+    assert kwargs["table_config"] == entity_info
     assert kwargs["delta_config"] == dataset.delta_config
     assert kwargs["update_time"] == update_time
     assert kwargs["valid_time"] is None

--- a/tests/backends/test_xtdb_live.py
+++ b/tests/backends/test_xtdb_live.py
@@ -81,12 +81,12 @@ def _xtdb_engine() -> Iterator[Engine]:
 def test_xtdb_live_create_append_read_roundtrip():
     table_config = TableConfig(
         schema="public",
-        name=f"live_cargos_{int(time.time())}",
+        name=f"live_records_{int(time.time())}",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
-            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "amount_value", "DOUBLE"),
         ],
     )
 
@@ -99,8 +99,8 @@ def test_xtdb_live_create_append_read_roundtrip():
                 pl.DataFrame(
                     {
                         "id": [1, 2],
-                        "destination": ["Tokyo", "Osaka"],
-                        "cargo_mcm": [10.5, 20.25],
+                        "destination": ["Alpha", "Beta"],
+                        "amount_value": [10.5, 20.25],
                     }
                 ),
                 table_config.schema,
@@ -113,24 +113,24 @@ def test_xtdb_live_create_append_read_roundtrip():
                 table_config.name,
             )
 
-    assert result.sort("_id").select(["_id", "destination", "cargo_mcm"]).to_dict(
+    assert result.sort("_id").select(["_id", "destination", "amount_value"]).to_dict(
         as_series=False
     ) == {
         "_id": [1, 2],
-        "destination": ["Tokyo", "Osaka"],
-        "cargo_mcm": [10.5, 20.25],
+        "destination": ["Alpha", "Beta"],
+        "amount_value": [10.5, 20.25],
     }
 
 
-def test_xtdb_live_composite_primary_key_roundtrip():
+def test_xtdb_live_insert_non_public_table_with_reserved_column_name():
     table_config = TableConfig(
-        schema="public",
-        name=f"live_composite_cargos_{int(time.time())}",
-        primary_keys=["vessel_id", "cargo_id"],
+        schema="source_a",
+        name=f"live_entity_info_{int(time.time())}",
+        primary_keys=["entity_id"],
         columns=[
-            TableColumnConfig("cargos", "vessel_id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "cargo_id", "VARCHAR(255)", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("entity_info", "entity_id", "INT", nullable=False),
+            TableColumnConfig("entity_info", "name", "VARCHAR(64)"),
+            TableColumnConfig("entity_info", "flag", "VARCHAR(64)"),
         ],
     )
 
@@ -142,9 +142,53 @@ def test_xtdb_live_composite_primary_key_roundtrip():
             backend.dataframes(connection).table_insert(
                 pl.DataFrame(
                     {
-                        "vessel_id": [10, 10],
-                        "cargo_id": ["A", "B"],
-                        "destination": ["Tokyo", "Osaka"],
+                        "entity_id": [311038700],
+                        "name": ["ALPHA"],
+                        "flag": ["BS"],
+                    }
+                ),
+                table_config.schema,
+                table_config.name,
+                table_config=table_config,
+            )
+
+            result = backend.dataframes(connection).from_table(
+                table_config.schema,
+                table_config.name,
+            )
+
+    assert result.sort("_id").select(["_id", "name", "flag"]).to_dict(
+        as_series=False
+    ) == {
+        "_id": [311038700],
+        "name": ["ALPHA"],
+        "flag": ["BS"],
+    }
+
+
+def test_xtdb_live_composite_primary_key_roundtrip():
+    table_config = TableConfig(
+        schema="public",
+        name=f"live_composite_records_{int(time.time())}",
+        primary_keys=["entity_id", "record_id"],
+        columns=[
+            TableColumnConfig("records", "entity_id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "record_id", "VARCHAR(255)", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
+        ],
+    )
+
+    with _xtdb_engine() as engine:
+        with engine.connect() as connection:
+            backend = XtdbBackend()
+            backend.table_configs(connection).create(table_config)
+
+            backend.dataframes(connection).table_insert(
+                pl.DataFrame(
+                    {
+                        "entity_id": [10, 10],
+                        "record_id": ["A", "B"],
+                        "destination": ["Alpha", "Beta"],
                     }
                 ),
                 table_config.schema,
@@ -161,29 +205,29 @@ def test_xtdb_live_composite_primary_key_roundtrip():
                 table_config.name,
             )
 
-    assert result.sort("cargo_id").select(
-        ["_id", "vessel_id", "cargo_id", "destination"]
+    assert result.sort("record_id").select(
+        ["_id", "entity_id", "record_id", "destination"]
     ).to_dict(as_series=False) == {
         "_id": [
-            'xtdb-pk-v1:[["vessel_id",10],["cargo_id","A"]]',
-            'xtdb-pk-v1:[["vessel_id",10],["cargo_id","B"]]',
+            'xtdb-pk-v1:[["entity_id",10],["record_id","A"]]',
+            'xtdb-pk-v1:[["entity_id",10],["record_id","B"]]',
         ],
-        "vessel_id": [10, 10],
-        "cargo_id": ["A", "B"],
-        "destination": ["Tokyo", "Osaka"],
+        "entity_id": [10, 10],
+        "record_id": ["A", "B"],
+        "destination": ["Alpha", "Beta"],
     }
-    assert list(reflected_config.primary_keys) == ["vessel_id", "cargo_id"]
+    assert list(reflected_config.primary_keys) == ["entity_id", "record_id"]
 
 
 def test_xtdb_live_temporal_upsert_honours_update_time_system_time():
     table_config = TableConfig(
         schema="public",
-        name=f"live_temporal_cargos_{int(time.time())}",
+        name=f"live_temporal_records_{int(time.time())}",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
-            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "amount_value", "DOUBLE"),
         ],
     )
 
@@ -196,8 +240,8 @@ def test_xtdb_live_temporal_upsert_honours_update_time_system_time():
                 pl.DataFrame(
                     {
                         "id": [1],
-                        "destination": ["Tokyo"],
-                        "cargo_mcm": [10.5],
+                        "destination": ["Alpha"],
+                        "amount_value": [10.5],
                     }
                 ),
                 table_config.schema,
@@ -210,8 +254,8 @@ def test_xtdb_live_temporal_upsert_honours_update_time_system_time():
                 pl.DataFrame(
                     {
                         "id": [1],
-                        "destination": ["Osaka"],
-                        "cargo_mcm": [20.25],
+                        "destination": ["Beta"],
+                        "amount_value": [20.25],
                     }
                 ),
                 table_config.schema,
@@ -226,7 +270,7 @@ def test_xtdb_live_temporal_upsert_honours_update_time_system_time():
             def read_at(asof: datetime) -> pl.DataFrame:
                 timestamp = asof.isoformat()
                 return backend.dataframes(connection).from_raw_sql(
-                    "SELECT _id, destination, cargo_mcm "
+                    "SELECT _id, destination, amount_value "
                     f"FROM {table_sql} "
                     f"FOR VALID_TIME AS OF TIMESTAMP '{timestamp}' "
                     f"FOR SYSTEM_TIME AS OF TIMESTAMP '{timestamp}'"
@@ -241,31 +285,31 @@ def test_xtdb_live_temporal_upsert_honours_update_time_system_time():
             )
 
     assert asof_before_first.is_empty()
-    assert asof_after_second.select(["_id", "destination", "cargo_mcm"]).to_dict(
+    assert asof_after_second.select(["_id", "destination", "amount_value"]).to_dict(
         as_series=False
     ) == {
         "_id": [1],
-        "destination": ["Osaka"],
-        "cargo_mcm": [20.25],
+        "destination": ["Beta"],
+        "amount_value": [20.25],
     }
-    assert asof_between_updates.select(["_id", "destination", "cargo_mcm"]).to_dict(
+    assert asof_between_updates.select(["_id", "destination", "amount_value"]).to_dict(
         as_series=False
     ) == {
         "_id": [1],
-        "destination": ["Tokyo"],
-        "cargo_mcm": [10.5],
+        "destination": ["Alpha"],
+        "amount_value": [10.5],
     }
 
 
 def test_xtdb_live_delta_upsert_drops_unchanged_rows():
     table_config = TableConfig(
         schema="public",
-        name=f"live_delta_cargos_{int(time.time())}",
+        name=f"live_delta_records_{int(time.time())}",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
-            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "amount_value", "DOUBLE"),
         ],
     )
     delta_config = DeltaConfig(
@@ -282,8 +326,8 @@ def test_xtdb_live_delta_upsert_drops_unchanged_rows():
                 pl.DataFrame(
                     {
                         "id": [1],
-                        "destination": ["Tokyo"],
-                        "cargo_mcm": [10.5],
+                        "destination": ["Alpha"],
+                        "amount_value": [10.5],
                     }
                 ),
                 table_config.schema,
@@ -297,8 +341,8 @@ def test_xtdb_live_delta_upsert_drops_unchanged_rows():
                 pl.DataFrame(
                     {
                         "id": [1],
-                        "destination": ["Tokyo"],
-                        "cargo_mcm": [10.5],
+                        "destination": ["Alpha"],
+                        "amount_value": [10.5],
                     }
                 ),
                 table_config.schema,
@@ -312,8 +356,8 @@ def test_xtdb_live_delta_upsert_drops_unchanged_rows():
                 pl.DataFrame(
                     {
                         "id": [1],
-                        "destination": ["Osaka"],
-                        "cargo_mcm": [20.25],
+                        "destination": ["Beta"],
+                        "amount_value": [20.25],
                     }
                 ),
                 table_config.schema,
@@ -325,7 +369,7 @@ def test_xtdb_live_delta_upsert_drops_unchanged_rows():
             )
 
             history = backend.dataframes(connection).from_raw_sql(
-                "SELECT _id, destination, cargo_mcm, _system_from "
+                "SELECT _id, destination, amount_value, _system_from "
                 f"FROM {table_config.schema}.{table_config.name} "
                 "FOR VALID_TIME ALL FOR SYSTEM_TIME ALL "
                 "ORDER BY _system_from"
@@ -335,7 +379,7 @@ def test_xtdb_live_delta_upsert_drops_unchanged_rows():
             def read_at(asof: datetime) -> pl.DataFrame:
                 timestamp = asof.isoformat()
                 return backend.dataframes(connection).from_raw_sql(
-                    "SELECT _id, destination, cargo_mcm "
+                    "SELECT _id, destination, amount_value "
                     f"FROM {table_sql} "
                     f"FOR VALID_TIME AS OF TIMESTAMP '{timestamp}' "
                     f"FOR SYSTEM_TIME AS OF TIMESTAMP '{timestamp}'"
@@ -350,31 +394,31 @@ def test_xtdb_live_delta_upsert_drops_unchanged_rows():
     assert changed_count == 1
     system_from_values = [str(value) for value in history["_system_from"].to_list()]
     assert not any(value.startswith("2030-01-02") for value in system_from_values)
-    assert asof_after_unchanged.select(["_id", "destination", "cargo_mcm"]).to_dict(
+    assert asof_after_unchanged.select(["_id", "destination", "amount_value"]).to_dict(
         as_series=False
     ) == {
         "_id": [1],
-        "destination": ["Tokyo"],
-        "cargo_mcm": [10.5],
+        "destination": ["Alpha"],
+        "amount_value": [10.5],
     }
-    assert asof_after_changed.select(["_id", "destination", "cargo_mcm"]).to_dict(
+    assert asof_after_changed.select(["_id", "destination", "amount_value"]).to_dict(
         as_series=False
     ) == {
         "_id": [1],
-        "destination": ["Osaka"],
-        "cargo_mcm": [20.25],
+        "destination": ["Beta"],
+        "amount_value": [20.25],
     }
 
 
 def test_xtdb_live_delta_upsert_takes_last_duplicate_source_key():
     table_config = TableConfig(
         schema="public",
-        name=f"live_delta_duplicate_cargos_{int(time.time())}",
+        name=f"live_delta_duplicate_records_{int(time.time())}",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
-            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "amount_value", "DOUBLE"),
         ],
     )
     delta_config = DeltaConfig(
@@ -391,8 +435,8 @@ def test_xtdb_live_delta_upsert_takes_last_duplicate_source_key():
                 pl.DataFrame(
                     {
                         "id": [1, 1],
-                        "destination": ["Tokyo", "Osaka"],
-                        "cargo_mcm": [10.5, 20.25],
+                        "destination": ["Alpha", "Beta"],
+                        "amount_value": [10.5, 20.25],
                     }
                 ),
                 table_config.schema,
@@ -405,31 +449,31 @@ def test_xtdb_live_delta_upsert_takes_last_duplicate_source_key():
 
             timestamp = datetime(2030, 1, 2, tzinfo=timezone.utc).isoformat()
             result = backend.dataframes(connection).from_raw_sql(
-                "SELECT _id, destination, cargo_mcm "
+                "SELECT _id, destination, amount_value "
                 f"FROM {table_config.schema}.{table_config.name} "
                 f"FOR VALID_TIME AS OF TIMESTAMP '{timestamp}' "
                 f"FOR SYSTEM_TIME AS OF TIMESTAMP '{timestamp}'"
             )
 
     assert row_count == 1
-    assert result.select(["_id", "destination", "cargo_mcm"]).to_dict(
+    assert result.select(["_id", "destination", "amount_value"]).to_dict(
         as_series=False
     ) == {
         "_id": [1],
-        "destination": ["Osaka"],
-        "cargo_mcm": [20.25],
+        "destination": ["Beta"],
+        "amount_value": [20.25],
     }
 
 
 def test_xtdb_live_delta_upsert_dropout_deletes_missing_rows():
     table_config = TableConfig(
         schema="public",
-        name=f"live_delta_dropout_cargos_{int(time.time())}",
+        name=f"live_delta_dropout_records_{int(time.time())}",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
-            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "amount_value", "DOUBLE"),
         ],
     )
     delta_config = DeltaConfig(row_finality="dropout")
@@ -443,8 +487,8 @@ def test_xtdb_live_delta_upsert_dropout_deletes_missing_rows():
                 pl.DataFrame(
                     {
                         "id": [1, 2],
-                        "destination": ["Tokyo", "Osaka"],
-                        "cargo_mcm": [10.5, 20.25],
+                        "destination": ["Alpha", "Beta"],
+                        "amount_value": [10.5, 20.25],
                     }
                 ),
                 table_config.schema,
@@ -458,8 +502,8 @@ def test_xtdb_live_delta_upsert_dropout_deletes_missing_rows():
                 pl.DataFrame(
                     {
                         "id": [1],
-                        "destination": ["Tokyo"],
-                        "cargo_mcm": [10.5],
+                        "destination": ["Alpha"],
+                        "amount_value": [10.5],
                     }
                 ),
                 table_config.schema,
@@ -475,7 +519,7 @@ def test_xtdb_live_delta_upsert_dropout_deletes_missing_rows():
             def read_at(asof: datetime) -> pl.DataFrame:
                 timestamp = asof.isoformat()
                 return backend.dataframes(connection).from_raw_sql(
-                    "SELECT _id, destination, cargo_mcm "
+                    "SELECT _id, destination, amount_value "
                     f"FROM {table_sql} "
                     f"FOR VALID_TIME AS OF TIMESTAMP '{timestamp}' "
                     f"FOR SYSTEM_TIME AS OF TIMESTAMP '{timestamp}' "
@@ -486,19 +530,19 @@ def test_xtdb_live_delta_upsert_dropout_deletes_missing_rows():
             after_dropout = read_at(datetime(2030, 1, 3, tzinfo=timezone.utc))
 
     assert changed_count == 2
-    assert before_dropout.select(["_id", "destination", "cargo_mcm"]).to_dict(
+    assert before_dropout.select(["_id", "destination", "amount_value"]).to_dict(
         as_series=False
     ) == {
         "_id": [1, 2],
-        "destination": ["Tokyo", "Osaka"],
-        "cargo_mcm": [10.5, 20.25],
+        "destination": ["Alpha", "Beta"],
+        "amount_value": [10.5, 20.25],
     }
-    assert after_dropout.select(["_id", "destination", "cargo_mcm"]).to_dict(
+    assert after_dropout.select(["_id", "destination", "amount_value"]).to_dict(
         as_series=False
     ) == {
         "_id": [1],
-        "destination": ["Tokyo"],
-        "cargo_mcm": [10.5],
+        "destination": ["Alpha"],
+        "amount_value": [10.5],
     }
 
 
@@ -508,8 +552,8 @@ def test_xtdb_live_delta_upsert_dropout_closes_missing_rows_at_valid_time():
         name=f"live_delta_dropout_valid_close_{int(time.time())}",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
         ],
     )
     delta_config = DeltaConfig(row_finality="dropout")
@@ -523,7 +567,7 @@ def test_xtdb_live_delta_upsert_dropout_closes_missing_rows_at_valid_time():
                 pl.DataFrame(
                     {
                         "id": [1, 2],
-                        "destination": ["Tokyo", "Osaka"],
+                        "destination": ["Alpha", "Beta"],
                         "_valid_from": [datetime(1985, 1, 1)] * 2,
                     }
                 ),
@@ -537,7 +581,7 @@ def test_xtdb_live_delta_upsert_dropout_closes_missing_rows_at_valid_time():
                 pl.DataFrame(
                     {
                         "id": [1],
-                        "destination": ["Tokyo"],
+                        "destination": ["Alpha"],
                         "_valid_from": [datetime(1986, 1, 1)],
                     }
                 ),
@@ -567,7 +611,7 @@ def test_xtdb_live_delta_upsert_dropout_closes_missing_rows_at_valid_time():
         as_series=False
     ) == {
         "_id": [2],
-        "destination": ["Osaka"],
+        "destination": ["Beta"],
         "_valid_from": [datetime(1985, 1, 1)],
         "_valid_to": [datetime(1986, 1, 1)],
     }
@@ -576,12 +620,12 @@ def test_xtdb_live_delta_upsert_dropout_closes_missing_rows_at_valid_time():
 def test_xtdb_live_temporal_upsert_honours_explicit_valid_time_window():
     table_config = TableConfig(
         schema="public",
-        name=f"live_valid_window_cargos_{int(time.time())}",
+        name=f"live_valid_window_records_{int(time.time())}",
         primary_keys=["id"],
         columns=[
-            TableColumnConfig("cargos", "id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
-            TableColumnConfig("cargos", "cargo_mcm", "DOUBLE"),
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "amount_value", "DOUBLE"),
         ],
     )
 
@@ -594,8 +638,8 @@ def test_xtdb_live_temporal_upsert_honours_explicit_valid_time_window():
                 pl.DataFrame(
                     {
                         "id": [1],
-                        "destination": ["Tokyo"],
-                        "cargo_mcm": [10.5],
+                        "destination": ["Alpha"],
+                        "amount_value": [10.5],
                         "_valid_from": [datetime(2030, 1, 10, tzinfo=timezone.utc)],
                         "_valid_to": [datetime(2030, 1, 20, tzinfo=timezone.utc)],
                     }
@@ -613,7 +657,7 @@ def test_xtdb_live_temporal_upsert_honours_explicit_valid_time_window():
                 valid_timestamp = valid_asof.isoformat()
                 system_timestamp = datetime(2030, 1, 2, tzinfo=timezone.utc).isoformat()
                 return backend.dataframes(connection).from_raw_sql(
-                    "SELECT _id, destination, cargo_mcm "
+                    "SELECT _id, destination, amount_value "
                     f"FROM {table_sql} "
                     f"FOR VALID_TIME AS OF TIMESTAMP '{valid_timestamp}' "
                     f"FOR SYSTEM_TIME AS OF TIMESTAMP '{system_timestamp}'"
@@ -625,12 +669,12 @@ def test_xtdb_live_temporal_upsert_honours_explicit_valid_time_window():
 
     assert row_count == 1
     assert before_window.is_empty()
-    assert inside_window.select(["_id", "destination", "cargo_mcm"]).to_dict(
+    assert inside_window.select(["_id", "destination", "amount_value"]).to_dict(
         as_series=False
     ) == {
         "_id": [1],
-        "destination": ["Tokyo"],
-        "cargo_mcm": [10.5],
+        "destination": ["Alpha"],
+        "amount_value": [10.5],
     }
     assert after_window.is_empty()
 
@@ -639,20 +683,20 @@ def test_xtdb_live_staging_roundtrip_projects_and_cleans_batch():
     suffix = int(time.time())
     delta_table_config = TableConfig(
         schema="public",
-        name=f"live_stage_cargo_stream_{suffix}",
+        name=f"live_stage_record_stream_{suffix}",
         columns=[
-            TableColumnConfig("stage", "cargo_id", "BIGINT"),
+            TableColumnConfig("stage", "record_id", "BIGINT"),
             TableColumnConfig("stage", "destination_name", "VARCHAR(255)"),
             TableColumnConfig("stage", "msg_timestamp", "TIMESTAMP"),
         ],
     )
     target_table_config = TableConfig(
         schema="public",
-        name=f"live_stage_cargos_{suffix}",
-        primary_keys=["cargo_id"],
+        name=f"live_stage_records_{suffix}",
+        primary_keys=["record_id"],
         columns=[
-            TableColumnConfig("cargos", "cargo_id", "BIGINT", nullable=False),
-            TableColumnConfig("cargos", "destination", "VARCHAR(255)"),
+            TableColumnConfig("records", "record_id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
         ],
     )
     dataset = DatasetConfig(
@@ -665,7 +709,7 @@ def test_xtdb_live_staging_roundtrip_projects_and_cleans_batch():
                 "table": target_table_config.name,
                 "type": "primary",
                 "columns": [
-                    {"source": "cargo_id", "target": "cargo_id"},
+                    {"source": "record_id", "target": "record_id"},
                     {"source": "destination_name", "target": "destination"},
                 ],
             }
@@ -683,15 +727,15 @@ def test_xtdb_live_staging_roundtrip_projects_and_cleans_batch():
             inserted_count = staging.insert_partition(
                 pl.DataFrame(
                     {
-                        "cargo_id": [1, 1],
-                        "destination_name": ["Osaka", "Tokyo"],
+                        "record_id": [1, 1],
+                        "destination_name": ["Beta", "Alpha"],
                         "msg_timestamp": [partition_time, partition_time],
                     }
                 ),
                 delta_table_config,
                 "stage-live-1",
                 partition_time,
-                uniqueness_col_set=["cargo_id"],
+                uniqueness_col_set=["record_id"],
                 prefill_nulls_with_default=True,
             )
             projected = staging.prepare_pipeline_item_dataframe(
@@ -713,8 +757,8 @@ def test_xtdb_live_staging_roundtrip_projects_and_cleans_batch():
 
     assert inserted_count == 1
     assert projected.to_dict(as_series=False) == {
-        "cargo_id": [1],
-        "destination": ["Tokyo"],
+        "record_id": [1],
+        "destination": ["Alpha"],
         "msg_timestamp": [projected_partition_time],
     }
     assert remaining.is_empty()

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -35,10 +35,10 @@ def test_xtdb_staging_insert_partition_uses_retained_stage_table(monkeypatch):
 
     delta_table_config = TableConfig(
         schema="fakedata",
-        name="cargo_stream",
+        name="record_stream",
         columns=[
-            TableColumnConfig("cargo_stream", "cargo_id", "INT"),
-            TableColumnConfig("cargo_stream", "destination_name", "VARCHAR(64)"),
+            TableColumnConfig("record_stream", "record_id", "INT"),
+            TableColumnConfig("record_stream", "destination_name", "VARCHAR(64)"),
         ],
     )
     partition_time = datetime(2030, 1, 1, 12, 0, tzinfo=timezone.utc)
@@ -48,29 +48,29 @@ def test_xtdb_staging_insert_partition_uses_retained_stage_table(monkeypatch):
     inserted_count = staging.insert_partition(
         pl.DataFrame(
             {
-                "cargo_id": [1, 1],
-                "destination_name": ["Osaka", "Tokyo"],
+                "record_id": [1, 1],
+                "destination_name": ["Beta", "Alpha"],
             }
         ),
         delta_table_config,
         "stage-1",
         partition_time,
-        uniqueness_col_set=["cargo_id"],
+        uniqueness_col_set=["record_id"],
         prefill_nulls_with_default=True,
     )
 
     assert inserted_count == 1
     stage_config = created_configs[0]
     assert stage_config.schema == "fakedata"
-    assert stage_config.name == "__cargo_stream_stage"
+    assert stage_config.name == "__record_stream_stage"
     assert list(stage_config.primary_keys) == ["stage_run_id", "stage_row_index"]
     assert inserted["table_schema"] == "fakedata"
-    assert inserted["table_name"] == "__cargo_stream_stage"
-    assert inserted["table_config"].name == "__cargo_stream_stage"
+    assert inserted["table_name"] == "__record_stream_stage"
+    assert inserted["table_config"].name == "__record_stream_stage"
     assert inserted["df"].to_dict(as_series=False) == {
         "stage_row_index": [0],
-        "cargo_id": [1],
-        "destination_name": ["Tokyo"],
+        "record_id": [1],
+        "destination_name": ["Alpha"],
         "stage_run_id": ["stage-1"],
         "stage_partition_time": [partition_time],
     }
@@ -85,7 +85,7 @@ def test_xtdb_staging_projects_from_insert_cache_after_partition_insert(monkeypa
             schema={
                 "stage_run_id": pl.String,
                 "stage_row_index": pl.Int64,
-                "cargo_id": pl.Int64,
+                "record_id": pl.Int64,
                 "destination_name": pl.String,
             }
         )
@@ -101,23 +101,23 @@ def test_xtdb_staging_projects_from_insert_cache_after_partition_insert(monkeypa
 
     delta_table_config = TableConfig(
         schema="fakedata",
-        name="cargo_stream",
+        name="record_stream",
         columns=[
-            TableColumnConfig("cargo_stream", "cargo_id", "INT"),
-            TableColumnConfig("cargo_stream", "destination_name", "VARCHAR(64)"),
+            TableColumnConfig("record_stream", "record_id", "INT"),
+            TableColumnConfig("record_stream", "destination_name", "VARCHAR(64)"),
         ],
     )
     dataset = DatasetConfig(
-        name="cargo_stream",
+        name="record_stream",
         delta_table_schema="fakedata",
         input_config={"type": "dsv", "search_paths": []},
         pipeline=[
             {
                 "schema": "fakedata",
-                "table": "cargos",
+                "table": "records",
                 "type": "primary",
                 "columns": [
-                    {"source": "cargo_id", "target": "cargo_id"},
+                    {"source": "record_id", "target": "record_id"},
                     {"source": "destination_name", "target": "destination"},
                 ],
             }
@@ -125,21 +125,21 @@ def test_xtdb_staging_projects_from_insert_cache_after_partition_insert(monkeypa
     )
     table_config = TableConfig(
         schema="fakedata",
-        name="cargos",
-        primary_keys=["cargo_id"],
+        name="records",
+        primary_keys=["record_id"],
         columns=[
-            TableColumnConfig("cargos", "cargo_id", "INT"),
-            TableColumnConfig("cargos", "destination", "VARCHAR(64)"),
+            TableColumnConfig("records", "record_id", "INT"),
+            TableColumnConfig("records", "destination", "VARCHAR(64)"),
         ],
     )
     staging = XtdbStagingOps(object())
 
     staging.insert_partition(
-        pl.DataFrame({"cargo_id": [1], "destination_name": ["Tokyo"]}),
+        pl.DataFrame({"record_id": [1], "destination_name": ["Alpha"]}),
         delta_table_config,
         "stage-1",
         datetime(2030, 1, 1, tzinfo=timezone.utc),
-        uniqueness_col_set=["cargo_id"],
+        uniqueness_col_set=["record_id"],
         prefill_nulls_with_default=True,
     )
     result = staging.prepare_pipeline_item_dataframe(
@@ -151,8 +151,8 @@ def test_xtdb_staging_projects_from_insert_cache_after_partition_insert(monkeypa
     )
 
     assert result.to_dict(as_series=False) == {
-        "cargo_id": [1],
-        "destination": ["Tokyo"],
+        "record_id": [1],
+        "destination": ["Alpha"],
     }
     from_raw_sql.assert_not_called()
 
@@ -162,8 +162,8 @@ def test_xtdb_staging_projects_pipeline_item_with_valid_time_mapping(monkeypatch
         {
             "stage_run_id": ["stage-1"],
             "stage_row_index": [0],
-            "cargo_id": [1],
-            "destination_name": ["Tokyo"],
+            "record_id": [1],
+            "destination_name": ["Alpha"],
             "msg_timestamp": [datetime(2030, 1, 1, tzinfo=timezone.utc)],
             "ignored": ["not written"],
         }
@@ -174,16 +174,16 @@ def test_xtdb_staging_projects_pipeline_item_with_valid_time_mapping(monkeypatch
         from_raw_sql,
     )
     dataset = DatasetConfig(
-        name="cargo_stream",
+        name="record_stream",
         delta_table_schema="fakedata",
         input_config={"type": "dsv", "search_paths": []},
         pipeline=[
             {
                 "schema": "fakedata",
-                "table": "cargos",
+                "table": "records",
                 "type": "primary",
                 "columns": [
-                    {"source": "cargo_id", "target": "cargo_id"},
+                    {"source": "record_id", "target": "record_id"},
                     {"source": "destination_name", "target": "destination"},
                 ],
             }
@@ -191,11 +191,11 @@ def test_xtdb_staging_projects_pipeline_item_with_valid_time_mapping(monkeypatch
     )
     table_config = TableConfig(
         schema="fakedata",
-        name="cargos",
-        primary_keys=["cargo_id"],
+        name="records",
+        primary_keys=["record_id"],
         columns=[
-            TableColumnConfig("cargos", "cargo_id", "INT"),
-            TableColumnConfig("cargos", "destination", "VARCHAR(64)"),
+            TableColumnConfig("records", "record_id", "INT"),
+            TableColumnConfig("records", "destination", "VARCHAR(64)"),
         ],
     )
 
@@ -204,16 +204,16 @@ def test_xtdb_staging_projects_pipeline_item_with_valid_time_mapping(monkeypatch
         dataset,
         0,
         table_config,
-        valid_time=ValidTimeConfig(table="cargos", from_column="msg_timestamp"),
+        valid_time=ValidTimeConfig(table="records", from_column="msg_timestamp"),
     )
 
     assert result.to_dict(as_series=False) == {
-        "cargo_id": [1],
-        "destination": ["Tokyo"],
+        "record_id": [1],
+        "destination": ["Alpha"],
         "msg_timestamp": [datetime(2030, 1, 1, tzinfo=timezone.utc)],
     }
     from_raw_sql.assert_called_once_with(
-        "SELECT * FROM fakedata.__cargo_stream_stage "
+        "SELECT * FROM fakedata.__record_stream_stage "
         "WHERE stage_run_id = 'stage-1'::TEXT"
     )
 
@@ -225,16 +225,16 @@ def test_xtdb_staging_cleanup_deletes_only_batch_run():
     connection.in_transaction.return_value = False
     delta_table_config = TableConfig(
         schema="fakedata",
-        name="cargo_stream",
+        name="record_stream",
         columns=[
-            TableColumnConfig("cargo_stream", "cargo_id", "INT"),
+            TableColumnConfig("record_stream", "record_id", "INT"),
         ],
     )
 
     XtdbStagingOps(connection).cleanup_run("stage-1", delta_table_config)
 
     assert driver_connection.execute.call_args.args == (
-        "DELETE FROM fakedata.__cargo_stream_stage "
+        "DELETE FROM fakedata.__record_stream_stage "
         "WHERE stage_run_id = 'stage-1'::TEXT",
     )
 
@@ -342,7 +342,7 @@ def test_xtdb_staging_deduces_explicit_numeric_foreign_keys(monkeypatch):
             "stage_run_id": ["stage-1"],
             "stage_row_index": [0],
             "origin_location_id": [1001],
-            "origin_name": ["Bonny"],
+            "origin_name": ["Alpha"],
             "origin_country": ["Nigeria"],
         }
     )
@@ -375,12 +375,12 @@ def test_xtdb_staging_deduces_explicit_numeric_foreign_keys(monkeypatch):
         table_insert,
     )
     dataset = DatasetConfig(
-        name="cargo_stream",
-        delta_table_schema="kpler",
+        name="record_stream",
+        delta_table_schema="sample",
         input_config={"type": "dsv", "search_paths": []},
         pipeline=[
             {
-                "schema": "kpler",
+                "schema": "sample",
                 "table": "location_info",
                 "type": "extract",
                 "columns": [
@@ -394,7 +394,7 @@ def test_xtdb_staging_deduces_explicit_numeric_foreign_keys(monkeypatch):
                 ],
             },
             {
-                "schema": "kpler",
+                "schema": "sample",
                 "table": "trades",
                 "type": "primary",
                 "columns": [
@@ -404,7 +404,7 @@ def test_xtdb_staging_deduces_explicit_numeric_foreign_keys(monkeypatch):
         ],
     )
     table_config = TableConfig(
-        schema="kpler",
+        schema="sample",
         name="location_info",
         primary_keys=["id"],
         columns=[
@@ -422,17 +422,17 @@ def test_xtdb_staging_deduces_explicit_numeric_foreign_keys(monkeypatch):
         valid_time=None,
     )
 
-    assert inserted["table_schema"] == "kpler"
+    assert inserted["table_schema"] == "sample"
     assert inserted["table_name"] == "location_info"
     assert inserted["table_config"] == table_config
     assert inserted["df"].to_dict(as_series=False) == {
         "id": [1001],
-        "name": ["Bonny"],
+        "name": ["Alpha"],
         "country": ["Nigeria"],
     }
     assert result.to_dict(as_series=False) == {
         "id": [1001],
-        "name": ["Bonny"],
+        "name": ["Alpha"],
         "country": ["Nigeria"],
     }
 
@@ -482,12 +482,12 @@ def test_xtdb_staging_generates_numeric_foreign_key_when_source_key_is_missing(
         table_insert,
     )
     dataset = DatasetConfig(
-        name="cargo_stream",
-        delta_table_schema="kpler",
+        name="record_stream",
+        delta_table_schema="sample",
         input_config={"type": "dsv", "search_paths": []},
         pipeline=[
             {
-                "schema": "kpler",
+                "schema": "sample",
                 "table": "location_info",
                 "type": "extract",
                 "columns": [
@@ -501,7 +501,7 @@ def test_xtdb_staging_generates_numeric_foreign_key_when_source_key_is_missing(
                 ],
             },
             {
-                "schema": "kpler",
+                "schema": "sample",
                 "table": "trades",
                 "type": "primary",
                 "columns": [
@@ -514,7 +514,7 @@ def test_xtdb_staging_generates_numeric_foreign_key_when_source_key_is_missing(
         ],
     )
     table_config = TableConfig(
-        schema="kpler",
+        schema="sample",
         name="location_info",
         primary_keys=["id"],
         columns=[
@@ -588,12 +588,12 @@ def test_xtdb_staging_reuses_deduced_foreign_key_for_later_primary_item(
         lambda self, df, table_schema, table_name, table_config=None: df.height,
     )
     dataset = DatasetConfig(
-        name="cargo_stream",
-        delta_table_schema="kpler",
+        name="record_stream",
+        delta_table_schema="sample",
         input_config={"type": "dsv", "search_paths": []},
         pipeline=[
             {
-                "schema": "kpler",
+                "schema": "sample",
                 "table": "location_info",
                 "type": "extract",
                 "columns": [
@@ -607,7 +607,7 @@ def test_xtdb_staging_reuses_deduced_foreign_key_for_later_primary_item(
                 ],
             },
             {
-                "schema": "kpler",
+                "schema": "sample",
                 "table": "trades",
                 "type": "primary",
                 "columns": [
@@ -621,7 +621,7 @@ def test_xtdb_staging_reuses_deduced_foreign_key_for_later_primary_item(
         ],
     )
     location_config = TableConfig(
-        schema="kpler",
+        schema="sample",
         name="location_info",
         primary_keys=["id"],
         columns=[
@@ -631,7 +631,7 @@ def test_xtdb_staging_reuses_deduced_foreign_key_for_later_primary_item(
         ],
     )
     trades_config = TableConfig(
-        schema="kpler",
+        schema="sample",
         name="trades",
         primary_keys=["id"],
         columns=[
@@ -714,12 +714,12 @@ def test_xtdb_staging_does_not_insert_same_generated_parent_twice(
         table_insert,
     )
     dataset = DatasetConfig(
-        name="cargo_stream",
-        delta_table_schema="kpler",
+        name="record_stream",
+        delta_table_schema="sample",
         input_config={"type": "dsv", "search_paths": []},
         pipeline=[
             {
-                "schema": "kpler",
+                "schema": "sample",
                 "table": "location_info",
                 "type": "extract",
                 "columns": [
@@ -733,7 +733,7 @@ def test_xtdb_staging_does_not_insert_same_generated_parent_twice(
                 ],
             },
             {
-                "schema": "kpler",
+                "schema": "sample",
                 "table": "location_info",
                 "columns": [
                     {
@@ -746,7 +746,7 @@ def test_xtdb_staging_does_not_insert_same_generated_parent_twice(
                 ],
             },
             {
-                "schema": "kpler",
+                "schema": "sample",
                 "table": "trades",
                 "type": "primary",
                 "columns": [
@@ -756,7 +756,7 @@ def test_xtdb_staging_does_not_insert_same_generated_parent_twice(
         ],
     )
     location_config = TableConfig(
-        schema="kpler",
+        schema="sample",
         name="location_info",
         primary_keys=["id"],
         columns=[

--- a/tests/config/test_valid_time_config.py
+++ b/tests/config/test_valid_time_config.py
@@ -4,16 +4,16 @@ from polars_hist_db.config.config import ParityConfig
 
 def _dataset_config(**overrides):
     config = {
-        "name": "cargo_stream",
+        "name": "record_stream",
         "delta_table_schema": "fakedata",
         "input_config": {"type": "dsv", "search_paths": []},
         "pipeline": [
             {
-                "table": "cargos",
+                "table": "records",
                 "schema": "fakedata",
                 "type": "primary",
                 "columns": [
-                    {"source": "cargo_id", "target": "cargo_id"},
+                    {"source": "record_id", "target": "record_id"},
                 ],
             }
         ],
@@ -27,7 +27,7 @@ def test_dataset_config_parses_valid_time_mappings():
         valid_time=[
             {
                 "schema": "fakedata",
-                "table": "cargos",
+                "table": "records",
                 "from_column": "msg_timestamp",
                 "to_column": "valid_until",
             }
@@ -37,44 +37,46 @@ def test_dataset_config_parses_valid_time_mappings():
     assert dataset.valid_time == [
         ValidTimeConfig(
             schema="fakedata",
-            table="cargos",
+            table="records",
             from_column="msg_timestamp",
             to_column="valid_until",
         )
     ]
-    assert dataset.valid_time_for_table("fakedata", "cargos") == dataset.valid_time[0]
+    assert dataset.valid_time_for_table("fakedata", "records") == dataset.valid_time[0]
 
 
 def test_dataset_valid_time_lookup_allows_schema_omission():
     dataset = _dataset_config(
         valid_time=[
             {
-                "table": "cargos",
+                "table": "records",
                 "from_column": "_asof_dt",
             }
         ]
     )
 
-    assert dataset.valid_time_for_table("fakedata", "cargos") == ValidTimeConfig(
-        table="cargos",
+    assert dataset.valid_time_for_table("fakedata", "records") == ValidTimeConfig(
+        table="records",
         from_column="_asof_dt",
     )
-    assert dataset.valid_time_for_table("other", "vessels") is None
+    assert dataset.valid_time_for_table("other", "entities") is None
 
 
 def test_parity_config_parses_ignore_columns_and_semantic_foreign_keys():
     parity = ParityConfig(
-        ignore_columns=["kpler.location_info.id"],
+        ignore_columns=["sample.location_info.id"],
         semantic_foreign_keys=[
             {
-                "source": "kpler.trades.origin_location_id",
-                "target": "kpler.location_info.id",
+                "source": "sample.trades.origin_location_id",
+                "target": "sample.location_info.id",
                 "columns": ["name", "country"],
             }
         ],
     )
 
-    assert parity.ignore_columns == ("kpler.location_info.id",)
-    assert parity.semantic_foreign_keys[0].source == ("kpler.trades.origin_location_id")
-    assert parity.semantic_foreign_keys[0].target == "kpler.location_info.id"
+    assert parity.ignore_columns == ("sample.location_info.id",)
+    assert parity.semantic_foreign_keys[0].source == (
+        "sample.trades.origin_location_id"
+    )
+    assert parity.semantic_foreign_keys[0].target == "sample.location_info.id"
     assert parity.semantic_foreign_keys[0].columns == ("name", "country")


### PR DESCRIPTION
## Summary
- Quote reserved identifiers in generated XTDB insert column lists.
- Add unit and live XTDB regressions using neutral sample schemas and fixture names.
- Rename domain-specific test fixtures and backend-contract examples to generic records/entities.

## Root Cause
The XTDB SQL parser rejects some reserved words when they are emitted unquoted in insert column lists. The backend already had identifier quoting support, but its reserved identifier list did not cover this case.

## Verification
- `uv run --group dev python -m pytest tests/`
- `POLARS_HIST_DB_XTDB_LIVE=1 uv run --group dev --extra xtdb python -m pytest -o addopts="" tests/backends/test_xtdb_live.py::test_xtdb_live_insert_non_public_table_with_reserved_column_name`
- `uv run --group dev ruff check <touched-python-files>`
- `git diff --check`
- local domain-term scan over tests and source docs returned no matches