### PR TITLE
fix: parameterize xtdb pgwire inserts

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 import hashlib
 import json
@@ -602,11 +602,17 @@ def _delete_xtdb_missing_rows(
     update_time: Optional[datetime],
     dropout_close_time: Optional[datetime],
 ) -> int:
-    current = dataframe_ops.from_raw_sql(
-        "SELECT _id FROM "
-        f"{_qualified_table_name(table_schema, table_name)}"
-        f"{_xtdb_temporal_basis_clause(update_time)}"
-    )
+    try:
+        current = dataframe_ops.from_raw_sql(
+            "SELECT _id FROM "
+            f"{_qualified_table_name(table_schema, table_name)}"
+            f"{_xtdb_temporal_basis_clause(update_time)}"
+        )
+    except Exception as exc:
+        if _is_xtdb_table_not_found_error(exc):
+            _rollback_xtdb_connection(dataframe_ops.connection)
+            return 0
+        raise
     if current.is_empty():
         return 0
 
@@ -701,6 +707,61 @@ def _is_xtdb_invalid_system_time_error(exc: Exception) -> bool:
     return "invalid-system-time" in message or "specified system-time older" in message
 
 
+def _is_xtdb_table_not_found_error(exc: Exception) -> bool:
+    return "Table not found:" in str(exc)
+
+
+def _rollback_xtdb_connection(connection: Any) -> None:
+    rollback = getattr(connection, "rollback", None)
+    if callable(rollback):
+        rollback()
+
+
+def _configure_xtdb_pgwire_parameter_adapters(driver_connection: Any) -> None:
+    adapters = getattr(driver_connection, "adapters", None)
+    register_dumper = getattr(adapters, "register_dumper", None)
+    if not callable(register_dumper):
+        return
+
+    try:
+        from psycopg.types.string import StrDumper
+    except ModuleNotFoundError:
+        return
+
+    register_dumper(str, StrDumper)
+
+
+def _xtdb_parameter_value(value: Any, cast_type: str) -> Any:
+    if (
+        isinstance(value, datetime)
+        and cast_type.upper().startswith("TIMESTAMP")
+        and value.tzinfo is not None
+    ):
+        return value.astimezone(timezone.utc).replace(tzinfo=None)
+    return value
+
+
+def _normalize_xtdb_timestamp_columns(
+    df: pl.DataFrame,
+    table_config: Optional[TableConfig],
+) -> pl.DataFrame:
+    casts = _xtdb_insert_casts(df, table_config)
+    expressions = []
+    for column, cast_type in zip(df.columns, casts, strict=True):
+        dtype = df.schema[column]
+        if (
+            isinstance(dtype, pl.Datetime)
+            and dtype.time_zone is not None
+            and cast_type.upper().startswith("TIMESTAMP")
+        ):
+            expressions.append(
+                pl.col(column).dt.convert_time_zone("UTC").dt.replace_time_zone(None)
+            )
+    if not expressions:
+        return df
+    return df.with_columns(expressions)
+
+
 def _execute_xtdb_dml(
     connection: Any,
     sql: str,
@@ -734,8 +795,14 @@ def _execute_xtdb_dml(
             driver_connection.execute(sql)
             row_count = 0
         else:
-            with driver_connection.cursor() as cursor:
+            _configure_xtdb_pgwire_parameter_adapters(driver_connection)
+            cursor = driver_connection.cursor()
+            try:
                 cursor.executemany(sql, rows)
+            finally:
+                close = getattr(cursor, "close", None)
+                if callable(close):
+                    close()
             row_count = len(rows)
         driver_connection.commit()
     except Exception as exc:
@@ -965,9 +1032,15 @@ def _filter_xtdb_unchanged_rows(
     incoming = _prepare_xtdb_insert_dataframe(indexed_df, table_config)
 
     table_sql = _qualified_table_name(table_schema, table_name)
-    current = dataframe_ops.from_raw_sql(
-        f"SELECT * FROM {table_sql}{_xtdb_temporal_basis_clause(update_time)}"
-    )
+    try:
+        current = dataframe_ops.from_raw_sql(
+            f"SELECT * FROM {table_sql}{_xtdb_temporal_basis_clause(update_time)}"
+        )
+    except Exception as exc:
+        if _is_xtdb_table_not_found_error(exc):
+            _rollback_xtdb_connection(dataframe_ops.connection)
+            return df
+        raise
     current = _restore_xtdb_logical_columns(current, table_config)
     if current.is_empty():
         return df
@@ -1322,16 +1395,14 @@ class XtdbDataframeOps:
                 columns = [_xtdb_column_identifier(column) for column in chunk.columns]
                 column_sql = ", ".join(columns)
                 casts = _xtdb_insert_casts(chunk, table_config)
-                rows = chunk.rows()
-                values_sql = ", ".join(
-                    "("
-                    + ", ".join(
-                        _xtdb_sql_literal(value, cast)
+                rows = [
+                    tuple(
+                        _xtdb_parameter_value(value, cast)
                         for value, cast in zip(row, casts, strict=True)
                     )
-                    + ")"
-                    for row in rows
-                )
+                    for row in chunk.rows()
+                ]
+                values_sql = "(" + ", ".join(f"%s::{cast}" for cast in casts) + ")"
                 table_sql = _qualified_table_name(table_schema, table_name)
                 insert_sql = (
                     f"INSERT INTO {table_sql} ({column_sql}) VALUES {values_sql}"
@@ -1339,6 +1410,7 @@ class XtdbDataframeOps:
                 _execute_xtdb_dml(
                     self.connection,
                     insert_sql,
+                    rows,
                     system_time=update_time,
                 )
                 inserted_count += len(rows)
@@ -1675,6 +1747,7 @@ class XtdbStagingOps:
             return 0
 
         stage_config = self.stage_table_config(delta_table_config)
+        df = _normalize_xtdb_timestamp_columns(df, stage_config)
         inserted_count = self._dataframes().table_insert(
             df,
             stage_config.schema,

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -157,9 +157,11 @@ def test_xtdb_temporal_upsert_dropout_deletes_missing_current_keys():
     assert result == 2
     executed_sql = [call.args[0] for call in driver_connection.execute.call_args_list]
     assert executed_sql[1] == "DELETE FROM test.records WHERE _id IN (2::BIGINT)"
-    assert executed_sql[3] == (
-        "INSERT INTO test.records (_id, destination) VALUES (1::BIGINT, 'Alpha'::TEXT)"
+    insert_call = driver_connection.cursor.return_value.executemany.call_args
+    assert insert_call.args[0] == (
+        "INSERT INTO test.records (_id, destination) VALUES (%s::BIGINT, %s::TEXT)"
     )
+    assert insert_call.args[1] == [(1, "Alpha")]
 
 
 def test_xtdb_temporal_upsert_dropout_closes_missing_keys_at_valid_time():
@@ -324,6 +326,70 @@ def test_xtdb_temporal_upsert_takes_last_duplicate_source_key():
         "id": [1],
         "destination": ["Beta"],
     }
+
+
+def test_xtdb_temporal_upsert_drop_unchanged_treats_missing_table_as_empty():
+    backend = XtdbBackend()
+    ops = Mock()
+    ops.from_raw_sql.side_effect = Exception("Table not found: test.records")
+    ops.table_insert.return_value = 1
+    table_config = TableConfig(
+        schema="test",
+        name="records",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
+        ],
+    )
+
+    result = backend.temporal_upsert(
+        pl.DataFrame({"id": [1], "destination": ["Alpha"]}),
+        "test",
+        "records",
+        dataframe_ops=ops,
+        table_config=table_config,
+        delta_config=DeltaConfig(drop_unchanged_rows=True),
+    )
+
+    assert result == 1
+    written_df = ops.table_insert.call_args.args[0]
+    assert written_df.to_dict(as_series=False) == {
+        "id": [1],
+        "destination": ["Alpha"],
+    }
+
+
+def test_xtdb_temporal_upsert_dropout_treats_missing_table_as_empty():
+    backend = XtdbBackend()
+    driver_connection = Mock()
+    connection = Mock()
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+    ops = XtdbDataframeOps(connection)
+    ops.from_raw_sql = Mock(side_effect=Exception("Table not found: test.records"))
+    table_config = TableConfig(
+        schema="test",
+        name="records",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "destination", "VARCHAR(255)"),
+        ],
+    )
+
+    result = backend.temporal_upsert(
+        pl.DataFrame({"id": [1], "destination": ["Alpha"]}),
+        "test",
+        "records",
+        dataframe_ops=ops,
+        table_config=table_config,
+        delta_config=DeltaConfig(row_finality="dropout"),
+    )
+
+    assert result == 1
+    executed_sql = [call.args[0] for call in driver_connection.execute.call_args_list]
+    assert not any(sql.startswith("DELETE FROM") for sql in executed_sql)
 
 
 def test_xtdb_temporal_upsert_treats_explicit_valid_time_change_as_changed():

--- a/tests/backends/test_xtdb_dataframe_ops.py
+++ b/tests/backends/test_xtdb_dataframe_ops.py
@@ -1,6 +1,8 @@
-from unittest.mock import Mock
+import builtins
 from datetime import datetime, timezone
+from decimal import Decimal
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import polars as pl
 import pytest
@@ -12,6 +14,10 @@ from polars_hist_db.backends.xtdb import (
 )
 from polars_hist_db.config import TableColumnConfig, TableConfig
 from polars_hist_db.core import TimeHint
+
+
+def _single_executemany_call(driver_connection: Mock):
+    return driver_connection.cursor.return_value.executemany.call_args
 
 
 def test_xtdb_dataframe_ops_reads_raw_sql_with_schema_overrides(monkeypatch):
@@ -328,6 +334,7 @@ def test_xtdb_dataframe_ops_uses_system_time_transaction_for_update_time():
 
 def test_xtdb_dataframe_ops_splits_pgwire_insert_by_max_rows():
     driver_connection = Mock()
+    cursor = driver_connection.cursor.return_value
     connection = Mock()
     connection.connection.driver_connection = driver_connection
     connection.in_transaction.return_value = False
@@ -342,17 +349,16 @@ def test_xtdb_dataframe_ops_splits_pgwire_insert_by_max_rows():
     )
 
     assert result == 5
-    insert_sql = [
-        call.args[0]
-        for call in driver_connection.execute.call_args_list
-        if call.args[0].startswith("INSERT INTO")
-    ]
+    insert_sql = [call.args[0] for call in cursor.executemany.call_args_list]
     assert insert_sql == [
-        "INSERT INTO test.records (_id, destination) VALUES "
-        "(1::BIGINT, 'A'::TEXT), (2::BIGINT, 'B'::TEXT)",
-        "INSERT INTO test.records (_id, destination) VALUES "
-        "(3::BIGINT, 'C'::TEXT), (4::BIGINT, 'D'::TEXT)",
-        "INSERT INTO test.records (_id, destination) VALUES (5::BIGINT, 'E'::TEXT)",
+        "INSERT INTO test.records (_id, destination) VALUES (%s::BIGINT, %s::TEXT)",
+        "INSERT INTO test.records (_id, destination) VALUES (%s::BIGINT, %s::TEXT)",
+        "INSERT INTO test.records (_id, destination) VALUES (%s::BIGINT, %s::TEXT)",
+    ]
+    assert [call.args[1] for call in cursor.executemany.call_args_list] == [
+        [(1, "A"), (2, "B")],
+        [(3, "C"), (4, "D")],
+        [(5, "E")],
     ]
 
 
@@ -402,6 +408,81 @@ def test_xtdb_dml_advances_reused_system_time_on_same_connection():
     ]
 
 
+def test_xtdb_dml_registers_text_dumper_for_parameterized_rows():
+    string_types = pytest.importorskip("psycopg.types.string")
+
+    driver_connection = Mock()
+    connection = Mock()
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+
+    _execute_xtdb_dml(
+        connection,
+        "INSERT INTO test.records (_id, destination) VALUES (%s::BIGINT, %s::TEXT)",
+        [(1, "Alpha")],
+    )
+
+    driver_connection.adapters.register_dumper.assert_any_call(
+        str, string_types.StrDumper
+    )
+
+
+def test_xtdb_dml_skips_text_dumper_when_psycopg_is_unavailable(monkeypatch):
+    original_import = builtins.__import__
+
+    def import_without_psycopg(name, *args, **kwargs):
+        if name.startswith("psycopg"):
+            raise ModuleNotFoundError("No module named 'psycopg'")
+        return original_import(name, *args, **kwargs)
+
+    driver_connection = Mock()
+    connection = Mock()
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+    monkeypatch.setattr(builtins, "__import__", import_without_psycopg)
+
+    _execute_xtdb_dml(
+        connection,
+        "INSERT INTO test.records (_id, destination) VALUES (%s::BIGINT, %s::TEXT)",
+        [(1, "Alpha")],
+    )
+
+    driver_connection.adapters.register_dumper.assert_not_called()
+
+
+def test_xtdb_dataframe_ops_normalizes_bound_timestamp_parameters_to_naive_utc():
+    driver_connection = Mock()
+    connection = Mock()
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+    ops = XtdbDataframeOps(connection)
+    table_config = TableConfig(
+        schema="test",
+        name="records",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "seen_at", "DATETIME"),
+        ],
+    )
+
+    ops.table_insert(
+        pl.DataFrame(
+            {
+                "id": [1],
+                "seen_at": [datetime(2030, 1, 1, 12, 30, tzinfo=timezone.utc)],
+            }
+        ),
+        "test",
+        "records",
+        table_config=table_config,
+    )
+
+    insert_call = _single_executemany_call(driver_connection)
+    assert "%s::TIMESTAMP" in insert_call.args[0]
+    assert insert_call.args[1] == [(1, datetime(2030, 1, 1, 12, 30))]
+
+
 def test_xtdb_dataframe_ops_uses_native_casts_for_mysql_compatibility_types():
     driver_connection = Mock()
     connection = Mock()
