### PR TITLE
fix: apply xtdb insert row limit to staging writes

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -1584,11 +1584,22 @@ class XtdbTableConfigOps:
 
 
 class XtdbStagingOps:
-    def __init__(self, connection: Any):
+    def __init__(
+        self,
+        connection: Any,
+        max_rows_per_insert: Optional[int] = None,
+    ):
         self.connection = connection
+        self.max_rows_per_insert = max_rows_per_insert
         self._stage_run_cache: dict[str, pl.DataFrame] = {}
         self._inserted_parent_row_cache: set[tuple[str, str, str]] = set()
         self._projected_parent_row_cache: set[tuple[str, str, str]] = set()
+
+    def _dataframes(self) -> XtdbDataframeOps:
+        return XtdbDataframeOps(
+            self.connection,
+            max_rows_per_insert=self.max_rows_per_insert,
+        )
 
     def stage_table_config(self, delta_table_config: TableConfig) -> TableConfig:
         stage_table = _xtdb_stage_table_name(delta_table_config.name)
@@ -1664,7 +1675,7 @@ class XtdbStagingOps:
             return 0
 
         stage_config = self.stage_table_config(delta_table_config)
-        inserted_count = XtdbDataframeOps(self.connection).table_insert(
+        inserted_count = self._dataframes().table_insert(
             df,
             stage_config.schema,
             stage_config.name,
@@ -1689,7 +1700,7 @@ class XtdbStagingOps:
         stage_run_literal = _xtdb_sql_literal(stage_run_id, "TEXT")
         stage_df = self._stage_run_cache.get(stage_run_id)
         if stage_df is None:
-            stage_df = XtdbDataframeOps(self.connection).from_raw_sql(
+            stage_df = self._dataframes().from_raw_sql(
                 f"SELECT * FROM {table_name} "
                 f"WHERE {_XTDB_STAGE_RUN_ID_COLUMN} = {stage_run_literal}"
             )
@@ -1842,7 +1853,7 @@ class XtdbStagingOps:
                     pl.coalesce(target_column, generated_value).alias(target_column)
                 )
 
-        parent_df = XtdbDataframeOps(self.connection).from_table(
+        parent_df = self._dataframes().from_table(
             table_config.schema,
             table_config.name,
         )
@@ -1919,7 +1930,7 @@ class XtdbStagingOps:
                 schema=parent_rows_to_insert.schema,
             )
         if not parent_rows_to_insert.is_empty():
-            XtdbDataframeOps(self.connection).table_insert(
+            self._dataframes().table_insert(
                 parent_rows_to_insert,
                 table_config.schema,
                 table_config.name,
@@ -2002,7 +2013,10 @@ class XtdbBackend:
         return XtdbTableConfigOps(connection)
 
     def staging(self, connection: Any) -> XtdbStagingOps:
-        return XtdbStagingOps(connection)
+        return XtdbStagingOps(
+            connection,
+            max_rows_per_insert=self.max_rows_per_insert,
+        )
 
     def time_hint_clause(self, time_hint: TimeHint) -> str | None:
         return system_time_hint_clause(time_hint)

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 import polars as pl
 import pytest
 
-from polars_hist_db.backends.xtdb import XtdbStagingOps
+from polars_hist_db.backends.xtdb import XtdbBackend, XtdbStagingOps
 from polars_hist_db.config import (
     DatasetConfig,
     TableColumnConfig,
@@ -75,6 +75,51 @@ def test_xtdb_staging_insert_partition_uses_retained_stage_table(monkeypatch):
         "stage_run_id": ["stage-1"],
         "stage_partition_time": [partition_time],
     }
+
+
+def test_xtdb_staging_insert_partition_preserves_insert_row_limit(monkeypatch):
+    observed = {}
+
+    def table_insert(self, df, table_schema, table_name, table_config=None):
+        observed["max_rows_per_insert"] = self.max_rows_per_insert
+        return df.height
+
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_insert",
+        table_insert,
+    )
+
+    delta_table_config = TableConfig(
+        schema="fakedata",
+        name="record_stream",
+        columns=[
+            TableColumnConfig("record_stream", "record_id", "INT"),
+            TableColumnConfig("record_stream", "destination_name", "VARCHAR(64)"),
+        ],
+    )
+    staging = XtdbStagingOps(object(), max_rows_per_insert=2500)
+
+    staging.insert_partition(
+        pl.DataFrame(
+            {
+                "record_id": [1, 2],
+                "destination_name": ["Alpha", "Beta"],
+            }
+        ),
+        delta_table_config,
+        "stage-1",
+        datetime(2030, 1, 1, 12, 0, tzinfo=timezone.utc),
+        uniqueness_col_set=["record_id"],
+        prefill_nulls_with_default=True,
+    )
+
+    assert observed["max_rows_per_insert"] == 2500
+
+
+def test_xtdb_backend_staging_preserves_insert_row_limit():
+    staging = XtdbBackend(max_rows_per_insert=2500).staging(object())
+
+    assert staging.max_rows_per_insert == 2500
 
 
 def test_xtdb_staging_projects_from_insert_cache_after_partition_insert(monkeypatch):


### PR DESCRIPTION
## Summary
- pass the configured XTDB insert row limit into staging operations
- route staging-owned dataframe reads/writes through configured dataframe ops
- add regression coverage for the staging boundary

## Root cause
Staging writes created raw XTDB dataframe ops without the backend row limit, so large staged partitions could be sent as one oversized insert even though the backend had a configured insert limit.

## Verification
- uv run pytest -q tests/backends/test_xtdb_staging_ops.py::test_xtdb_staging_insert_partition_preserves_insert_row_limit
- uv run pytest -q tests/backends/test_xtdb_staging_ops.py tests/backends/test_xtdb_dataframe_ops.py tests/backends/test_xtdb_backend.py tests/backends/test_registry.py tests/config/test_db_engine_config.py
- git diff --check