### PR TITLE
fix: align XTDB staging projection with configured schema

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -22,6 +22,7 @@ from ..config import (
     ValidTimeConfig,
 )
 from ..core import TimeHint
+from ..pipeline_projection import project_staged_pipeline_item_dataframe
 from ..types import PolarsType
 from .config import DbEngineConfig
 from .temporal import system_time_hint_clause
@@ -1046,6 +1047,23 @@ def _fill_xtdb_staging_defaults(
     return _fill_xtdb_defaults(df, table_config)
 
 
+def _materialize_xtdb_missing_staging_columns(
+    df: pl.DataFrame, table_config: TableConfig
+) -> pl.DataFrame:
+    missing_columns = [
+        column for column in table_config.columns if column.name not in df.columns
+    ]
+    if not missing_columns:
+        return df
+
+    return df.with_columns(
+        pl.lit(_xtdb_default_value(column.default_value, column.data_type))
+        .cast(PolarsType.from_sql(column.data_type))
+        .alias(column.name)
+        for column in missing_columns
+    )
+
+
 def _dedupe_xtdb_staging_dataframe(
     df: pl.DataFrame, uniqueness_col_set: Iterable[str]
 ) -> pl.DataFrame:
@@ -1053,84 +1071,6 @@ def _dedupe_xtdb_staging_dataframe(
     if not unique_columns:
         return df.unique(keep="last", maintain_order=True)
     return df.unique(subset=unique_columns, keep="last", maintain_order=True)
-
-
-def _include_xtdb_valid_time_source_columns(
-    selected_columns: list[str],
-    src_tgt_colname_map: dict[str, str],
-    valid_time: Optional[ValidTimeConfig],
-    stage_df: pl.DataFrame,
-) -> list[str]:
-    result = list(selected_columns)
-    if valid_time is None:
-        return result
-
-    target_to_source = {
-        target: source for source, target in src_tgt_colname_map.items()
-    }
-    for valid_time_column in [valid_time.from_column, valid_time.to_column]:
-        if valid_time_column is None:
-            continue
-        source_column = target_to_source.get(valid_time_column, valid_time_column)
-        if source_column in stage_df.columns and source_column not in result:
-            result.append(source_column)
-    return result
-
-
-def _project_xtdb_staged_pipeline_item_dataframe(
-    stage_df: pl.DataFrame,
-    dataset: Any,
-    pipeline_id: int,
-    table_config: TableConfig,
-    valid_time: Optional[ValidTimeConfig],
-) -> pl.DataFrame:
-    upload_items = dataset.pipeline.extract_items(pipeline_id)
-    src_tgt_colname_map = dict(upload_items.select("source", "target").iter_rows())
-    selected_columns = upload_items["source"].to_list()
-    selected_columns = _include_xtdb_valid_time_source_columns(
-        selected_columns,
-        src_tgt_colname_map,
-        valid_time,
-        stage_df,
-    )
-
-    missing_columns = sorted(set(selected_columns).difference(stage_df.columns))
-    if missing_columns:
-        nullable_target_columns = {
-            column.name: column
-            for column in table_config.columns
-            if column.nullable and not column.autoincrement
-        }
-        fill_columns = []
-        rejected_columns = []
-        for source_column in missing_columns:
-            target_column_name = src_tgt_colname_map[source_column]
-            target_column = nullable_target_columns.get(target_column_name)
-            if target_column is None:
-                rejected_columns.append(source_column)
-                continue
-
-            dtype = _xtdb_polars_type_or_none(target_column.data_type)
-            null_literal = pl.lit(None)
-            if dtype is not None:
-                null_literal = null_literal.cast(dtype)
-            fill_columns.append(null_literal.alias(source_column))
-
-        if rejected_columns:
-            raise ValueError(
-                "column mismatch on "
-                f"{set(rejected_columns)} in {upload_items['source'].to_list()}"
-            )
-
-        stage_df = stage_df.with_columns(fill_columns)
-
-    return stage_df.select(selected_columns).rename(
-        {
-            source: target
-            for source, target in src_tgt_colname_map.items()
-            if source in selected_columns and source != target
-        }
-    )
 
 
 def _xtdb_deduced_foreign_key_columns(col_info: pl.DataFrame) -> dict[str, str]:
@@ -1717,6 +1657,7 @@ class XtdbStagingOps:
         if prefill_nulls_with_default:
             df = _fill_xtdb_staging_defaults(df, delta_table_config)
         df = _dedupe_xtdb_staging_dataframe(df, uniqueness_col_set)
+        df = _materialize_xtdb_missing_staging_columns(df, delta_table_config)
         df = df.with_row_index(_XTDB_STAGE_ROW_INDEX_COLUMN).with_columns(
             pl.lit(stage_run_id).alias(_XTDB_STAGE_RUN_ID_COLUMN),
             pl.lit(partition_time).alias(_XTDB_STAGE_PARTITION_TIME_COLUMN),
@@ -1759,7 +1700,7 @@ class XtdbStagingOps:
             table_config,
         )
         self._stage_run_cache[stage_run_id] = stage_df
-        projected_df = _project_xtdb_staged_pipeline_item_dataframe(
+        projected_df = project_staged_pipeline_item_dataframe(
             stage_df, dataset, pipeline_id, table_config, valid_time
         )
         return self._filter_duplicate_projected_parent_rows(

--- a/polars_hist_db/pipeline_projection.py
+++ b/polars_hist_db/pipeline_projection.py
@@ -1,0 +1,84 @@
+from typing import Any, Optional
+
+import polars as pl
+
+from .config import TableConfig, ValidTimeConfig
+from .types import PolarsType
+
+
+def _include_valid_time_source_columns(
+    selected_columns: list[str],
+    src_tgt_colname_map: dict[str, str],
+    valid_time: Optional[ValidTimeConfig],
+    stage_df: pl.DataFrame,
+) -> list[str]:
+    result = list(selected_columns)
+    if valid_time is None:
+        return result
+
+    target_to_source = {
+        target: source for source, target in src_tgt_colname_map.items()
+    }
+    for valid_time_column in [valid_time.from_column, valid_time.to_column]:
+        if valid_time_column is None:
+            continue
+        source_column = target_to_source.get(valid_time_column, valid_time_column)
+        if source_column in stage_df.columns and source_column not in result:
+            result.append(source_column)
+    return result
+
+
+def project_staged_pipeline_item_dataframe(
+    stage_df: pl.DataFrame,
+    dataset: Any,
+    pipeline_id: int,
+    table_config: TableConfig,
+    valid_time: Optional[ValidTimeConfig],
+) -> pl.DataFrame:
+    upload_items = dataset.pipeline.extract_items(pipeline_id)
+    src_tgt_colname_map = dict(upload_items.select("source", "target").iter_rows())
+    selected_columns = upload_items["source"].to_list()
+    selected_columns = _include_valid_time_source_columns(
+        selected_columns,
+        src_tgt_colname_map,
+        valid_time,
+        stage_df,
+    )
+
+    missing_columns = sorted(set(selected_columns).difference(stage_df.columns))
+    if missing_columns:
+        nullable_target_columns = {
+            column.name: column
+            for column in table_config.columns
+            if column.nullable and not column.autoincrement
+        }
+        fill_columns = []
+        rejected_columns = []
+        for source_column in missing_columns:
+            target_column_name = src_tgt_colname_map[source_column]
+            target_column = nullable_target_columns.get(target_column_name)
+            if target_column is None:
+                rejected_columns.append(source_column)
+                continue
+
+            fill_columns.append(
+                pl.lit(None)
+                .cast(PolarsType.from_sql(target_column.data_type))
+                .alias(source_column)
+            )
+
+        if rejected_columns:
+            raise ValueError(
+                "column mismatch on "
+                f"{set(rejected_columns)} in {upload_items['source'].to_list()}"
+            )
+
+        stage_df = stage_df.with_columns(fill_columns)
+
+    return stage_df.select(selected_columns).rename(
+        {
+            source: target
+            for source, target in src_tgt_colname_map.items()
+            if source in selected_columns and source != target
+        }
+    )

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -20,7 +20,18 @@ from polars_hist_db.config import (
 )
 
 
-def test_xtdb_create_engine_includes_configured_credentials():
+def test_xtdb_create_engine_includes_configured_credentials(monkeypatch):
+    calls = []
+    engine = Mock()
+    engine.dialect = SimpleNamespace()
+
+    def fake_create_engine(url, **kwargs):
+        calls.append((url, kwargs))
+        return engine
+
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.create_engine", fake_create_engine
+    )
     config = DbEngineConfig(
         backend="xtdb",
         hostname="xtdb.example.internal",
@@ -30,13 +41,13 @@ def test_xtdb_create_engine_includes_configured_credentials():
         password="secret/pass",
     )
 
-    engine = XtdbBackend().create_engine(config)
+    result = XtdbBackend().create_engine(config)
 
-    assert str(engine.url) == (
-        "postgresql+psycopg://xtdb:***@xtdb.example.internal:5432/xtdb"
+    assert result is engine
+    assert calls[0][0] == (
+        "postgresql+psycopg://xtdb:secret%2Fpass@xtdb.example.internal:5432/xtdb"
     )
-    assert engine.url.username == "xtdb"
-    assert engine.url.password == "secret/pass"
+    assert calls[0][1]["connect_args"] == {"prepare_threshold": None}
 
 
 def test_xtdb_temporal_upsert_delegates_to_dataframe_insert():

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -276,6 +276,107 @@ def test_xtdb_staging_projects_missing_nullable_pipeline_columns(monkeypatch):
     assert result.schema["source_note"] == pl.String
 
 
+def test_xtdb_staging_insert_cache_matches_stage_table_schema_for_missing_columns(
+    monkeypatch,
+):
+    inserted = {}
+
+    def table_insert(self, df, table_schema, table_name, table_config=None):
+        inserted["df"] = df
+        return df.height
+
+    from_raw_sql = Mock(
+        return_value=pl.DataFrame(
+            schema={
+                "stage_run_id": pl.String,
+                "stage_row_index": pl.Int64,
+                "record_id": pl.Int64,
+                "destination_name": pl.String,
+                "source_note": pl.String,
+            }
+        )
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_insert",
+        table_insert,
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
+        from_raw_sql,
+    )
+
+    delta_table_config = TableConfig(
+        schema="fakedata",
+        name="record_stream",
+        columns=[
+            TableColumnConfig("record_stream", "record_id", "INT", nullable=False),
+            TableColumnConfig("record_stream", "destination_name", "VARCHAR(64)"),
+            TableColumnConfig("record_stream", "source_note", "VARCHAR(128)"),
+        ],
+    )
+    dataset = DatasetConfig(
+        name="record_stream",
+        delta_table_schema="fakedata",
+        input_config={"type": "dsv", "search_paths": []},
+        pipeline=[
+            {
+                "schema": "fakedata",
+                "table": "records",
+                "type": "primary",
+                "columns": [
+                    {"source": "record_id", "target": "record_id"},
+                    {"source": "destination_name", "target": "destination"},
+                    {"source": "source_note", "target": "source_note"},
+                ],
+            }
+        ],
+    )
+    table_config = TableConfig(
+        schema="fakedata",
+        name="records",
+        primary_keys=["record_id"],
+        columns=[
+            TableColumnConfig("records", "record_id", "INT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(64)"),
+            TableColumnConfig("records", "source_note", "VARCHAR(128)"),
+        ],
+    )
+    staging = XtdbStagingOps(object())
+
+    staging.insert_partition(
+        pl.DataFrame({"record_id": [1], "destination_name": ["Alpha"]}),
+        delta_table_config,
+        "stage-1",
+        datetime(2030, 1, 1, tzinfo=timezone.utc),
+        uniqueness_col_set=["record_id"],
+        prefill_nulls_with_default=True,
+    )
+    result = staging.prepare_pipeline_item_dataframe(
+        "stage-1",
+        dataset,
+        0,
+        table_config,
+        valid_time=None,
+    )
+
+    assert result.to_dict(as_series=False) == {
+        "record_id": [1],
+        "destination": ["Alpha"],
+        "source_note": [None],
+    }
+    assert result.schema["source_note"] == pl.String
+    assert inserted["df"].to_dict(as_series=False) == {
+        "stage_row_index": [0],
+        "record_id": [1],
+        "destination_name": ["Alpha"],
+        "source_note": [None],
+        "stage_run_id": ["stage-1"],
+        "stage_partition_time": [datetime(2030, 1, 1, tzinfo=timezone.utc)],
+    }
+    assert inserted["df"].schema["source_note"] == pl.String
+    from_raw_sql.assert_not_called()
+
+
 def test_xtdb_staging_rejects_missing_required_pipeline_columns(monkeypatch):
     stage_df = pl.DataFrame(
         {


### PR DESCRIPTION
## Summary
- move staged pipeline source/target projection into a shared helper outside the XTDB backend
- materialize configured staging columns before XTDB insert/cache so cached stage reads match persisted stage table shape
- add a regression test covering missing configured staging columns in the insert cache

## Verification
- uv run pytest tests/backends/test_xtdb_staging_ops.py -q
- uv run pytest tests/backends/test_xtdb_backend.py -q
- uv run pytest tests/backends/test_xtdb_dataset_ingest.py -q
- uv run pytest tests/dataset/test_backend_entrypoint.py -q
- uv run pytest -q
- uv run ruff check .
- uv run mypy .