### PR TITLE
fix: support xtdb pgwire credentials

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import math
 import re
+from urllib.parse import quote
 from typing import Any, Iterable, Literal, Mapping, Optional, cast
 
 import polars as pl
@@ -2015,7 +2016,13 @@ class XtdbBackend:
 
     def create_engine(self, config: DbEngineConfig) -> Engine:
         database = config.database or "xtdb"
-        url = f"postgresql+psycopg://{config.hostname}:{config.port}/{database}"
+        auth = ""
+        if config.username:
+            auth = quote(config.username, safe="")
+            if config.password:
+                auth = f"{auth}:{quote(config.password, safe='')}"
+            auth = f"{auth}@"
+        url = f"postgresql+psycopg://{auth}{config.hostname}:{config.port}/{database}"
         engine = create_engine(
             url,
             connect_args={"prepare_threshold": None},

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -20,6 +20,25 @@ from polars_hist_db.config import (
 )
 
 
+def test_xtdb_create_engine_includes_configured_credentials():
+    config = DbEngineConfig(
+        backend="xtdb",
+        hostname="xtdb.example.internal",
+        port=5432,
+        database="xtdb",
+        username="xtdb",
+        password="secret/pass",
+    )
+
+    engine = XtdbBackend().create_engine(config)
+
+    assert str(engine.url) == (
+        "postgresql+psycopg://xtdb:***@xtdb.example.internal:5432/xtdb"
+    )
+    assert engine.url.username == "xtdb"
+    assert engine.url.password == "secret/pass"
+
+
 def test_xtdb_temporal_upsert_delegates_to_dataframe_insert():
     backend = XtdbBackend()
     ops = Mock()


### PR DESCRIPTION
## Summary
- include configured username/password in XTDB pgwire SQLAlchemy URLs
- URL-encode credentials before embedding them in the connection URL
- add a regression test covering credential-bearing XTDB configs

## Verification
- RED: UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/backends/test_xtdb_backend.py::test_xtdb_create_engine_includes_configured_credentials -q failed because credentials were omitted from the XTDB URL
- GREEN: UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/backends/test_xtdb_backend.py::test_xtdb_create_engine_includes_configured_credentials -q
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/backends/test_xtdb_backend.py -q
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check polars_hist_db/backends/xtdb.py tests/backends/test_xtdb_backend.py