### PR TITLE
feat: use xtdb adbc for bulk staging ingest

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -1660,8 +1660,10 @@ class XtdbStagingOps:
         self,
         connection: Any,
         max_rows_per_insert: Optional[int] = None,
+        adbc_connection: Any | None = None,
     ):
         self.connection = connection
+        self.adbc_connection = adbc_connection
         self.max_rows_per_insert = max_rows_per_insert
         self._stage_run_cache: dict[str, pl.DataFrame] = {}
         self._inserted_parent_row_cache: set[tuple[str, str, str]] = set()
@@ -1672,6 +1674,14 @@ class XtdbStagingOps:
             self.connection,
             max_rows_per_insert=self.max_rows_per_insert,
         )
+
+    def _bulk_dataframes(self) -> XtdbDataframeOps | XtdbAdbcDataframeOps:
+        if self.adbc_connection is not None:
+            return XtdbAdbcDataframeOps(
+                self.adbc_connection,
+                max_rows_per_insert=self.max_rows_per_insert,
+            )
+        return self._dataframes()
 
     def stage_table_config(self, delta_table_config: TableConfig) -> TableConfig:
         stage_table = _xtdb_stage_table_name(delta_table_config.name)
@@ -1748,7 +1758,7 @@ class XtdbStagingOps:
 
         stage_config = self.stage_table_config(delta_table_config)
         df = _normalize_xtdb_timestamp_columns(df, stage_config)
