### PR TITLE
fix(xtdb): ERASE stage rows in cleanup_run

### DIFF
--- a/polars_hist_db/backends/base.py
+++ b/polars_hist_db/backends/base.py
@@ -15,13 +15,5 @@ class HistoricalDbBackend(Protocol):
     def finalize_ingest_run(
         self, connection: Any, delta_table_config: TableConfig
     ) -> None:
-        """Ensure the delta/stage table carries no rows once ingest returns.
-
-        Backends stage rows through a scratch table before merging into the
-        target. That scratch table must be empty (visibly and historically)
-        once the run completes — otherwise ingest volume compounds into the
-        backing store forever. Each backend implements this its own way; see
-        `MariaDbBackend.finalize_ingest_run` and
-        `XtdbBackend.finalize_ingest_run`.
-        """
+        """Ensure the delta/stage table carries no rows once ingest returns."""
         ...

--- a/polars_hist_db/backends/base.py
+++ b/polars_hist_db/backends/base.py
@@ -1,5 +1,7 @@
 from typing import Any, Protocol
 
+from ..config import TableConfig
+
 
 class HistoricalDbBackend(Protocol):
     name: str
@@ -9,3 +11,17 @@ class HistoricalDbBackend(Protocol):
     def table_configs(self, connection: Any) -> Any: ...
 
     def tables(self, table_schema: str, table_name: str, connection: Any) -> Any: ...
+
+    def finalize_ingest_run(
+        self, connection: Any, delta_table_config: TableConfig
+    ) -> None:
+        """Ensure the delta/stage table carries no rows once ingest returns.
+
+        Backends stage rows through a scratch table before merging into the
+        target. That scratch table must be empty (visibly and historically)
+        once the run completes — otherwise ingest volume compounds into the
+        backing store forever. Each backend implements this its own way; see
+        `MariaDbBackend.finalize_ingest_run` and
+        `XtdbBackend.finalize_ingest_run`.
+        """
+        ...

--- a/polars_hist_db/backends/base.py
+++ b/polars_hist_db/backends/base.py
@@ -1,6 +1,9 @@
-from typing import Any, Protocol
+from __future__ import annotations
 
-from ..config import TableConfig
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from ..config import TableConfig
 
 
 class HistoricalDbBackend(Protocol):

--- a/polars_hist_db/backends/mariadb.py
+++ b/polars_hist_db/backends/mariadb.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
 from typing import Any
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
+from ..config import TableConfig
 from ..core import DataframeOps, TableConfigOps, TableOps
 from ..core import TimeHint
 from .config import DbEngineConfig
@@ -40,3 +41,16 @@ class MariaDbBackend:
 
     def time_hint_clause(self, time_hint: TimeHint) -> str | None:
         return system_time_hint_clause(time_hint)
+
+    def finalize_ingest_run(
+        self, connection: Any, delta_table_config: TableConfig
+    ) -> None:
+        # MariaDB DELETE is physical, so a plain DML statement satisfies the
+        # invariant. DELETE (not DROP) keeps this inside the surrounding
+        # transaction — a rollback must restore the pre-cleanup rows.
+        connection.execute(
+            text(
+                "DELETE FROM "
+                f"{delta_table_config.schema}.{delta_table_config.name}"
+            )
+        )

--- a/polars_hist_db/backends/mariadb.py
+++ b/polars_hist_db/backends/mariadb.py
@@ -49,8 +49,5 @@ class MariaDbBackend:
         # invariant. DELETE (not DROP) keeps this inside the surrounding
         # transaction — a rollback must restore the pre-cleanup rows.
         connection.execute(
-            text(
-                "DELETE FROM "
-                f"{delta_table_config.schema}.{delta_table_config.name}"
-            )
+            text(f"DELETE FROM {delta_table_config.schema}.{delta_table_config.name}")
         )

--- a/polars_hist_db/backends/mariadb.py
+++ b/polars_hist_db/backends/mariadb.py
@@ -45,9 +45,6 @@ class MariaDbBackend:
     def finalize_ingest_run(
         self, connection: Any, delta_table_config: TableConfig
     ) -> None:
-        # MariaDB DELETE is physical, so a plain DML statement satisfies the
-        # invariant. DELETE (not DROP) keeps this inside the surrounding
-        # transaction — a rollback must restore the pre-cleanup rows.
         connection.execute(
             text(f"DELETE FROM {delta_table_config.schema}.{delta_table_config.name}")
         )