@@ -442,14 +523,25 @@ def test_xtdb_dataframe_ops_uses_native_casts_for_mysql_compatibility_types():
         table_config=table_config,
     )
 
-    insert_sql = driver_connection.execute.call_args_list[1].args[0]
-    assert "TRUE::BOOLEAN" in insert_sql
-    assert "1::INTEGER" in insert_sql
-    assert "2::INTEGER" in insert_sql
-    assert "738221::INTEGER" in insert_sql
-    assert "4::INTEGER" in insert_sql
-    assert "'2030-01-01T12:00:00'::TIMESTAMP" in insert_sql
-    assert "'12:30:00'::TIME" in insert_sql
+    insert_call = _single_executemany_call(driver_connection)
+    insert_sql = insert_call.args[0]
+    assert "INSERT INTO test.compat_types" in insert_sql
+    assert "%s::BOOLEAN" in insert_sql
+    assert insert_sql.count("%s::INTEGER") == 5
+    assert "%s::TIMESTAMP" in insert_sql
+    assert "%s::TIME" in insert_sql
+    assert insert_call.args[1] == [
+        (
+            1,
+            True,
+            1,
+            2,
+            738221,
+            4,
+            datetime(2030, 1, 1, 12, 0),
+            datetime(2030, 1, 1, 12, 30).time(),
+        )
+    ]
 
 
 def test_xtdb_dataframe_ops_casts_null_values_to_configured_types():
