### PR TITLE
fix: bound XTDB insert chunk size

### DIFF
--- a/docs/configuration.qmd
+++ b/docs/configuration.qmd
@@ -32,6 +32,12 @@ XTDB uses two ports when both backend paths are enabled:
 - `port` defaults to `5432` for the pgwire/SQLAlchemy path.
 - `adbc_port` defaults to `9832` for the ADBC/FlightSQL path.
 
+XTDB writes are chunked by `max_rows_per_insert`, which defaults to `10000`.
+This bounds the size of each final insert/ingest transaction after staging,
+deduplication, transforms, foreign-key handling, and unchanged-row filtering
+have already run. Lower this value for smaller XTDB nodes or raise it only after
+load testing retained/replay workloads.
+
 ## table_configs
 
 A collection of tables that will be managed by this configuration.

--- a/polars_hist_db/backends/config.py
+++ b/polars_hist_db/backends/config.py
@@ -19,6 +19,12 @@ def _default_adbc_port(backend: str) -> Optional[int]:
     return None
 
 
+def _default_max_rows_per_insert(backend: str) -> Optional[int]:
+    if backend == "xtdb":
+        return 10_000
+    return None
+
+
 def _parse_port(value: Any, backend: str) -> int:
     if value is None:
         return _default_port(backend)
@@ -39,6 +45,27 @@ def _parse_optional_port(value: Any, backend: str) -> Optional[int]:
     return _default_adbc_port(backend)
 
 
+def _parse_optional_positive_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, str) and value.isdigit():
+        parsed = int(value)
+    else:
+        raise ValueError(f"Expected a positive integer or null, got {value!r}")
+
+    if parsed < 1:
+        raise ValueError(f"Expected a positive integer or null, got {value!r}")
+    return parsed
+
+
+def _parse_max_rows_per_insert(value: Any, backend: str) -> Optional[int]:
+    if value is None:
+        return _default_max_rows_per_insert(backend)
+    return _parse_optional_positive_int(value)
+
+
 @dataclass(frozen=True)
 class DbEngineConfig:
     backend: BackendName = "mariadb"
@@ -51,6 +78,7 @@ class DbEngineConfig:
     ssl_config: Optional[Mapping[str, Any]] = None
     pool_size: int = 3
     max_overflow: int = 2
+    max_rows_per_insert: Optional[int] = None
 
     @classmethod
     def from_mapping(cls, cfg: Mapping[str, Any]) -> "DbEngineConfig":
@@ -66,6 +94,9 @@ class DbEngineConfig:
             ssl_config=cfg.get("ssl_config"),
             pool_size=int(cfg.get("pool_size", 3)),
             max_overflow=int(cfg.get("max_overflow", 2)),
+            max_rows_per_insert=_parse_max_rows_per_insert(
+                cfg.get("max_rows_per_insert"), backend
+            ),
         )
 
 

--- a/polars_hist_db/backends/registry.py
+++ b/polars_hist_db/backends/registry.py
@@ -15,4 +15,12 @@ def get_backend(name: str = "mariadb"):
 
 
 def backend_from_config(config: DbEngineConfig):
