### PR TITLE
fix: cache empty xtdb staging partitions

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -1651,9 +1651,6 @@ class XtdbStagingOps:
         uniqueness_col_set: Iterable[str],
         prefill_nulls_with_default: bool,
     ) -> int:
-        if df.is_empty():
-            return 0
-
         if prefill_nulls_with_default:
             df = _fill_xtdb_staging_defaults(df, delta_table_config)
         df = _dedupe_xtdb_staging_dataframe(df, uniqueness_col_set)
@@ -1662,6 +1659,9 @@ class XtdbStagingOps:
             pl.lit(stage_run_id).alias(_XTDB_STAGE_RUN_ID_COLUMN),
             pl.lit(partition_time).alias(_XTDB_STAGE_PARTITION_TIME_COLUMN),
         )
+        if df.is_empty():
+            self._stage_run_cache[stage_run_id] = df
+            return 0
 
         stage_config = self.stage_table_config(delta_table_config)
         inserted_count = XtdbDataframeOps(self.connection).table_insert(

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -158,6 +158,78 @@ def test_xtdb_staging_projects_from_insert_cache_after_partition_insert(monkeypa
     from_raw_sql.assert_not_called()
 
 
+def test_xtdb_staging_projects_empty_insert_from_cache(monkeypatch):
+    table_insert = Mock(return_value=0)
+    from_raw_sql = Mock(
+        side_effect=AssertionError("empty staged partition should stay cached")
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_insert",
+        table_insert,
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
+        from_raw_sql,
+    )
+
+    delta_table_config = TableConfig(
+        schema="fakedata",
+        name="record_stream",
+        columns=[
+            TableColumnConfig("record_stream", "record_id", "INT"),
+            TableColumnConfig("record_stream", "destination_name", "VARCHAR(64)"),
+        ],
+    )
+    dataset = DatasetConfig(
+        name="record_stream",
+        delta_table_schema="fakedata",
+        input_config={"type": "dsv", "search_paths": []},
+        pipeline=[
+            {
+                "schema": "fakedata",
+                "table": "records",
+                "type": "primary",
+                "columns": [
+                    {"source": "record_id", "target": "record_id"},
+                    {"source": "destination_name", "target": "destination"},
+                ],
+            }
+        ],
+    )
+    table_config = TableConfig(
+        schema="fakedata",
+        name="records",
+        primary_keys=["record_id"],
+        columns=[
+            TableColumnConfig("records", "record_id", "INT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(64)"),
+        ],
+    )
+    staging = XtdbStagingOps(object())
+
+    inserted_count = staging.insert_partition(
+        pl.DataFrame(schema={"record_id": pl.Int64, "destination_name": pl.String}),
+        delta_table_config,
+        "stage-1",
+        datetime(2030, 1, 1, tzinfo=timezone.utc),
+        uniqueness_col_set=["record_id"],
+        prefill_nulls_with_default=True,
+    )
+    result = staging.prepare_pipeline_item_dataframe(
+        "stage-1",
+        dataset,
+        0,
+        table_config,
+        valid_time=None,
+    )
+
+    assert inserted_count == 0
+    assert result.is_empty()
+    assert result.schema == {"record_id": pl.Int64, "destination": pl.String}
+    table_insert.assert_not_called()
+    from_raw_sql.assert_not_called()
+
+
 def test_xtdb_staging_projects_pipeline_item_with_valid_time_mapping(monkeypatch):
     stage_df = pl.DataFrame(
         {


### PR DESCRIPTION
## Summary
- preserve empty XTDB staging partitions in the stage-run cache after schema materialization
- avoid querying an empty staging table result that has lost source-column schema
- add a regression covering empty projected batches with required source columns

## Verification
- uv run pytest -q tests/backends/test_xtdb_staging_ops.py::test_xtdb_staging_projects_empty_insert_from_cache
- uv run pytest -q tests/backends/test_xtdb_staging_ops.py
- uv run pytest -q tests/backends/test_xtdb_backend.py tests/backends/test_xtdb_staging_ops.py
- git diff --check