@@ -482,9 +574,11 @@ def test_xtdb_dataframe_ops_casts_null_values_to_configured_types():
         table_config=table_config,
     )
 
-    insert_sql = driver_connection.execute.call_args_list[1].args[0]
-    assert "NULL::TIMESTAMP" in insert_sql
-    assert "NULL::DOUBLE PRECISION" in insert_sql
+    insert_call = _single_executemany_call(driver_connection)
+    insert_sql = insert_call.args[0]
+    assert "%s::TIMESTAMP" in insert_sql
+    assert "%s::DOUBLE PRECISION" in insert_sql
+    assert insert_call.args[1] == [(1, None, None)]
 
 
 def test_xtdb_dataframe_ops_casts_categorical_values_to_configured_decimal():
@@ -516,8 +610,10 @@ def test_xtdb_dataframe_ops_casts_categorical_values_to_configured_decimal():
         table_config=table_config,
     )
 
-    insert_sql = driver_connection.execute.call_args_list[1].args[0]
-    assert "12.345::DECIMAL(15,3)" in insert_sql
+    insert_call = _single_executemany_call(driver_connection)
+    insert_sql = insert_call.args[0]
+    assert "%s::DECIMAL(15,3)" in insert_sql
+    assert insert_call.args[1] == [(1, Decimal("12.345"))]
 
 
 def test_xtdb_dataframe_ops_quotes_reserved_insert_columns():
