### PR TITLE
fix: fall back when xtdb adbc ingest is unavailable

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -50,6 +50,16 @@ def _load_flight_sql() -> Any:
     return flight_sql
 
 
+def _is_xtdb_adbc_ingest_unavailable(exc: Exception) -> bool:
+    message = str(exc).lower()
+    class_name = exc.__class__.__name__
+    return (
+        class_name in {"NotImplementedError", "NotSupportedError"}
+        and "executeingest" in message
+        and ("not implemented" in message or "not_implemented" in message)
+    )
+
+
 def _xtdb_type_to_config_type(data_type: str) -> str:
     normalized = data_type.upper()
     xtdb_types = {
@@ -1683,6 +1693,40 @@ class XtdbStagingOps:
             )
         return self._dataframes()
 
+    def _bulk_table_insert(
+        self,
+        df: pl.DataFrame,
+        table_schema: str,
+        table_name: str,
+        *,
+        table_config: TableConfig,
+    ) -> int:
+        if self.adbc_connection is None:
+            return self._dataframes().table_insert(
+                df,
+                table_schema,
+                table_name,
+                table_config=table_config,
+            )
+
+        try:
+            return self._bulk_dataframes().table_insert(
+                df,
+                table_schema,
+                table_name,
+                table_config=table_config,
+            )
+        except Exception as exc:
+            if not _is_xtdb_adbc_ingest_unavailable(exc):
+                raise
+
+        return self._dataframes().table_insert(
+            df,
+            table_schema,
+            table_name,
+            table_config=table_config,
+        )
+
     def stage_table_config(self, delta_table_config: TableConfig) -> TableConfig:
         stage_table = _xtdb_stage_table_name(delta_table_config.name)
         existing_column_names = {column.name for column in delta_table_config.columns}
@@ -1758,7 +1802,7 @@ class XtdbStagingOps:
 
         stage_config = self.stage_table_config(delta_table_config)
         df = _normalize_xtdb_timestamp_columns(df, stage_config)
-        inserted_count = self._bulk_dataframes().table_insert(
+        inserted_count = self._bulk_table_insert(
             df,
             stage_config.schema,
             stage_config.name,
@@ -2013,7 +2057,7 @@ class XtdbStagingOps:
                 schema=parent_rows_to_insert.schema,
             )
         if not parent_rows_to_insert.is_empty():
-            self._bulk_dataframes().table_insert(
+            self._bulk_table_insert(
                 parent_rows_to_insert,
                 table_config.schema,
                 table_config.name,

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -173,6 +173,63 @@ def test_xtdb_staging_insert_partition_uses_adbc_bulk_connection(monkeypatch):
     pgwire_insert.assert_not_called()
 
 
+def test_xtdb_staging_insert_partition_falls_back_when_adbc_ingest_unavailable(
+    monkeypatch,
+):
+    adbc_connection = object()
+    inserted = {}
+
+    def adbc_table_insert(self, df, table_schema, table_name, table_config=None):
+        raise NotImplementedError("NOT_IMPLEMENTED: ExecuteIngest")
+
+    def pgwire_table_insert(self, df, table_schema, table_name, table_config=None):
+        inserted["connection"] = self.connection
+        inserted["max_rows_per_insert"] = self.max_rows_per_insert
+        inserted["df"] = df
+        inserted["table_schema"] = table_schema
+        inserted["table_name"] = table_name
+        inserted["table_config"] = table_config
+        return df.height
+
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbAdbcDataframeOps.table_insert",
+        adbc_table_insert,
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_insert",
+        pgwire_table_insert,
+    )
+    pgwire_connection = object()
+    delta_table_config = TableConfig(
+        schema="fakedata",
+        name="record_stream",
+        columns=[
+            TableColumnConfig("record_stream", "record_id", "INT"),
+            TableColumnConfig("record_stream", "destination_name", "VARCHAR(64)"),
+        ],
+    )
+    staging = XtdbBackend(max_rows_per_insert=2500).staging(
+        pgwire_connection,
+        adbc_connection=adbc_connection,
+    )
+
+    inserted_count = staging.insert_partition(
+        pl.DataFrame({"record_id": [1], "destination_name": ["Alpha"]}),
+        delta_table_config,
+        "stage-1",
+        datetime(2030, 1, 1, 12, 0, tzinfo=timezone.utc),
+        uniqueness_col_set=["record_id"],
+        prefill_nulls_with_default=True,
+    )
+
+    assert inserted_count == 1
+    assert inserted["connection"] is pgwire_connection
+    assert inserted["max_rows_per_insert"] == 2500
+    assert inserted["table_schema"] == "fakedata"
+    assert inserted["table_name"] == "__record_stream_stage"
+    assert inserted["table_config"].name == "__record_stream_stage"
+
+
 def test_xtdb_staging_projects_from_insert_cache_after_partition_insert(monkeypatch):
     def table_insert(self, df, table_schema, table_name, table_config=None):
         return df.height


### PR DESCRIPTION
## Summary
- fall back to PgWire staging inserts when remote XTDB ADBC ingest reports ExecuteIngest as unavailable
- keep ADBC staging as the preferred path when supported
- add a regression test for the fallback path

## Context
Current XTDB Flight SQL returns NOT_IMPLEMENTED for ExecuteIngest, so the staging path must preserve the existing PgWire fallback until native remote ingest support is available.

## Tests
- uv run pytest tests/backends/test_xtdb_staging_ops.py::test_xtdb_staging_insert_partition_falls_back_when_adbc_ingest_unavailable -q
- uv run pytest tests/backends/test_xtdb_staging_ops.py tests/backends/test_xtdb_adbc_ops.py tests/dataset/test_backend_entrypoint.py -q
- uv run pytest -q