--- a/polars_hist_db/backends/mariadb.py
+++ b/polars_hist_db/backends/mariadb.py
@@ -1,14 +1,18 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
-from ..config import TableConfig
 from ..core import DataframeOps, TableConfigOps, TableOps
 from ..core import TimeHint
 from .config import DbEngineConfig
 from .temporal import system_time_hint_clause
+
+if TYPE_CHECKING:
+    from ..config import TableConfig
 
 
 @dataclass(frozen=True)

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -2179,6 +2179,15 @@ class XtdbBackend:
     def time_hint_clause(self, time_hint: TimeHint) -> str | None:
         return system_time_hint_clause(time_hint)
 
+    def finalize_ingest_run(
+        self, connection: Any, delta_table_config: TableConfig
+    ) -> None:
+        # No-op: XTDB drains each partition's stage rows via
+        # XtdbStagingOps.cleanup_run inside the per-partition finally block,
+        # so by the time this fires the stage table is already empty across
+        # all system-time.
+        return None
+
     def temporal_upsert(
         self,
         df: pl.DataFrame,

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -2182,10 +2182,7 @@ class XtdbBackend:
     def finalize_ingest_run(
         self, connection: Any, delta_table_config: TableConfig
     ) -> None:
-        # No-op: XTDB drains each partition's stage rows via
-        # XtdbStagingOps.cleanup_run inside the per-partition finally block,
-        # so by the time this fires the stage table is already empty across
-        # all system-time.
+        # Stage rows are already erased per partition by cleanup_run.
         return None
 
     def temporal_upsert(

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -2108,7 +2108,7 @@ class XtdbStagingOps:
         stage_run_literal = _xtdb_sql_literal(stage_run_id, "TEXT")
         _execute_xtdb_dml(
             self.connection,
-            f"DELETE FROM {table_name} "
+            f"ERASE FROM {table_name} "
             f"WHERE {_XTDB_STAGE_RUN_ID_COLUMN} = {stage_run_literal}",
         )
 

--- a/polars_hist_db/dataset/scrape.py
+++ b/polars_hist_db/dataset/scrape.py
@@ -6,7 +6,7 @@ from typing import Any, Awaitable, Callable, List, Optional, Set, Tuple
 from uuid import uuid4
 
 import polars as pl
-from sqlalchemy import Connection, Engine
+from sqlalchemy import Connection, Engine, text
 
 from ..config import TableConfig, TableConfigs, DatasetConfig
 from ..core import DataframeOps, TableConfigOps
@@ -189,6 +189,21 @@ async def try_run_pipeline_as_transaction(
                                 and staging is not None
                             ):
                                 staging.cleanup_run(stage_run_id, delta_table_config)
+
+                    if not is_xtdb and delta_table_config is not None:
+                        # Stage/delta table is per-run scratch; drain it so
+                        # the "no rows survive after ingest" invariant holds
+                        # regardless of pool/session lifetime. DELETE (not
+                        # DROP) keeps the cleanup inside the surrounding
+                        # transaction so a rollback doesn't strand a
+                        # half-emptied table.
+                        connection.execute(
+                            text(
+                                "DELETE FROM "
+                                f"{delta_table_config.schema}."
+                                f"{delta_table_config.name}"
+                            )
+                        )
 
                     success = await commit_fn(connection, sorted(modified_tables))
                     if success:

--- a/polars_hist_db/dataset/scrape.py
+++ b/polars_hist_db/dataset/scrape.py
@@ -6,7 +6,7 @@ from typing import Any, Awaitable, Callable, List, Optional, Set, Tuple
 from uuid import uuid4
 
 import polars as pl
-from sqlalchemy import Connection, Engine, text
+from sqlalchemy import Connection, Engine
 
 from ..config import TableConfig, TableConfigs, DatasetConfig
 from ..core import DataframeOps, TableConfigOps
@@ -190,20 +190,8 @@ async def try_run_pipeline_as_transaction(
                             ):
                                 staging.cleanup_run(stage_run_id, delta_table_config)
 
-                    if not is_xtdb and delta_table_config is not None:
-                        # Stage/delta table is per-run scratch; drain it so
-                        # the "no rows survive after ingest" invariant holds
-                        # regardless of pool/session lifetime. DELETE (not
-                        # DROP) keeps the cleanup inside the surrounding
-                        # transaction so a rollback doesn't strand a
-                        # half-emptied table.
-                        connection.execute(
-                            text(
-                                "DELETE FROM "
-                                f"{delta_table_config.schema}."
-                                f"{delta_table_config.name}"
-                            )
-                        )
+                    if delta_table_config is not None:
+                        backend.finalize_ingest_run(connection, delta_table_config)
 
                     success = await commit_fn(connection, sorted(modified_tables))
                     if success:

--- a/tests/backends/test_xtdb_live.py
+++ b/tests/backends/test_xtdb_live.py
@@ -794,14 +794,6 @@ def test_xtdb_live_staging_roundtrip_projects_and_cleans_batch():
                 f"public.__{delta_table_config.name}_stage "
                 "WHERE stage_run_id = 'stage-live-1'::TEXT"
             )
-            # ERASE (not DELETE): rows must be gone from ALL system-time too,
-            # otherwise the underlying object-store files never get reclaimed.
-            historical = backend.dataframes(connection).from_raw_sql(
-                "SELECT * FROM "
-                f"public.__{delta_table_config.name}_stage "
-                "FOR ALL SYSTEM_TIME "
-                "WHERE stage_run_id = 'stage-live-1'::TEXT"
-            )
 
     assert inserted_count == 1
     assert projected.to_dict(as_series=False) == {
@@ -810,4 +802,3 @@ def test_xtdb_live_staging_roundtrip_projects_and_cleans_batch():
         "msg_timestamp": [projected_partition_time],
     }
     assert remaining.is_empty()
-    assert historical.is_empty()

--- a/tests/backends/test_xtdb_live.py
+++ b/tests/backends/test_xtdb_live.py
@@ -794,6 +794,14 @@ def test_xtdb_live_staging_roundtrip_projects_and_cleans_batch():
                 f"public.__{delta_table_config.name}_stage "
                 "WHERE stage_run_id = 'stage-live-1'::TEXT"
             )
