### PR TITLE
feat(observability): uploader row-flow OTel counters (WG-269)

### DIFF
--- a/polars_hist_db/loaders/jetstream_input_source.py
+++ b/polars_hist_db/loaders/jetstream_input_source.py
@@ -17,6 +17,7 @@ import polars as pl
 from sqlalchemy import Connection, Engine
 
 from ..core.audit import AuditOps
+from ..observability import record_uploader_batch
 from ..utils.exceptions import NonRetryableException
 
 from .ingest_payload import load_df_from_msg
@@ -161,6 +162,12 @@ class JetStreamInputSource(InputSource[JetStreamInputConfig]):
                         num_items_received,
                         js_sub_cfg.subject,
                         received_items_ts,
+                    )
+                    record_uploader_batch(
+                        table=f"{table_schema}.{table_name}",
+                        subject=js_sub_cfg.subject,
+                        received=num_items_received,
+                        written=len(df),
                     )
 
                     partitions = self._apply_time_partitioning(df, msg_ts)

--- a/polars_hist_db/observability.py
+++ b/polars_hist_db/observability.py
@@ -1,0 +1,89 @@
+"""Uploader-side metrics for polars_hist_db loaders.
+
+Exposed as OpenTelemetry counters that a host service can export to
+Prometheus via any OTLP-compatible exporter. If the `opentelemetry`
+package is not installed, all recorders are no-ops — the library stays
+usable without the optional observability dependency.
+
+The concrete signal wired today is `record_uploader_batch`, called from
+`JetStreamInputSource.next_df` after the delta filter runs. It emits:
+
+* `uploader_rows_received_total{table, subject}` — messages arriving on
+  the wire (before any filtering).
+* `uploader_rows_written_total{table, subject}` — rows surviving the
+  delta / audit / dedupe filter, i.e. rows that WILL be written to the
+  target table if commit succeeds.
+* `uploader_rows_dropped_total{table, subject}` — derived: received minus
+  written. Emitted separately so an alert can key on it directly.
+
+Alerts consuming these counters live in `whengas-iac` (PrometheusRule).
+The canonical "uploader stuck" shape is `rate(received) > 0 AND
+rate(written) == 0`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+LOGGER = logging.getLogger(__name__)
+
+_COUNTERS: dict[str, Any] = {}
+
+
+def _get_counter(name: str, description: str) -> Any | None:
+    """Return an OTel Counter, or None if OTel isn't installed. Cached
+    per-name so callers don't pay the get_meter/create_counter cost each
+    batch."""
+    if name in _COUNTERS:
+        return _COUNTERS[name]
+    try:
+        from opentelemetry import metrics
+    except ImportError:
+        _COUNTERS[name] = None
+        return None
+    try:
+        meter = metrics.get_meter("polars_hist_db.uploader")
+        counter = meter.create_counter(name, description=description)
+    except Exception:  # noqa: BLE001 - metrics are best-effort
+        _COUNTERS[name] = None
+        return None
+    _COUNTERS[name] = counter
+    return counter
+
+
+def clear_counters() -> None:
+    """Reset the counter cache (used by tests)."""
+    _COUNTERS.clear()
+
+
+def record_uploader_batch(
+    *, table: str, subject: str, received: int, written: int
+) -> None:
+    """Record one uploader batch. `table` is the fully-qualified
+    `<schema>.<name>` target table; `subject` is the NATS subject the
+    batch came from."""
+    if received < 0 or written < 0:
+        return
+    attrs = {"table": table, "subject": subject}
+    received_c = _get_counter(
+        "uploader_rows_received_total",
+        "Rows received by the polars_hist_db uploader before delta filtering.",
+    )
+    written_c = _get_counter(
+        "uploader_rows_written_total",
+        "Rows surviving the delta filter, staged for write to the target table.",
+    )
+    dropped_c = _get_counter(
+        "uploader_rows_dropped_total",
+        "Rows dropped by the delta filter (received minus written).",
+    )
+    try:
+        if received_c is not None:
+            received_c.add(received, attributes=attrs)
+        if written_c is not None:
+            written_c.add(written, attributes=attrs)
+        if dropped_c is not None:
+            dropped_c.add(max(0, received - written), attributes=attrs)
+    except Exception:  # noqa: BLE001, S110 - metrics are best-effort
+        pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ module = [
     "adbc_driver_flightsql.*",
     "psycopg.*",
     "pyarrow.*",
+    "opentelemetry.*",
 ]
 ignore_missing_imports = true
 

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,130 @@
+"""Tests for polars_hist_db.observability.record_uploader_batch."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from polars_hist_db import observability
+
+
+@pytest.fixture(autouse=True)
+def _reset_counter_cache():
+    observability.clear_counters()
+    yield
+    observability.clear_counters()
+
+
+class _FakeCounter:
+    def __init__(self):
+        self.calls = []
+
+    def add(self, value, attributes=None):
+        self.calls.append((value, dict(attributes or {})))
+
+
+class _FakeMeter:
+    def __init__(self):
+        self.counters: dict[str, _FakeCounter] = {}
+
+    def create_counter(self, name, description=""):
+        counter = self.counters.setdefault(name, _FakeCounter())
+        return counter
+
+
+def _install_fake_otel(monkeypatch):
+    meter = _FakeMeter()
+
+    class _MetricsShim:
+        @staticmethod
+        def get_meter(_name):
+            return meter
+
+    fake_otel = SimpleNamespace(metrics=_MetricsShim())
+    monkeypatch.setitem(__import__("sys").modules, "opentelemetry", fake_otel)
+    return meter
+
+
+def test_record_uploader_batch_emits_three_counters(monkeypatch):
+    meter = _install_fake_otel(monkeypatch)
+
+    observability.record_uploader_batch(
+        table="fakedata.cargos",
+        subject="uploader.cargos",
+        received=50,
+        written=12,
+    )
+
+    assert set(meter.counters) == {
+        "uploader_rows_received_total",
+        "uploader_rows_written_total",
+        "uploader_rows_dropped_total",
+    }
+    assert meter.counters["uploader_rows_received_total"].calls == [
+        (50, {"table": "fakedata.cargos", "subject": "uploader.cargos"})
+    ]
+    assert meter.counters["uploader_rows_written_total"].calls == [
+        (12, {"table": "fakedata.cargos", "subject": "uploader.cargos"})
+    ]
+    assert meter.counters["uploader_rows_dropped_total"].calls == [
+        (38, {"table": "fakedata.cargos", "subject": "uploader.cargos"})
+    ]
+
+
+def test_record_uploader_batch_all_written(monkeypatch):
+    meter = _install_fake_otel(monkeypatch)
+
+    observability.record_uploader_batch(
+        table="fakedata.cargos",
+        subject="uploader.cargos",
+        received=10,
+        written=10,
+    )
+
+    assert meter.counters["uploader_rows_dropped_total"].calls == [
+        (0, {"table": "fakedata.cargos", "subject": "uploader.cargos"})
+    ]
+
+
+def test_record_uploader_batch_stuck_scenario(monkeypatch):
+    """The exact shape the 'uploader stuck' alert keys on: received > 0,
+    written == 0, dropped == received."""
+    meter = _install_fake_otel(monkeypatch)
+
+    observability.record_uploader_batch(
+        table="fakedata.cargos",
+        subject="uploader.cargos",
+        received=50,
+        written=0,
+    )
+
+    assert meter.counters["uploader_rows_written_total"].calls == [
+        (0, {"table": "fakedata.cargos", "subject": "uploader.cargos"})
+    ]
+    assert meter.counters["uploader_rows_dropped_total"].calls == [
+        (50, {"table": "fakedata.cargos", "subject": "uploader.cargos"})
+    ]
+
+
+def test_record_uploader_batch_noop_without_otel(monkeypatch):
+    """When opentelemetry is not importable, the recorder silently does
+    nothing — the library remains usable without the optional dep."""
+    import sys
+
+    monkeypatch.setitem(sys.modules, "opentelemetry", None)
+
+    observability.record_uploader_batch(
+        table="fakedata.cargos",
+        subject="uploader.cargos",
+        received=50,
+        written=12,
+    )
+
+
+def test_record_uploader_batch_ignores_negative_counts(monkeypatch):
+    meter = _install_fake_otel(monkeypatch)
+
+    observability.record_uploader_batch(
+        table="fakedata.cargos", subject="uploader.cargos", received=-1, written=0
+    )
+
+    assert meter.counters == {}


### PR DESCRIPTION
## Summary
- New `polars_hist_db.observability.record_uploader_batch(...)` emits three OpenTelemetry counters per batch: `uploader_rows_received_total`, `uploader_rows_written_total`, `uploader_rows_dropped_total`, each labelled `{table, subject}`.
- Wired into `JetStreamInputSource.next_df` right after the delta-filter log line.
- Optional dependency — a `try/except ImportError` on `opentelemetry` keeps the library usable without the extra. Host service is responsible for wiring an OTLP exporter.

## Why
Piece (2) of the detection story from the 2026-07-05 incident. The uploader was logging `got [0/50] ...` for hours before anyone noticed — no metric surface = no alerting.

Canonical alert shape (lands as a follow-up PrometheusRule):

```
rate(uploader_rows_received_total[15m]) > 0
  AND rate(uploader_rows_written_total[15m]) == 0
```

## Test plan
- [x] Emits all three counters with correct labels + values
- [x] All-written batch: dropped=0
- [x] Stuck scenario: received>0, written=0, dropped=received
- [x] No-op when opentelemetry missing
- [x] Ignores negative counts