### PR TITLE
fix: use XTDB bulk writes for non-temporal ingests

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -1721,6 +1721,9 @@ class XtdbStagingOps:
             table_config=table_config,
         )
 
+    def bulk_dataframes(self) -> XtdbDataframeOps | XtdbAdbcDataframeOps:
+        return self._bulk_dataframes()
+
     def stage_table_config(self, delta_table_config: TableConfig) -> TableConfig:
         stage_table = _xtdb_stage_table_name(delta_table_config.name)
         existing_column_names = {column.name for column in delta_table_config.columns}

--- a/polars_hist_db/dataset/primary_item.py
+++ b/polars_hist_db/dataset/primary_item.py
@@ -11,6 +11,19 @@ from ..core import TableConfigOps, DeltaTableOps, TableOps
 LOGGER = logging.getLogger(__name__)
 
 
+def _xtdb_temporal_write_kwargs(
+    table_config: TableConfig,
+    valid_time: Any,
+    upload_time: datetime,
+    staging: Any,
+) -> dict[str, Any]:
+    if table_config.is_temporal or valid_time is not None:
+        return {"update_time": upload_time}
+    if hasattr(staging, "bulk_dataframes"):
+        return {"dataframe_ops": staging.bulk_dataframes()}
+    return {}
+
+
 def scrape_primary_item(
     pipeline_id: int,
     dataset: DatasetConfig,
@@ -95,6 +108,12 @@ def scrape_xtdb_pipeline_item(
     )
 
     backend.table_configs(connection).create(table_config)
+    temporal_write_kwargs = _xtdb_temporal_write_kwargs(
+        table_config,
+        valid_time,
+        upload_time,
+        staging,
+    )
     modified_count = backend.temporal_upsert(
         target_df,
         table_config.schema,
@@ -102,8 +121,8 @@ def scrape_xtdb_pipeline_item(
         connection=connection,
         table_config=table_config,
         delta_config=dataset.delta_config,
-        update_time=upload_time,
         valid_time=valid_time,
+        **temporal_write_kwargs,
     )
 
     LOGGER.debug("(item %d) XTDB upserted %d rows", pipeline_id, modified_count)

--- a/tests/backends/test_xtdb_dataset_ingest.py
+++ b/tests/backends/test_xtdb_dataset_ingest.py
@@ -40,10 +40,14 @@ class _FakeStagingOps:
     def __init__(self, dataframe):
         self.dataframe = dataframe
         self.prepare_calls = []
+        self.bulk_dataframe_ops = object()
 
     def prepare_pipeline_item_dataframe(self, *args, **kwargs):
         self.prepare_calls.append((args, kwargs))
         return self.dataframe
+
+    def bulk_dataframes(self):
+        return self.bulk_dataframe_ops
 
 
 def test_xtdb_primary_ingest_uses_staged_dataframe_for_temporal_upsert():
@@ -139,7 +143,67 @@ def test_xtdb_primary_ingest_uses_staged_dataframe_for_temporal_upsert():
     )
 
 
-def test_xtdb_extract_ingest_uses_staged_dataframe_for_temporal_upsert():
+def test_xtdb_primary_ingest_uses_bulk_dataframe_ops_for_non_temporal_table():
+    tables = TableConfigs(
+        items=[
+            {
+                "schema": "fakedata",
+                "name": "records",
+                "primary_keys": ["record_id"],
+                "columns": [
+                    {"name": "record_id", "data_type": "INT", "nullable": False},
+                    {"name": "destination", "data_type": "VARCHAR(64)"},
+                ],
+                "is_temporal": False,
+            }
+        ]
+    )
+    dataset = DatasetConfig(
+        name="record_stream",
+        delta_table_schema="fakedata",
+        input_config={"type": "dsv", "search_paths": []},
+        pipeline=[
+            {
+                "schema": "fakedata",
+                "table": "records",
+                "type": "primary",
+                "columns": [
+                    {"source": "record_id", "target": "record_id"},
+                    {"source": "destination_name", "target": "destination"},
+                ],
+            }
+        ],
+    )
+    update_time = datetime(2030, 1, 1, 12, 5, tzinfo=timezone.utc)
+    staged_df = pl.DataFrame(
+        {
+            "record_id": [1],
+            "destination": ["Alpha"],
+        }
+    )
+    backend = _FakeXtdbBackend()
+    staging = _FakeStagingOps(staged_df)
+
+    did_modify = scrape_primary_item(
+        0,
+        dataset,
+        tables,
+        update_time,
+        SimpleNamespace(),
+        stage_run_id="stage-1",
+        staging=staging,
+        backend=backend,
+    )
+
+    assert did_modify is True
+    args, kwargs = backend.temporal_upsert_calls[0]
+    assert args[1:] == ("fakedata", "records")
+    assert kwargs["dataframe_ops"] is staging.bulk_dataframe_ops
+    assert "update_time" not in kwargs
+    assert kwargs["valid_time"] is None
+
+
+def test_xtdb_extract_ingest_uses_bulk_dataframe_ops_for_non_temporal_table():
     tables = TableConfigs(
         items=[
             {
@@ -223,5 +287,6 @@ def test_xtdb_extract_ingest_uses_staged_dataframe_for_temporal_upsert():
     }
     assert kwargs["table_config"] == entity_info
     assert kwargs["delta_config"] == dataset.delta_config
-    assert kwargs["update_time"] == update_time
+    assert kwargs["dataframe_ops"] is staging.bulk_dataframe_ops
+    assert "update_time" not in kwargs
     assert kwargs["valid_time"] is None


### PR DESCRIPTION
## Summary
- Use bulk dataframe writes for XTDB pipeline items when the target table is non-temporal and has no valid-time mapping.
- Keep source-time SYSTEM_TIME writes for temporal tables and explicit valid-time mappings.
- Add unit coverage for primary and extract non-temporal XTDB pipeline items.

## Tests
- uv run pytest tests/backends/test_xtdb_backend.py tests/backends/test_xtdb_dataframe_ops.py tests/backends/test_xtdb_dataset_ingest.py tests/backends/test_xtdb_staging_ops.py tests/backends/test_xtdb_adbc_ops.py -q