### PR TITLE
fix: tolerate missing nullable XTDB projection columns

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -1022,6 +1022,7 @@ def _project_xtdb_staged_pipeline_item_dataframe(
     stage_df: pl.DataFrame,
     dataset: Any,
     pipeline_id: int,
+    table_config: TableConfig,
     valid_time: Optional[ValidTimeConfig],
 ) -> pl.DataFrame:
     upload_items = dataset.pipeline.extract_items(pipeline_id)
@@ -1036,10 +1037,33 @@ def _project_xtdb_staged_pipeline_item_dataframe(
 
     missing_columns = sorted(set(selected_columns).difference(stage_df.columns))
     if missing_columns:
-        raise ValueError(
-            "column mismatch on "
-            f"{set(missing_columns)} in {upload_items['source'].to_list()}"
-        )
+        nullable_target_columns = {
+            column.name: column
+            for column in table_config.columns
+            if column.nullable and not column.autoincrement
+        }
+        fill_columns = []
+        rejected_columns = []
+        for source_column in missing_columns:
+            target_column_name = src_tgt_colname_map[source_column]
+            target_column = nullable_target_columns.get(target_column_name)
+            if target_column is None:
+                rejected_columns.append(source_column)
+                continue
+
+            dtype = _xtdb_polars_type_or_none(target_column.data_type)
+            null_literal = pl.lit(None)
+            if dtype is not None:
+                null_literal = null_literal.cast(dtype)
+            fill_columns.append(null_literal.alias(source_column))
+
+        if rejected_columns:
+            raise ValueError(
+                "column mismatch on "
+                f"{set(rejected_columns)} in {upload_items['source'].to_list()}"
+            )
+
+        stage_df = stage_df.with_columns(fill_columns)
 
     return stage_df.select(selected_columns).rename(
         {
@@ -1671,7 +1695,7 @@ class XtdbStagingOps:
         )
         self._stage_run_cache[stage_run_id] = stage_df
         projected_df = _project_xtdb_staged_pipeline_item_dataframe(
-            stage_df, dataset, pipeline_id, valid_time
+            stage_df, dataset, pipeline_id, table_config, valid_time
         )
         return self._filter_duplicate_projected_parent_rows(
             projected_df,

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 from unittest.mock import Mock
 
 import polars as pl
+import pytest
 
 from polars_hist_db.backends.xtdb import XtdbStagingOps
 from polars_hist_db.config import (
@@ -216,6 +217,111 @@ def test_xtdb_staging_projects_pipeline_item_with_valid_time_mapping(monkeypatch
         "SELECT * FROM fakedata.__record_stream_stage "
         "WHERE stage_run_id = 'stage-1'::TEXT"
     )
+
+
+def test_xtdb_staging_projects_missing_nullable_pipeline_columns(monkeypatch):
+    stage_df = pl.DataFrame(
+        {
+            "stage_run_id": ["stage-1"],
+            "stage_row_index": [0],
+            "record_id": [1],
+            "destination_name": ["Alpha"],
+        }
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
+        Mock(return_value=stage_df),
+    )
+    dataset = DatasetConfig(
+        name="record_stream",
+        delta_table_schema="fakedata",
+        input_config={"type": "dsv", "search_paths": []},
+        pipeline=[
+            {
+                "schema": "fakedata",
+                "table": "records",
+                "type": "primary",
+                "columns": [
+                    {"source": "record_id", "target": "record_id"},
+                    {"source": "destination_name", "target": "destination"},
+                    {"source": "source_note", "target": "source_note"},
+                ],
+            }
+        ],
+    )
+    table_config = TableConfig(
+        schema="fakedata",
+        name="records",
+        primary_keys=["record_id"],
+        columns=[
+            TableColumnConfig("records", "record_id", "INT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(64)"),
+            TableColumnConfig("records", "source_note", "VARCHAR(128)"),
+        ],
+    )
+
+    result = XtdbStagingOps(object()).prepare_pipeline_item_dataframe(
+        "stage-1",
+        dataset,
+        0,
+        table_config,
+        valid_time=None,
+    )
+
+    assert result.to_dict(as_series=False) == {
+        "record_id": [1],
+        "destination": ["Alpha"],
+        "source_note": [None],
+    }
+    assert result.schema["source_note"] == pl.String
+
+
+def test_xtdb_staging_rejects_missing_required_pipeline_columns(monkeypatch):
+    stage_df = pl.DataFrame(
+        {
+            "stage_run_id": ["stage-1"],
+            "stage_row_index": [0],
+            "record_id": [1],
+        }
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
+        Mock(return_value=stage_df),
+    )
+    dataset = DatasetConfig(
+        name="record_stream",
+        delta_table_schema="fakedata",
+        input_config={"type": "dsv", "search_paths": []},
+        pipeline=[
+            {
+                "schema": "fakedata",
+                "table": "records",
+                "type": "primary",
+                "columns": [
+                    {"source": "record_id", "target": "record_id"},
+                    {"source": "destination_name", "target": "destination"},
+                ],
+            }
+        ],
+    )
+    table_config = TableConfig(
+        schema="fakedata",
+        name="records",
+        primary_keys=["record_id"],
+        columns=[
+            TableColumnConfig("records", "record_id", "INT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(64)", nullable=False),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="column mismatch"):
+        XtdbStagingOps(object()).prepare_pipeline_item_dataframe(
+            "stage-1",
+            dataset,
+            0,
+            table_config,
+            valid_time=None,
+        )
 
 
 def test_xtdb_staging_cleanup_deletes_only_batch_run():


### PR DESCRIPTION
## Summary
- fill missing nullable XTDB projection columns with typed null values from the table config
- keep strict column mismatch errors for missing non-nullable target columns
- add regression coverage for both paths

## Verification
- uv run python -m pytest tests/
- uv run ruff check .
- uv run ruff format --check .
- uv run mypy .