@@ -550,7 +646,7 @@ def test_xtdb_dataframe_ops_quotes_reserved_insert_columns():
         table_config=table_config,
     )
 
-    insert_sql = driver_connection.execute.call_args_list[1].args[0]
+    insert_sql = _single_executemany_call(driver_connection).args[0]
     assert 'INSERT INTO source_a.entity_info (_id, name, "flag")' in insert_sql
 
 
@@ -582,10 +678,12 @@ def test_xtdb_dataframe_ops_encodes_insert_columns_with_slashes():
         table_config=table_config,
     )
 
-    insert_sql = driver_connection.execute.call_args_list[1].args[0]
+    insert_call = _single_executemany_call(driver_connection)
+    insert_sql = insert_call.args[0]
     assert '"capacity/bcm"' not in insert_sql
     assert "capacity_bcm" in insert_sql
-    assert "4.080::DECIMAL(15,3)" in insert_sql
+    assert "%s::DECIMAL(15,3)" in insert_sql
+    assert insert_call.args[1] == [(1, Decimal("4.080"))]
 
 
 def test_xtdb_dataframe_ops_uses_underscore_column_mapping():
@@ -620,7 +718,7 @@ def test_xtdb_dataframe_ops_uses_underscore_column_mapping():
         table_config=table_config,
     )
 