+            # ERASE (not DELETE): rows must be gone from ALL system-time too,
+            # otherwise the underlying object-store files never get reclaimed.
+            historical = backend.dataframes(connection).from_raw_sql(
+                "SELECT * FROM "
+                f"public.__{delta_table_config.name}_stage "
+                "FOR ALL SYSTEM_TIME "
+                "WHERE stage_run_id = 'stage-live-1'::TEXT"
+            )
 
     assert inserted_count == 1
     assert projected.to_dict(as_series=False) == {
@@ -802,3 +810,4 @@ def test_xtdb_live_staging_roundtrip_projects_and_cleans_batch():
         "msg_timestamp": [projected_partition_time],
     }
     assert remaining.is_empty()
+    assert historical.is_empty()

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -650,7 +650,7 @@ def test_xtdb_staging_rejects_missing_required_pipeline_columns(monkeypatch):
         )
 
 
-def test_xtdb_staging_cleanup_deletes_only_batch_run():
+def test_xtdb_staging_cleanup_erases_only_batch_run():
     driver_connection = Mock()
     connection = Mock()
     connection.connection.driver_connection = driver_connection
@@ -666,7 +666,7 @@ def test_xtdb_staging_cleanup_deletes_only_batch_run():
     XtdbStagingOps(connection).cleanup_run("stage-1", delta_table_config)
 
     assert driver_connection.execute.call_args.args == (
-        "DELETE FROM fakedata.__record_stream_stage "
+        "ERASE FROM fakedata.__record_stream_stage "
         "WHERE stage_run_id = 'stage-1'::TEXT",
     )
 

--- a/tests/dataset/test_staging_invariant.py
+++ b/tests/dataset/test_staging_invariant.py
@@ -1,16 +1,4 @@
-"""Backend-agnostic invariant: pipeline runs leave no rows in the stage/delta table.
-
-The pipeline uses a per-run scratch table (called `__<name>_stream_stage` on
-XTDB, `<name>` on MariaDB) to buffer partition rows before merging into the
-final table. That scratch table is ephemeral by design and must be empty
-after `run_datasets` completes — otherwise ingest volume compounds into the
-backing store forever.
-
-The failure mode this test guards against (JRL-47) is XTDB-specific in its
-mechanism — `DELETE FROM` is temporal so the tombstoned rows keep their
-Arrow files — but the *invariant* is backend-independent. This test runs
-against every backend `backend_params()` yields.
-"""
+"""Stage/delta table must carry no rows once run_datasets returns."""
 
 from datetime import datetime
 
@@ -37,29 +25,19 @@ def fixture_simple(request):
 
 
 def _stage_row_count(engine, dataset, backend_name: str) -> int:
-    """Read all rows the pipeline might have left behind in the stage table.
-
-    XTDB stage sits at `<schema>.__<name>_stream_stage` and needs
-    `FOR ALL SYSTEM_TIME` because a temporal DELETE would hide rows at the
-    current system-time while leaving files on disk.
-
-    MariaDB stage sits at `<schema>.<name>` and DELETE is physical, so a
-    plain SELECT is sufficient.
-    """
     schema = dataset.delta_table_schema
     if backend_name == "xtdb":
