### PR TITLE
fix: cast XTDB categorical values through strings

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -433,11 +433,16 @@ def _apply_xtdb_configured_column_dtypes(
         return df
 
     configured_dtypes = _xtdb_configured_column_dtypes(table_config)
-    casts = [
-        pl.col(column).cast(dtype, strict=False)
-        for column, dtype in configured_dtypes.items()
-        if column in df.columns
-    ]
+    casts = []
+    for column, dtype in configured_dtypes.items():
+        if column not in df.columns:
+            continue
+
+        source_expr = pl.col(column)
+        if df.schema[column] == pl.Categorical and dtype not in {pl.String, pl.Utf8}:
+            source_expr = source_expr.cast(pl.String)
+        casts.append(source_expr.cast(dtype, strict=False))
+
     if not casts:
         return df
     return df.with_columns(casts)

--- a/tests/backends/test_xtdb_dataframe_ops.py
+++ b/tests/backends/test_xtdb_dataframe_ops.py
@@ -444,6 +444,39 @@ def test_xtdb_dataframe_ops_casts_null_values_to_configured_types():
     assert "NULL::DOUBLE PRECISION" in insert_sql
 
 
+def test_xtdb_dataframe_ops_casts_categorical_values_to_configured_decimal():
+    driver_connection = Mock()
+    connection = Mock()
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+    ops = XtdbDataframeOps(connection)
+    table_config = TableConfig(
+        schema="test",
+        name="records",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "capacity", "DECIMAL(15,3)"),
+        ],
+    )
+
+    ops.table_insert(
+        pl.DataFrame(
+            {
+                "id": [1],
+                "capacity": ["12.345"],
+            },
+            schema_overrides={"capacity": pl.Categorical},
+        ),
+        "test",
+        "records",
+        table_config=table_config,
+    )
+
+    insert_sql = driver_connection.execute.call_args_list[1].args[0]
+    assert "12.345::DECIMAL(15,3)" in insert_sql
+
+
 def test_xtdb_dataframe_ops_quotes_reserved_insert_columns():
     driver_connection = Mock()
     connection = Mock()

--- a/uv.lock
+++ b/uv.lock
@@ -1491,7 +1491,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1537,7 +1537,7 @@ sqlalchemy = [
 
 [[package]]
 name = "polars-hist-db"
-version = "0.12.17"
+version = "0.12.18"
 source = { editable = "." }
 dependencies = [
     { name = "nats-py" },


### PR DESCRIPTION
## Summary
- cast categorical source columns through strings before applying configured non-string XTDB target types
- add regression coverage for categorical numeric values targeting configured Decimal columns
- refresh the lockfile to match the current package version

## Verification
- uv run python -m pytest tests/
- uv run ruff check .
- uv run ruff format --check .
- uv run mypy .