-    insert_sql = driver_connection.execute.call_args_list[1].args[0]
+    insert_sql = _single_executemany_call(driver_connection).args[0]
     assert '"metrics.properties.Capacity/Value"' not in insert_sql
     assert "metrics_properties_capacity_value" in insert_sql
 

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -73,7 +73,7 @@ def test_xtdb_staging_insert_partition_uses_retained_stage_table(monkeypatch):
         "record_id": [1],
         "destination_name": ["Alpha"],
         "stage_run_id": ["stage-1"],
-        "stage_partition_time": [partition_time],
+        "stage_partition_time": [partition_time.replace(tzinfo=None)],
     }
 
 
@@ -488,7 +488,7 @@ def test_xtdb_staging_insert_cache_matches_stage_table_schema_for_missing_column
         "destination_name": ["Alpha"],
         "source_note": [None],
         "stage_run_id": ["stage-1"],
-        "stage_partition_time": [datetime(2030, 1, 1, tzinfo=timezone.utc)],
+        "stage_partition_time": [datetime(2030, 1, 1)],
     }
     assert inserted["df"].schema["source_note"] == pl.String
     from_raw_sql.assert_not_called()


### PR DESCRIPTION
## Summary
- send XTDB PgWire inserts through typed parameterized executemany calls instead of large literal VALUES statements
- register text parameter adapters and normalize timestamp parameters for XTDB TIMESTAMP writes
- treat missing XTDB target tables as empty during first-write filtering paths and rollback the failed transaction state

## Tests
- uv run ruff check polars_hist_db/backends/xtdb.py tests/backends/test_xtdb_backend.py tests/backends/test_xtdb_dataframe_ops.py tests/backends/test_xtdb_staging_ops.py
- uv run pytest tests/backends/test_xtdb_dataframe_ops.py tests/backends/test_xtdb_staging_ops.py tests/backends/test_xtdb_backend.py tests/backends/test_xtdb_adbc_ops.py -q
- uv run pytest -q
- UV_CACHE_DIR=.uv-cache POLARS_HIST_DB_XTDB_LIVE=1 uv run pytest -m integration tests/backends/test_xtdb_live.py -q