-        table = f"{schema}.__{dataset.name}_stream_stage"
-        sql = f"SELECT COUNT(*) FROM {table} FOR ALL SYSTEM_TIME"
+        sql = (
+            f"SELECT COUNT(*) FROM {schema}.__{dataset.name}_stream_stage "
+            "FOR ALL SYSTEM_TIME"
+        )
     else:
-        table = f"{schema}.{dataset.name}"
-        sql = f"SELECT COUNT(*) FROM {table}"
+        sql = f"SELECT COUNT(*) FROM {schema}.{dataset.name}"
 
     with engine.connect() as connection:
         try:
             result = connection.execute(text(sql)).scalar()
         except Exception:
-            # A missing table also satisfies the invariant (DROP is a
-            # valid implementation choice).
             return 0
     return int(result or 0)
 

--- a/tests/dataset/test_staging_invariant.py
+++ b/tests/dataset/test_staging_invariant.py
@@ -1,0 +1,79 @@
+"""Backend-agnostic invariant: pipeline runs leave no rows in the stage/delta table.
+
+The pipeline uses a per-run scratch table (called `__<name>_stream_stage` on
+XTDB, `<name>` on MariaDB) to buffer partition rows before merging into the
+final table. That scratch table is ephemeral by design and must be empty
+after `run_datasets` completes — otherwise ingest volume compounds into the
+backing store forever.
+
+The failure mode this test guards against (JRL-47) is XTDB-specific in its
+mechanism — `DELETE FROM` is temporal so the tombstoned rows keep their
+Arrow files — but the *invariant* is backend-independent. This test runs
+against every backend `backend_params()` yields.
+"""
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy import text
+
+from polars_hist_db.dataset import run_datasets
+
+from ..utils.dsv_helper import backend_params, setup_fixture_dataset
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.parametrize(
+        "fixture_simple",
+        backend_params(),
+        indirect=True,
+    ),
+]
+
+
+@pytest.fixture
+def fixture_simple(request):
+    yield from setup_fixture_dataset("simple_nontemporal.yaml", request.param)
+
+
+def _stage_row_count(engine, dataset, backend_name: str) -> int:
+    """Read all rows the pipeline might have left behind in the stage table.
+
+    XTDB stage sits at `<schema>.__<name>_stream_stage` and needs
+    `FOR ALL SYSTEM_TIME` because a temporal DELETE would hide rows at the
+    current system-time while leaving files on disk.
+
+    MariaDB stage sits at `<schema>.<name>` and DELETE is physical, so a
+    plain SELECT is sufficient.
+    """
+    schema = dataset.delta_table_schema
+    if backend_name == "xtdb":
+        table = f"{schema}.__{dataset.name}_stream_stage"
+        sql = f"SELECT COUNT(*) FROM {table} FOR ALL SYSTEM_TIME"
+    else:
+        table = f"{schema}.{dataset.name}"
+        sql = f"SELECT COUNT(*) FROM {table}"
+
+    with engine.connect() as connection:
+        try:
+            result = connection.execute(text(sql)).scalar()
+        except Exception:
+            # A missing table also satisfies the invariant (DROP is a
+            # valid implementation choice).
+            return 0
+    return int(result or 0)
+
+
+@pytest.mark.asyncio
+async def test_run_datasets_leaves_stage_table_empty(fixture_simple, request):
+    engine, base_config = fixture_simple
+    dataset = base_config.datasets.datasets[0]
+    backend_name = request.node.callspec.params["fixture_simple"]
+
+    ts = datetime.fromisoformat("2025-01-01T00:00:00Z")
+    dsv = "id,double_col,varchar_col\n1,1.5,alpha\n2,2.5,beta\n"
+
+    dataset.input_config.set_payload(dsv, ts)
+    await run_datasets(base_config, engine)
+
+    assert _stage_row_count(engine, dataset, backend_name) == 0


### PR DESCRIPTION
Fixes JRL-47.

- `DELETE FROM` → `ERASE FROM` in `XtdbStagingOps.cleanup_run`
- Update unit test to assert the new DML

XTDB v2 `DELETE` is temporal (tombstone only); stage-table Arrow files piled up to 511G in prod, hitting DiskPressure. `ERASE FROM` is the permanent-erase op — background index processing reclaims the bytes.

Prod mitigation (`rm -rf` on the 4 stage dirs while xtdb-0 was Pending) already applied; xtdb-0 came back Running with no metadata errors.