+    if config.backend == "xtdb":
+        return XtdbBackend(
+            max_rows_per_insert=(
+                config.max_rows_per_insert
+                if config.max_rows_per_insert is not None
+                else XtdbBackend().max_rows_per_insert
+            )
+        )
     return get_backend(config.backend)

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -443,6 +443,18 @@ def _apply_xtdb_configured_column_dtypes(
     return df.with_columns(casts)
 
 
+def _iter_xtdb_insert_chunks(
+    df: pl.DataFrame,
+    max_rows_per_insert: Optional[int],
+) -> Iterable[pl.DataFrame]:
+    if max_rows_per_insert is None or df.height <= max_rows_per_insert:
+        yield df
+        return
+
+    for offset in range(0, df.height, max_rows_per_insert):
+        yield df.slice(offset, max_rows_per_insert)
+
+
 def _prepare_xtdb_insert_dataframe(
     df: pl.DataFrame,
     table_config: Optional[TableConfig],
@@ -1141,8 +1153,13 @@ def _cast_null_parent_lookup_columns(
 
 
 class XtdbDataframeOps:
-    def __init__(self, connection: Any):
+    def __init__(
+        self,
+        connection: Any,
+        max_rows_per_insert: Optional[int] = None,
+    ):
         self.connection = connection
+        self.max_rows_per_insert = max_rows_per_insert
 
     def from_raw_sql(
         self,
@@ -1266,49 +1283,62 @@ class XtdbDataframeOps:
     ) -> int:
         df = _prepare_xtdb_insert_dataframe(df, table_config)
         df = _apply_xtdb_configured_column_dtypes(df, table_config)
+        if df.is_empty():
+            return 0
+
         driver_connection = _driver_connection(self.connection)
         if driver_connection is not None:
-            if df.is_empty():
-                return 0
-
-            columns = [_quote_identifier(column) for column in df.columns]
-            column_sql = ", ".join(columns)
-            casts = _xtdb_insert_casts(df, table_config)
-            rows = df.rows()
-            values_sql = ", ".join(
-                "("
-                + ", ".join(
-                    _xtdb_sql_literal(value, cast)
-                    for value, cast in zip(row, casts, strict=True)
+            inserted_count = 0
+            for chunk in _iter_xtdb_insert_chunks(df, self.max_rows_per_insert):
+                columns = [_quote_identifier(column) for column in chunk.columns]
+                column_sql = ", ".join(columns)
+                casts = _xtdb_insert_casts(chunk, table_config)
+                rows = chunk.rows()
+                values_sql = ", ".join(
+                    "("
+                    + ", ".join(
+                        _xtdb_sql_literal(value, cast)
+                        for value, cast in zip(row, casts, strict=True)
+                    )
+                    + ")"
+                    for row in rows
                 )
-                + ")"
-                for row in rows
-            )
-            table_sql = _qualified_table_name(table_schema, table_name)
-            insert_sql = f"INSERT INTO {table_sql} ({column_sql}) VALUES {values_sql}"
-            _execute_xtdb_dml(
-                self.connection,
-                insert_sql,
-                system_time=update_time,
-            )
-            return len(rows)
+                table_sql = _qualified_table_name(table_schema, table_name)
+                insert_sql = (
+                    f"INSERT INTO {table_sql} ({column_sql}) VALUES {values_sql}"
+                )
+                _execute_xtdb_dml(
+                    self.connection,
+                    insert_sql,
+                    system_time=update_time,
+                )
+                inserted_count += len(rows)
+            return inserted_count
 
         if update_time is not None:
             raise ValueError(
                 "XTDB pgwire system-time writes require a live DBAPI connection"
             )
 
-        result = df.write_database(
-            table_name=f"{table_schema}.{table_name}",
-            connection=self.connection,
-            if_table_exists="append",
-        )
-        return int(result) if result is not None else 0
+        inserted_count = 0
+        for chunk in _iter_xtdb_insert_chunks(df, self.max_rows_per_insert):
+            result = chunk.write_database(
+                table_name=f"{table_schema}.{table_name}",
+                connection=self.connection,
+                if_table_exists="append",
+            )
+            inserted_count += int(result) if result is not None else 0
+        return inserted_count
 
 
 class XtdbAdbcDataframeOps:
-    def __init__(self, connection: Any):
+    def __init__(
+        self,
+        connection: Any,
+        max_rows_per_insert: Optional[int] = None,
+    ):
         self.connection = connection
+        self.max_rows_per_insert = max_rows_per_insert
 
     def from_raw_sql(
         self,
@@ -1363,14 +1393,15 @@ class XtdbAdbcDataframeOps:
 
         df = _prepare_xtdb_insert_dataframe(df, table_config)
         df = _apply_xtdb_configured_column_dtypes(df, table_config)
-        arrow_table = _normalize_xtdb_ingest_arrow(df.to_arrow())
-        with self.connection.cursor() as cursor:
-            cursor.adbc_ingest(
-                table_name,
-                arrow_table,
-                mode="create_append",
-                db_schema_name=table_schema,
-            )
+        for chunk in _iter_xtdb_insert_chunks(df, self.max_rows_per_insert):
+            arrow_table = _normalize_xtdb_ingest_arrow(chunk.to_arrow())
+            with self.connection.cursor() as cursor:
+                cursor.adbc_ingest(
+                    table_name,
+                    arrow_table,
+                    mode="create_append",
+                    db_schema_name=table_schema,
+                )
         return df.height
 
 
@@ -1892,6 +1923,7 @@ class XtdbStagingOps:
 @dataclass(frozen=True)
 class XtdbBackend:
     name: str = "xtdb"
+    max_rows_per_insert: Optional[int] = 10_000
 
     def create_engine(self, config: DbEngineConfig) -> Engine:
         database = config.database or "xtdb"
@@ -1919,10 +1951,16 @@ class XtdbBackend:
         return _load_flight_sql().connect(self.adbc_uri(config), autocommit=True)
 
     def dataframes(self, connection: Any) -> XtdbDataframeOps:
-        return XtdbDataframeOps(connection)
+        return XtdbDataframeOps(
+            connection,
+            max_rows_per_insert=self.max_rows_per_insert,
+        )
 
     def adbc_dataframes(self, connection: Any) -> XtdbAdbcDataframeOps:
-        return XtdbAdbcDataframeOps(connection)
+        return XtdbAdbcDataframeOps(
+            connection,
+            max_rows_per_insert=self.max_rows_per_insert,
+        )
 
     def table_configs(self, connection: Any) -> XtdbTableConfigOps:
         return XtdbTableConfigOps(connection)

--- a/tests/backends/test_registry.py
+++ b/tests/backends/test_registry.py
@@ -32,3 +32,13 @@ def test_backend_from_config_uses_db_engine_config_backend():
     backend = backend_from_config(DbEngineConfig(backend="xtdb"))
 
     assert isinstance(backend, XtdbBackend)
+    assert backend.max_rows_per_insert == 10_000
+
+
+def test_backend_from_config_passes_xtdb_max_rows_per_insert():
+    backend = backend_from_config(
+        DbEngineConfig(backend="xtdb", max_rows_per_insert=2500)
+    )
+
+    assert isinstance(backend, XtdbBackend)
+    assert backend.max_rows_per_insert == 2500

--- a/tests/backends/test_xtdb_adbc_ops.py
+++ b/tests/backends/test_xtdb_adbc_ops.py
@@ -135,6 +135,27 @@ def test_xtdb_adbc_dataframe_ops_targets_configured_schema():
     assert connection.cursor_instance.ingests[0][3] == {"db_schema_name": "analytics"}
 
 
+def test_xtdb_adbc_dataframe_ops_splits_ingest_by_max_rows():
+    connection = _FakeAdbcConnection()
+    ops = XtdbAdbcDataframeOps(connection, max_rows_per_insert=2)
+
+    result = ops.table_insert(
+        pl.DataFrame({"id": [1, 2, 3, 4, 5], "destination": ["A", "B", "C", "D", "E"]}),
+        "public",
+        "records",
+        table_config=_record_config(),
+    )
+
+    assert result == 5
+    ingests = connection.cursor_instance.ingests
+    assert len(ingests) == 3
+    assert [ingest[1].to_pydict() for ingest in ingests] == [
+        {"_id": [1, 2], "destination": ["A", "B"]},
+        {"_id": [3, 4], "destination": ["C", "D"]},
+        {"_id": [5], "destination": ["E"]},
+    ]
+
+
 def test_xtdb_backend_builds_adbc_uri():
     uri = XtdbBackend().adbc_uri(
         DbEngineConfig(backend="xtdb", hostname="127.0.0.1", adbc_port=19832)

--- a/tests/backends/test_xtdb_dataframe_ops.py
+++ b/tests/backends/test_xtdb_dataframe_ops.py
@@ -147,20 +147,32 @@ def test_xtdb_dataframe_ops_reads_table_with_configured_schema_overrides(monkeyp
     )
 
 
-def test_xtdb_dataframe_ops_writes_dataframe_via_polars_write_database():
-    df = Mock()
-    df.write_database.return_value = 7
+def test_xtdb_dataframe_ops_writes_dataframe_via_polars_write_database(monkeypatch):
+    captured = {}
+
+    def write_database(self, **kwargs):
+        captured["df"] = self
+        captured["kwargs"] = kwargs
+        return 2
+
+    monkeypatch.setattr(pl.DataFrame, "write_database", write_database)
+
+    df = pl.DataFrame({"_id": [1, 2], "destination": ["Alpha", "Beta"]})
     connection = object()
     ops = XtdbDataframeOps(connection)
 
     result = ops.table_insert(df, "test", "records")
 
-    assert result == 7
-    df.write_database.assert_called_once_with(
-        table_name="test.records",
-        connection=connection,
-        if_table_exists="append",
-    )
+    assert result == 2
+    assert captured["df"].to_dict(as_series=False) == {
+        "_id": [1, 2],
+        "destination": ["Alpha", "Beta"],
+    }
+    assert captured["kwargs"] == {
+        "table_name": "test.records",
+        "connection": connection,
+        "if_table_exists": "append",
+    }
 
 
 def test_xtdb_dataframe_ops_maps_configured_primary_key_to_id(monkeypatch):
@@ -269,6 +281,36 @@ def test_xtdb_dataframe_ops_uses_system_time_transaction_for_update_time():
     assert driver_connection.execute.call_args_list[0].args == (
         "BEGIN READ WRITE WITH (SYSTEM_TIME = TIMESTAMP '2030-01-01T12:00:00+00:00')",
     )
+
+
+def test_xtdb_dataframe_ops_splits_pgwire_insert_by_max_rows():
+    driver_connection = Mock()
+    connection = Mock()
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+    ops = XtdbDataframeOps(connection, max_rows_per_insert=2)
+
+    result = ops.table_insert(
+        pl.DataFrame(
+            {"_id": [1, 2, 3, 4, 5], "destination": ["A", "B", "C", "D", "E"]}
+        ),
+        "test",
+        "records",
+    )
+
+    assert result == 5
+    insert_sql = [
+        call.args[0]
+        for call in driver_connection.execute.call_args_list
+        if call.args[0].startswith("INSERT INTO")
+    ]
+    assert insert_sql == [
+        "INSERT INTO test.records (_id, destination) VALUES "
+        "(1::BIGINT, 'A'::TEXT), (2::BIGINT, 'B'::TEXT)",
+        "INSERT INTO test.records (_id, destination) VALUES "
+        "(3::BIGINT, 'C'::TEXT), (4::BIGINT, 'D'::TEXT)",
+        "INSERT INTO test.records (_id, destination) VALUES (5::BIGINT, 'E'::TEXT)",
+    ]
 
 
 def test_xtdb_dml_advances_reused_system_time_on_same_connection():

--- a/tests/config/test_db_engine_config.py
+++ b/tests/config/test_db_engine_config.py
@@ -52,3 +52,15 @@ def test_db_engine_config_defaults_xtdb_adbc_port():
     config = DbEngineConfig.from_mapping({"backend": "xtdb"})
 
     assert config.adbc_port == 9832
+    assert config.max_rows_per_insert == 10_000
+
+
+def test_db_engine_config_parses_max_rows_per_insert():
+    config = DbEngineConfig.from_mapping(
+        {
+            "backend": "xtdb",
+            "max_rows_per_insert": "2500",
+        }
+    )
+
+    assert config.max_rows_per_insert == 2500


### PR DESCRIPTION
## Summary
- add db.max_rows_per_insert with an XTDB default of 10000 rows
- propagate the configured value through backend_from_config into XTDB PgWire and ADBC dataframe ops
- split final XTDB inserts/ingests into bounded chunks after staging, transforms, dedupe, foreign-key handling, and unchanged-row filtering
- document the XTDB write chunking knob

## Verification
- uv run python -m pytest tests/backends/test_xtdb_dataframe_ops.py tests/backends/test_xtdb_adbc_ops.py tests/backends/test_xtdb_backend.py tests/backends/test_registry.py tests/config/test_db_engine_config.py
- uv run ruff format --check .
- uv run ruff check .
- uv run python -m pytest
- uv run mypy polars_hist_db