### PR TITLE
fix: preserve XTDB primary key columns

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -181,15 +181,12 @@ def _normalize_xtdb_ingest_arrow(table: pa.Table) -> pa.Table:
 def _xtdb_declared_columns(table_config: TableConfig) -> list[str]:
     document_id_columns = _xtdb_document_id_columns(table_config)
     uses_explicit_id = document_id_columns == ["_id"]
-    uses_single_source_key = len(document_id_columns) == 1 and not uses_explicit_id
 
     declared_columns = ["_id"]
     for column in table_config.columns:
         if column.name in _XTDB_SYSTEM_COLUMNS:
             continue
         if uses_explicit_id and column.name == "_id":
-            continue
-        if uses_single_source_key and column.name == document_id_columns[0]:
             continue
         declared_columns.append(column.name)
 
@@ -429,14 +426,13 @@ def _xtdb_insert_casts(
         document_id_columns = _xtdb_document_id_columns(table_config)
         if len(document_id_columns) > 1:
             configured_types["_id"] = "TEXT"
+        elif document_id_columns != ["_id"]:
+            for column in table_config.columns:
+                if column.name == document_id_columns[0]:
+                    configured_types["_id"] = _xtdb_cast_type(column.data_type)
+                    break
         for column in table_config.columns:
-            target_name = (
-                "_id"
-                if len(document_id_columns) == 1
-                and column.name == document_id_columns[0]
-                else column.name
-            )
-            configured_types[target_name] = _xtdb_cast_type(column.data_type)
+            configured_types[column.name] = _xtdb_cast_type(column.data_type)
 
     casts = []
     for name, dtype in df.schema.items():
@@ -448,19 +444,15 @@ def _xtdb_configured_column_dtypes(
     table_config: TableConfig,
 ) -> dict[str, pl.DataType]:
     document_id_columns = _xtdb_document_id_columns(table_config)
-    uses_single_source_key = len(document_id_columns) == 1
     dtypes: dict[str, pl.DataType] = {}
 
     for column in table_config.columns:
         dtype = _xtdb_polars_type_or_none(column.data_type)
         if dtype is None:
             continue
-        target_name = (
-            "_id"
-            if uses_single_source_key and column.name == document_id_columns[0]
-            else column.name
-        )
-        dtypes[target_name] = dtype
+        dtypes[column.name] = dtype
+        if document_id_columns != ["_id"] and document_id_columns == [column.name]:
+            dtypes["_id"] = dtype
 
     if len(document_id_columns) > 1:
         dtypes["_id"] = pl.String()
@@ -537,7 +529,9 @@ def _prepare_xtdb_insert_dataframe(
         )
 
     if len(document_id_columns) == 1:
-        return df.rename({document_id_columns[0]: "_id"})
+        return df.with_columns(pl.col(document_id_columns[0]).alias("_id")).select(
+            ["_id", *df.columns]
+        )
 
     document_ids = [
         _xtdb_composite_document_id(document_id_columns, row)

--- a/tests/backends/test_xtdb_adbc_ops.py
+++ b/tests/backends/test_xtdb_adbc_ops.py
@@ -69,6 +69,7 @@ def test_xtdb_adbc_dataframe_ops_ingests_arrow_with_id_mapping():
     assert arrow_table.schema.field("destination").type == pa.string()
     assert arrow_table.to_pydict() == {
         "_id": [1, 2],
+        "id": [1, 2],
         "destination": ["Alpha", "Beta"],
     }
 
@@ -106,6 +107,7 @@ def test_xtdb_adbc_dataframe_ops_ingests_null_columns_with_configured_arrow_type
     assert arrow_table.schema.field("amount_value").type == pa.float64()
     assert arrow_table.to_pydict() == {
         "_id": [1],
+        "id": [1],
         "destination_date": [None],
         "amount_value": [None],
     }
@@ -150,9 +152,9 @@ def test_xtdb_adbc_dataframe_ops_splits_ingest_by_max_rows():
     ingests = connection.cursor_instance.ingests
     assert len(ingests) == 3
     assert [ingest[1].to_pydict() for ingest in ingests] == [
-        {"_id": [1, 2], "destination": ["A", "B"]},
-        {"_id": [3, 4], "destination": ["C", "D"]},
-        {"_id": [5], "destination": ["E"]},
+        {"_id": [1, 2], "id": [1, 2], "destination": ["A", "B"]},
+        {"_id": [3, 4], "id": [3, 4], "destination": ["C", "D"]},
+        {"_id": [5], "id": [5], "destination": ["E"]},
     ]
 
 

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -159,9 +159,10 @@ def test_xtdb_temporal_upsert_dropout_deletes_missing_current_keys():
     assert executed_sql[1] == "DELETE FROM test.records WHERE _id IN (2::BIGINT)"
     insert_call = driver_connection.cursor.return_value.executemany.call_args
     assert insert_call.args[0] == (
-        "INSERT INTO test.records (_id, destination) VALUES (%s::BIGINT, %s::TEXT)"
+        "INSERT INTO test.records (_id, id, destination) "
+        "VALUES (%s::BIGINT, %s::BIGINT, %s::TEXT)"
     )
-    assert insert_call.args[1] == [(1, "Alpha")]
+    assert insert_call.args[1] == [(1, 1, "Alpha")]
 
 
 def test_xtdb_temporal_upsert_dropout_closes_missing_keys_at_valid_time():
@@ -747,6 +748,7 @@ def test_xtdb_table_creation_maps_mysql_compatibility_types(monkeypatch):
     ]
     assert _xtdb_declared_columns(table_config) == [
         "_id",
+        "id",
         "bool_col",
         "bit_col",
         "tinyint_col",

--- a/tests/backends/test_xtdb_dataframe_ops.py
+++ b/tests/backends/test_xtdb_dataframe_ops.py
@@ -146,6 +146,7 @@ def test_xtdb_dataframe_ops_reads_table_with_configured_schema_overrides(monkeyp
         connection,
         schema_overrides={
             "_id": pl.Int64,
+            "id": pl.Int64,
             "destination_date": pl.Datetime(),
             "amount_value": pl.Float64,
             "_valid_from": pl.Datetime("us", "UTC"),
@@ -159,6 +160,7 @@ def test_xtdb_dataframe_ops_restores_logical_columns_with_slashes(monkeypatch):
         return_value=pl.DataFrame(
             {
                 "_id": [1],
+                "id": [1],
                 "capacity_bcm": ["12.345"],
             }
         )
@@ -183,12 +185,13 @@ def test_xtdb_dataframe_ops_restores_logical_columns_with_slashes(monkeypatch):
 
     result = ops.from_table("test", "records")
 
-    assert result.columns == ["_id", "capacity/bcm"]
+    assert result.columns == ["_id", "id", "capacity/bcm"]
     read_database.assert_called_once_with(
         "SELECT * FROM test.records",
         connection,
         schema_overrides={
             "_id": pl.Int64,
+            "id": pl.Int64,
             "capacity_bcm": pl.Decimal(15, 3),
             "_valid_from": pl.Datetime("us", "UTC"),
             "_valid_to": pl.Datetime("us", "UTC"),
@@ -253,6 +256,7 @@ def test_xtdb_dataframe_ops_maps_configured_primary_key_to_id(monkeypatch):
     written_df = captured["df"]
     assert written_df.to_dict(as_series=False) == {
         "_id": [1, 2],
+        "id": [1, 2],
         "destination": ["A", "B"],
     }
     assert captured["kwargs"] == {
@@ -480,7 +484,7 @@ def test_xtdb_dataframe_ops_normalizes_bound_timestamp_parameters_to_naive_utc()
 
     insert_call = _single_executemany_call(driver_connection)
     assert "%s::TIMESTAMP" in insert_call.args[0]
-    assert insert_call.args[1] == [(1, datetime(2030, 1, 1, 12, 30))]
+    assert insert_call.args[1] == [(1, 1, datetime(2030, 1, 1, 12, 30))]
 
 
 def test_xtdb_dataframe_ops_uses_native_casts_for_mysql_compatibility_types():
@@ -527,11 +531,12 @@ def test_xtdb_dataframe_ops_uses_native_casts_for_mysql_compatibility_types():
     insert_sql = insert_call.args[0]
     assert "INSERT INTO test.compat_types" in insert_sql
     assert "%s::BOOLEAN" in insert_sql
-    assert insert_sql.count("%s::INTEGER") == 5
+    assert insert_sql.count("%s::INTEGER") == 6
     assert "%s::TIMESTAMP" in insert_sql
     assert "%s::TIME" in insert_sql
     assert insert_call.args[1] == [
         (
+            1,
             1,
             True,
             1,
@@ -578,7 +583,7 @@ def test_xtdb_dataframe_ops_casts_null_values_to_configured_types():
     insert_sql = insert_call.args[0]
     assert "%s::TIMESTAMP" in insert_sql
     assert "%s::DOUBLE PRECISION" in insert_sql
-    assert insert_call.args[1] == [(1, None, None)]
+    assert insert_call.args[1] == [(1, 1, None, None)]
 
 
 def test_xtdb_dataframe_ops_casts_categorical_values_to_configured_decimal():
@@ -613,7 +618,7 @@ def test_xtdb_dataframe_ops_casts_categorical_values_to_configured_decimal():
     insert_call = _single_executemany_call(driver_connection)
     insert_sql = insert_call.args[0]
     assert "%s::DECIMAL(15,3)" in insert_sql
-    assert insert_call.args[1] == [(1, Decimal("12.345"))]
+    assert insert_call.args[1] == [(1, 1, Decimal("12.345"))]
 
 
 def test_xtdb_dataframe_ops_quotes_reserved_insert_columns():
@@ -647,7 +652,9 @@ def test_xtdb_dataframe_ops_quotes_reserved_insert_columns():
     )
 
     insert_sql = _single_executemany_call(driver_connection).args[0]
-    assert 'INSERT INTO source_a.entity_info (_id, name, "flag")' in insert_sql
+    assert (
+        'INSERT INTO source_a.entity_info (_id, entity_id, name, "flag")' in insert_sql
+    )
 
 
 def test_xtdb_dataframe_ops_encodes_insert_columns_with_slashes():
@@ -681,9 +688,10 @@ def test_xtdb_dataframe_ops_encodes_insert_columns_with_slashes():
     insert_call = _single_executemany_call(driver_connection)
     insert_sql = insert_call.args[0]
     assert '"capacity/bcm"' not in insert_sql
+    assert "entity_id" in insert_sql
     assert "capacity_bcm" in insert_sql
     assert "%s::DECIMAL(15,3)" in insert_sql
-    assert insert_call.args[1] == [(1, Decimal("4.080"))]
+    assert insert_call.args[1] == [(1, 1, Decimal("4.080"))]
 
 
 def test_xtdb_dataframe_ops_uses_underscore_column_mapping():


### PR DESCRIPTION
## Summary
- keep single-column primary keys as queryable logical columns when writing XTDB documents
- continue writing _id as the XTDB document identity
- update ADBC, pgwire, schema override, and table declaration tests for the preserved key column

## Verification
- uv run pytest tests/backends/test_xtdb*.py -q
- uv run pytest -q