-        inserted_count = self._dataframes().table_insert(
+        inserted_count = self._bulk_dataframes().table_insert(
             df,
             stage_config.schema,
             stage_config.name,
@@ -2003,7 +2013,7 @@ class XtdbStagingOps:
                 schema=parent_rows_to_insert.schema,
             )
         if not parent_rows_to_insert.is_empty():
-            self._dataframes().table_insert(
+            self._bulk_dataframes().table_insert(
                 parent_rows_to_insert,
                 table_config.schema,
                 table_config.name,
@@ -2085,10 +2095,16 @@ class XtdbBackend:
     def table_configs(self, connection: Any) -> XtdbTableConfigOps:
         return XtdbTableConfigOps(connection)
 
-    def staging(self, connection: Any) -> XtdbStagingOps:
+    def staging(
+        self,
+        connection: Any,
+        *,
+        adbc_connection: Any | None = None,
+    ) -> XtdbStagingOps:
         return XtdbStagingOps(
             connection,
             max_rows_per_insert=self.max_rows_per_insert,
+            adbc_connection=adbc_connection,
         )
 
     def time_hint_clause(self, time_hint: TimeHint) -> str | None:

--- a/polars_hist_db/dataset/entrypoint.py
+++ b/polars_hist_db/dataset/entrypoint.py
@@ -31,20 +31,29 @@ async def run_datasets(
         engine = backend.create_engine(config.db_config)
 
     num_datasets_processed = 0
-    for dataset in config.datasets.datasets:
-        if dataset_name is None or dataset.name == dataset_name:
-            num_datasets_processed += 1
-            LOGGER.info("scraping dataset %s", dataset.name)
-            await _run_dataset(
-                dataset.input_config,
-                dataset,
-                config.tables,
-                engine,
-                debug_capture_output,
-                backend,
-                js=js,
-                raise_on_error=raise_on_error,
-            )
+    adbc_connection = None
+    try:
+        for dataset in config.datasets.datasets:
+            if dataset_name is None or dataset.name == dataset_name:
+                if getattr(backend, "name", None) == "xtdb" and adbc_connection is None:
+                    adbc_connection = backend.create_adbc_connection(config.db_config)
+
+                num_datasets_processed += 1
+                LOGGER.info("scraping dataset %s", dataset.name)
+                await _run_dataset(
+                    dataset.input_config,
+                    dataset,
+                    config.tables,
+                    engine,
+                    debug_capture_output,
+                    backend,
+                    adbc_connection=adbc_connection,
+                    js=js,
+                    raise_on_error=raise_on_error,
+                )
+    finally:
+        if adbc_connection is not None:
+            adbc_connection.close()
 
     if num_datasets_processed == 0:
         LOGGER.error("no datasets processed for %s", dataset_name)
@@ -83,6 +92,7 @@ async def _run_dataset(
     engine: Engine,
     debug_capture_output: Optional[List[Tuple[datetime, pl.DataFrame]]],
     backend,
+    adbc_connection=None,
     js: Optional[JetStreamContext] = None,
     raise_on_error: bool = False,
 ):
@@ -109,6 +119,7 @@ async def _run_dataset(
                 commit_fn,
                 delta_table_config=delta_table_config,
                 backend=backend,
+                adbc_connection=adbc_connection,
             )
 
     except Exception as e:

--- a/polars_hist_db/dataset/scrape.py
+++ b/polars_hist_db/dataset/scrape.py
@@ -94,6 +94,7 @@ async def try_run_pipeline_as_transaction(
     seconds_between_retries: float = 60,
     delta_table_config: Optional[TableConfig] = None,
     backend: Any = None,
+    adbc_connection: Any = None,
 ):
     main_table_config: TableConfig = tables[dataset.pipeline.get_main_table_name()[1]]
     tbl_to_header_map = dataset.pipeline.get_header_map(main_table_config.name)
@@ -104,7 +105,14 @@ async def try_run_pipeline_as_transaction(
         with engine.connect() as connection:
             try:
                 with _pipeline_transaction_context(connection, is_xtdb):
-                    staging = backend.staging(connection) if is_xtdb else None
+                    staging = (
+                        backend.staging(
+                            connection,
+                            adbc_connection=adbc_connection,
+                        )
+                        if is_xtdb
+                        else None
+                    )
                     if delta_table_config is not None and not is_xtdb:
                         _ensure_delta_table(
                             connection,

--- a/tests/backends/test_xtdb_adbc_live.py
+++ b/tests/backends/test_xtdb_adbc_live.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import polars as pl
 import pytest
+from sqlalchemy import text
 
 from polars_hist_db.backends import DbEngineConfig, XtdbBackend
 from polars_hist_db.config import TableColumnConfig, TableConfig
@@ -25,6 +26,7 @@ pytestmark = [
 
 try:
     import adbc_driver_flightsql  # noqa: F401
+    import psycopg  # noqa: F401
 except ImportError:
     pytestmark = [
         *pytestmark,
@@ -78,6 +80,59 @@ def _xtdb_adbc_connection() -> Iterator[Any]:
         subprocess.run(["docker", "rm", "-f", container_id], check=False)
 
 
+@contextmanager
+def _xtdb_pgwire_and_adbc_connections() -> Iterator[tuple[Any, Any]]:
+    container_id = _docker(
+        [
+            "run",
+            "--rm",
+            "-d",
+            "-p",
+            "5432",
+            "-p",
+            "9832",
+            "ghcr.io/xtdb/xtdb:nightly",
+        ]
+    )
+    engine = None
+    adbc_connection = None
+    try:
+        backend = XtdbBackend()
+        config = DbEngineConfig(
+            backend="xtdb",
+            hostname="127.0.0.1",
+            port=_published_port(container_id, "5432/tcp"),
+            adbc_port=_published_port(container_id, "9832/tcp"),
+        )
+        engine = backend.create_engine(config)
+        deadline = time.monotonic() + 60
+        while True:
+            try:
+                with engine.connect() as connection:
+                    connection.execute(text("SELECT 1"))
+                adbc_connection = backend.create_adbc_connection(config)
+                with adbc_connection.cursor() as cursor:
+                    cursor.execute("SELECT 1")
+                    cursor.fetch_arrow_table()
+                break
+            except Exception:
+                if adbc_connection is not None:
+                    adbc_connection.close()
+                    adbc_connection = None
+                if time.monotonic() > deadline:
+                    raise
+                time.sleep(1)
+
+        with engine.connect() as pgwire_connection:
+            yield pgwire_connection, adbc_connection
+    finally:
+        if adbc_connection is not None:
+            adbc_connection.close()
+        if engine is not None:
+            engine.dispose()
+        subprocess.run(["docker", "rm", "-f", container_id], check=False)
+
+
 def test_xtdb_adbc_live_arrow_ingest_read_roundtrip():
     table_config = TableConfig(
         schema="public",
@@ -114,6 +169,59 @@ def test_xtdb_adbc_live_arrow_ingest_read_roundtrip():
         "_id": [1, 2],
         "destination": ["Alpha", "Beta"],
         "amount_value": [10.5, 20.25],
+    }
+
+
+def test_xtdb_adbc_live_staging_partition_roundtrip():
+    stream_name = f"live_adbc_stage_records_{int(time.time())}"
+    delta_table_config = TableConfig(
+        schema="sample",
+        name=stream_name,
+        columns=[
+            TableColumnConfig(stream_name, "record_id", "BIGINT", nullable=False),
+            TableColumnConfig(stream_name, "destination", "VARCHAR(255)"),
+            TableColumnConfig(stream_name, "amount_value", "DOUBLE"),
+        ],
+    )
+
+    with _xtdb_pgwire_and_adbc_connections() as (
+        pgwire_connection,
+        adbc_connection,
+    ):
+        backend = XtdbBackend(max_rows_per_insert=2)
+        staging = backend.staging(
+            pgwire_connection,
+            adbc_connection=adbc_connection,
+        )
+        stage_config = staging.ensure_table(delta_table_config)
+
+        inserted_count = staging.insert_partition(
+            pl.DataFrame(
+                {
+                    "record_id": [1, 2, 3],
+                    "destination": ["Alpha", "Beta", "Gamma"],
+                    "amount_value": [10.5, 20.25, 30.75],
+                }
+            ),
+            delta_table_config,
+            "stage-1",
+            datetime(2030, 1, 1, tzinfo=timezone.utc),
+            uniqueness_col_set=["record_id"],
+            prefill_nulls_with_default=True,
+        )
+        persisted = backend.dataframes(pgwire_connection).from_table(
+            stage_config.schema,
+            stage_config.name,
+        )
+
+    assert inserted_count == 3
+    assert persisted.sort("record_id").select(
+        ["record_id", "destination", "amount_value", "stage_run_id"]
+    ).to_dict(as_series=False) == {
+        "record_id": [1, 2, 3],
+        "destination": ["Alpha", "Beta", "Gamma"],
+        "amount_value": [10.5, 20.25, 30.75],
+        "stage_run_id": ["stage-1", "stage-1", "stage-1"],
     }
 
 

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -122,6 +122,57 @@ def test_xtdb_backend_staging_preserves_insert_row_limit():
     assert staging.max_rows_per_insert == 2500
 
 
+def test_xtdb_staging_insert_partition_uses_adbc_bulk_connection(monkeypatch):
+    adbc_connection = object()
+    pgwire_insert = Mock(side_effect=AssertionError("should use ADBC bulk ingest"))
+    inserted = {}
+
+    def adbc_table_insert(self, df, table_schema, table_name, table_config=None):
+        inserted["connection"] = self.connection
+        inserted["df"] = df
+        inserted["table_schema"] = table_schema
+        inserted["table_name"] = table_name
+        inserted["table_config"] = table_config
+        return df.height
+
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_insert",
+        pgwire_insert,
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbAdbcDataframeOps.table_insert",
+        adbc_table_insert,
+    )
+    delta_table_config = TableConfig(
+        schema="fakedata",
+        name="record_stream",
+        columns=[
+            TableColumnConfig("record_stream", "record_id", "INT"),
+            TableColumnConfig("record_stream", "destination_name", "VARCHAR(64)"),
+        ],
+    )
+    staging = XtdbBackend(max_rows_per_insert=2500).staging(
+        object(),
+        adbc_connection=adbc_connection,
+    )
+
+    inserted_count = staging.insert_partition(
+        pl.DataFrame({"record_id": [1], "destination_name": ["Alpha"]}),
+        delta_table_config,
+        "stage-1",
+        datetime(2030, 1, 1, 12, 0, tzinfo=timezone.utc),
+        uniqueness_col_set=["record_id"],
+        prefill_nulls_with_default=True,
+    )
+
+    assert inserted_count == 1
+    assert inserted["connection"] is adbc_connection
+    assert inserted["table_schema"] == "fakedata"
+    assert inserted["table_name"] == "__record_stream_stage"
+    assert inserted["table_config"].name == "__record_stream_stage"
+    pgwire_insert.assert_not_called()
+
+
 def test_xtdb_staging_projects_from_insert_cache_after_partition_insert(monkeypatch):
     def table_insert(self, df, table_schema, table_name, table_config=None):
         return df.height
@@ -658,6 +709,113 @@ def test_xtdb_staging_deduces_foreign_keys_and_inserts_missing_parent(
         "country_id": [generated_id],
         "name": ["Japan"],
     }
+
+
+def test_xtdb_staging_inserts_missing_parent_with_adbc_bulk_connection(monkeypatch):
+    adbc_connection = object()
+    stage_df = pl.DataFrame(
+        {
+            "stage_run_id": ["stage-1"],
+            "stage_row_index": [0],
+            "country_id": [None],
+            "country_name": ["Japan"],
+        },
+        schema={
+            "stage_run_id": pl.String,
+            "stage_row_index": pl.Int64,
+            "country_id": pl.String,
+            "country_name": pl.String,
+        },
+    )
+    parent_df = pl.DataFrame(
+        schema={
+            "_id": pl.String,
+            "country_id": pl.String,
+            "name": pl.String,
+        }
+    )
+    pgwire_insert = Mock(side_effect=AssertionError("should use ADBC bulk ingest"))
+    inserted = {}
+
+    def adbc_table_insert(self, df, table_schema, table_name, table_config=None):
+        inserted["connection"] = self.connection
+        inserted["df"] = df
+        inserted["table_schema"] = table_schema
+        inserted["table_name"] = table_name
+        inserted["table_config"] = table_config
+        return df.height
+
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
+        Mock(return_value=stage_df),
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_table",
+        Mock(return_value=parent_df),
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_insert",
+        pgwire_insert,
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbAdbcDataframeOps.table_insert",
+        adbc_table_insert,
+    )
+    dataset = DatasetConfig(
+        name="country_stream",
+        delta_table_schema="ref",
+        input_config={"type": "dsv", "search_paths": []},
+        pipeline=[
+            {
+                "schema": "ref",
+                "table": "countries",
+                "type": "primary",
+                "columns": [
+                    {
+                        "source": "country_id",
+                        "target": "country_id",
+                        "deduce_foreign_key": True,
+                    },
+                    {"source": "country_name", "target": "name"},
+                ],
+            }
+        ],
+    )
+    table_config = TableConfig(
+        schema="ref",
+        name="countries",
+        primary_keys=["country_id"],
+        columns=[
+            TableColumnConfig("countries", "country_id", "VARCHAR(128)"),
+            TableColumnConfig("countries", "name", "VARCHAR(64)"),
+        ],
+    )
+
+    result = XtdbStagingOps(
+        object(),
+        adbc_connection=adbc_connection,
+    ).prepare_pipeline_item_dataframe(
+        "stage-1",
+        dataset,
+        0,
+        table_config,
+        valid_time=None,
+    )
+
+    generated_id = 'xtdb-fk-v1:ref.countries:[["name","Japan"]]'
+    assert inserted["connection"] is adbc_connection
+    assert inserted["table_schema"] == "ref"
+    assert inserted["table_name"] == "countries"
+    assert inserted["table_config"] == table_config
+    assert inserted["df"].to_dict(as_series=False) == {
+        "country_id": [generated_id],
+        "name": ["Japan"],
+    }
+    assert result.to_dict(as_series=False) == {
+        "country_id": [generated_id],
+        "name": ["Japan"],
+    }
+    pgwire_insert.assert_not_called()
 
 
 def test_xtdb_staging_deduces_explicit_numeric_foreign_keys(monkeypatch):

--- a/tests/dataset/test_backend_entrypoint.py
+++ b/tests/dataset/test_backend_entrypoint.py
@@ -16,6 +16,31 @@ class _FakeBackend:
         return object()
 
 
+class _FakeAdbcConnection:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeXtdbBackend:
+    name = "xtdb"
+
+    def __init__(self):
+        self.created_engine_with = None
+        self.created_adbc_with = None
+        self.adbc_connection = _FakeAdbcConnection()
+
+    def create_engine(self, config):
+        self.created_engine_with = config
+        return object()
+
+    def create_adbc_connection(self, config):
+        self.created_adbc_with = config
+        return self.adbc_connection
+
+
 class _ContextManager:
     def __init__(self, value):
         self.value = value
@@ -98,6 +123,50 @@ async def test_run_datasets_creates_engine_from_config_when_engine_is_omitted(
     await run_datasets(config)
 
     assert fake_backend.created_with == config.db_config
+
+
+@pytest.mark.asyncio
+async def test_run_datasets_creates_xtdb_adbc_connection(monkeypatch):
+    fake_backend = _FakeXtdbBackend()
+    observed = {}
+    dataset = SimpleNamespace(
+        name="records",
+        input_config=SimpleNamespace(type="dsv"),
+    )
+    config = SimpleNamespace(
+        db_config=DbEngineConfig(backend="xtdb"),
+        datasets=SimpleNamespace(datasets=[dataset]),
+        tables=object(),
+    )
+
+    async def fake_run_dataset(
+        input_config,
+        dataset_arg,
+        tables,
+        engine,
+        debug_capture_output,
+        backend,
+        *,
+        adbc_connection=None,
+        js=None,
+        raise_on_error=False,
+    ):
+        observed["adbc_connection"] = adbc_connection
+
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.entrypoint.backend_from_config",
+        lambda config: fake_backend,
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.entrypoint._run_dataset", fake_run_dataset
+    )
+
+    await run_datasets(config)
+
+    assert fake_backend.created_engine_with == config.db_config
+    assert fake_backend.created_adbc_with == config.db_config
+    assert observed["adbc_connection"] is fake_backend.adbc_connection
+    assert fake_backend.adbc_connection.closed is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- create an XTDB ADBC connection for dataset runs and pass it into staging
- route retained staging partition inserts and normalized parent inserts through ADBC Arrow ingest when available
- keep PgWire as the fallback/control path for reads, cleanup, and explicit temporal DML

## Tests
- uv run ruff check polars_hist_db/backends/xtdb.py polars_hist_db/dataset/entrypoint.py polars_hist_db/dataset/scrape.py tests/backends/test_xtdb_staging_ops.py tests/backends/test_xtdb_adbc_live.py tests/dataset/test_backend_entrypoint.py
- uv run pytest tests/backends/test_xtdb_staging_ops.py tests/backends/test_xtdb_adbc_ops.py tests/dataset/test_backend_entrypoint.py -q
- uv run pytest tests/backends/test_xtdb_dataframe_ops.py tests/backends/test_xtdb_staging_ops.py tests/backends/test_xtdb_backend.py tests/backends/test_xtdb_adbc_ops.py tests/dataset/test_backend_entrypoint.py -q
- uv run pytest -q
- UV_CACHE_DIR=.uv-cache POLARS_HIST_DB_XTDB_LIVE=1 uv run pytest -m integration tests/backends/test_xtdb_adbc_live.py -q
- UV_CACHE_DIR=.uv-cache POLARS_HIST_DB_XTDB_LIVE=1 uv run pytest -m integration tests/backends/test_xtdb_live.py -q