### PR TITLE
feat(wg-258): enforce valid-time ingestion contract

### DIFF
--- a/docs/configuration.qmd
+++ b/docs/configuration.qmd
@@ -150,3 +150,47 @@ This task populates the `food_prices` table:
 - All columns are required (marked with `!`)
 - Table is marked as `type: primary` for system versioning
 - Note: Currently only one primary task is allowed per pipeline
+
+### Valid time
+
+Datasets can map source validity columns onto a backend's valid-time metadata
+with `valid_time` entries:
+
+```yaml
+datasets:
+- name: source_event_stream
+  delta_table_schema: source
+  valid_time:
+  - schema: source
+    table: events
+    from_column: event_timestamp
+
+  pipeline:
+  - schema: source
+    table: events
+    type: primary
+    columns:
+    - {source: id, target: id}
+    - {source: event_timestamp, target: event_timestamp}
+```
+
+The configured `from_column` identifies when a row becomes valid. An optional
+`to_column` identifies when the row stops being valid for rows with an explicit
+validity window:
+
+```yaml
+valid_time:
+- schema: overrides
+  table: data_override_operations
+  from_column: valid_from
+  to_column: valid_to
+```
+
+Mapped valid-time source columns are required. Ingest fails if a configured
+`from_column` or `to_column` is missing or contains null values, because
+falling back to upload/system time would change the source semantics.
+
+Backends decide how to materialize the backend-neutral valid-time contract. The
+XTDB backend maps `from_column` to `_valid_from` and `to_column` to `_valid_to`.
+SQL/MariaDB ingestion validates the configured source columns in the staging
+table, but does not materialize separate valid-time metadata.

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -1109,6 +1109,13 @@ def _apply_xtdb_valid_time_mapping(
             + ", ".join(missing_columns)
         )
 
+    null_columns = [source for source in mappings if df[source].null_count() > 0]
+    if null_columns:
+        raise ValueError(
+            "XTDB valid-time mapping references null source value(s): "
+            + ", ".join(null_columns)
+        )
+
     for source, target in mappings.items():
         if target in df.columns and source != target:
             raise ValueError(

--- a/polars_hist_db/dataset/primary_item.py
+++ b/polars_hist_db/dataset/primary_item.py
@@ -3,10 +3,12 @@ import logging
 from typing import Any, Optional
 
 import polars as pl
+from sqlalchemy import func, or_, select, Table
 from sqlalchemy import Connection
 
 from ..config import TableConfig, TableConfigs, DatasetConfig
 from ..core import TableConfigOps, DeltaTableOps, TableOps
+from ..pipeline_projection import valid_time_source_columns
 
 LOGGER = logging.getLogger(__name__)
 
@@ -22,6 +24,34 @@ def _xtdb_temporal_write_kwargs(
     if hasattr(staging, "bulk_dataframes"):
         return {"dataframe_ops": staging.bulk_dataframes()}
     return {}
+
+
+def _validate_sql_valid_time_source_table(
+    connection: Connection,
+    source_table: Table,
+    source_columns: list[str],
+) -> None:
+    missing_columns = [
+        column for column in source_columns if column not in source_table.c
+    ]
+    if missing_columns:
+        raise ValueError(
+            "valid-time mapping references missing source column(s): "
+            + ", ".join(missing_columns)
+        )
+
+    if not source_columns:
+        return
+
+    null_predicates = [source_table.c[column].is_(None) for column in source_columns]
+    null_count = connection.execute(
+        select(func.count()).select_from(source_table).where(or_(*null_predicates))
+    ).scalar_one()
+    if null_count:
+        raise ValueError(
+            "valid-time mapping references null source value(s): "
+            + ", ".join(source_columns)
+        )
 
 
 def scrape_primary_item(
@@ -53,11 +83,22 @@ def scrape_primary_item(
             backend,
         )
 
-    upload_items = pipeline.extract_items(pipeline_id)
-    selected_columns = upload_items["source"].to_list()
-
     TableConfigOps(connection).create(main_table_config)
     tbo = TableOps(delta_table_schema, delta_table_name, connection)
+    source_tbl = tbo.get_table_metadata()
+
+    upload_items = pipeline.extract_items(pipeline_id)
+    selected_columns = upload_items["source"].to_list()
+    src_tgt_colname_map = dict(upload_items.select("source", "target").iter_rows())
+    valid_time = dataset.valid_time_for_table(
+        main_table_config.schema, main_table_config.name
+    )
+    _validate_sql_valid_time_source_table(
+        connection,
+        source_tbl,
+        valid_time_source_columns(src_tgt_colname_map, valid_time),
+    )
+
     common_columns = [c.name for c in tbo.get_column_intersection(selected_columns)]
 
     if selected_columns is not None:
@@ -76,7 +117,7 @@ def scrape_primary_item(
         upload_time,
         is_main_table=True,
         source_columns=common_columns,
-        src_tgt_colname_map=dict(upload_items.select("source", "target").iter_rows()),
+        src_tgt_colname_map=src_tgt_colname_map,
     )
 
     LOGGER.debug("(item %d) upserted %d rows", -1, ni + nu)

--- a/polars_hist_db/pipeline_projection.py
+++ b/polars_hist_db/pipeline_projection.py
@@ -16,15 +16,49 @@ def _include_valid_time_source_columns(
     if valid_time is None:
         return result
 
+    required_source_columns = valid_time_source_columns(src_tgt_colname_map, valid_time)
+    for source_column in required_source_columns:
+        if source_column not in result:
+            result.append(source_column)
+
+    missing_columns = [
+        source for source in required_source_columns if source not in stage_df.columns
+    ]
+    if missing_columns:
+        raise ValueError(
+            "valid-time mapping references missing source column(s): "
+            + ", ".join(missing_columns)
+        )
+
+    null_columns = [
+        source
+        for source in required_source_columns
+        if stage_df[source].null_count() > 0
+    ]
+    if null_columns:
+        raise ValueError(
+            "valid-time mapping references null source value(s): "
+            + ", ".join(null_columns)
+        )
+
+    return result
+
+
+def valid_time_source_columns(
+    src_tgt_colname_map: dict[str, str],
+    valid_time: Optional[ValidTimeConfig],
+) -> list[str]:
+    if valid_time is None:
+        return []
+
     target_to_source = {
         target: source for source, target in src_tgt_colname_map.items()
     }
+    result = []
     for valid_time_column in [valid_time.from_column, valid_time.to_column]:
         if valid_time_column is None:
             continue
-        source_column = target_to_source.get(valid_time_column, valid_time_column)
-        if source_column in stage_df.columns and source_column not in result:
-            result.append(source_column)
+        result.append(target_to_source.get(valid_time_column, valid_time_column))
     return result
 
 

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -691,6 +691,49 @@ def test_xtdb_temporal_upsert_rejects_missing_valid_time_source_column():
         )
 
 
+@pytest.mark.parametrize(
+    ("data", "valid_time", "missing_column"),
+    [
+        (
+            {
+                "id": [1],
+                "destination": ["Alpha"],
+                "msg_timestamp": [None],
+            },
+            ValidTimeConfig(table="records", from_column="msg_timestamp"),
+            "msg_timestamp",
+        ),
+        (
+            {
+                "id": [1],
+                "destination": ["Alpha"],
+                "msg_timestamp": [datetime(2030, 1, 1, tzinfo=timezone.utc)],
+                "valid_until": [None],
+            },
+            ValidTimeConfig(
+                table="records",
+                from_column="msg_timestamp",
+                to_column="valid_until",
+            ),
+            "valid_until",
+        ),
+    ],
+)
+def test_xtdb_temporal_upsert_rejects_null_valid_time_source_column(
+    data, valid_time, missing_column
+):
+    backend = XtdbBackend()
+
+    with pytest.raises(ValueError, match=f"null source value.*{missing_column}"):
+        backend.temporal_upsert(
+            pl.DataFrame(data),
+            "test",
+            "records",
+            dataframe_ops=Mock(),
+            valid_time=valid_time,
+        )
+
+
 def test_xtdb_temporal_upsert_rejects_valid_time_target_conflict():
     backend = XtdbBackend()
 

--- a/tests/dataset/test_valid_time_contract.py
+++ b/tests/dataset/test_valid_time_contract.py
@@ -1,0 +1,159 @@
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import Column, DateTime, Integer, MetaData, String, Table, create_engine
+
+from polars_hist_db.config import DatasetConfig, TableConfigs
+from polars_hist_db.dataset.primary_item import scrape_primary_item
+from polars_hist_db.dataset.primary_item import _validate_sql_valid_time_source_table
+
+
+def _source_table(connection):
+    metadata = MetaData()
+    table = Table(
+        "stage_events",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("event_value", String(64)),
+        Column("event_timestamp", DateTime(timezone=True)),
+        Column("valid_until", DateTime(timezone=True)),
+    )
+    metadata.create_all(connection)
+    return table
+
+
+@pytest.fixture
+def connection():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        yield conn
+
+
+def test_sql_valid_time_source_table_accepts_non_null_columns(connection):
+    table = _source_table(connection)
+    connection.execute(
+        table.insert(),
+        {
+            "id": 1,
+            "event_value": "Alpha",
+            "event_timestamp": datetime(2030, 1, 1, tzinfo=timezone.utc),
+            "valid_until": datetime(2030, 2, 1, tzinfo=timezone.utc),
+        },
+    )
+
+    _validate_sql_valid_time_source_table(
+        connection,
+        table,
+        ["event_timestamp", "valid_until"],
+    )
+
+
+def test_sql_valid_time_source_table_rejects_missing_columns(connection):
+    table = _source_table(connection)
+
+    with pytest.raises(ValueError, match="missing source column.*event_timestamp"):
+        _validate_sql_valid_time_source_table(
+            connection,
+            table,
+            ["event_timestamp_missing"],
+        )
+
+
+def test_sql_valid_time_source_table_rejects_null_values(connection):
+    table = _source_table(connection)
+    connection.execute(
+        table.insert(),
+        {
+            "id": 1,
+            "event_value": "Alpha",
+            "event_timestamp": None,
+            "valid_until": datetime(2030, 2, 1, tzinfo=timezone.utc),
+        },
+    )
+
+    with pytest.raises(ValueError, match="null source value.*event_timestamp"):
+        _validate_sql_valid_time_source_table(
+            connection,
+            table,
+            ["event_timestamp", "valid_until"],
+        )
+
+
+def test_mariadb_primary_ingest_rejects_null_valid_time_source(monkeypatch, connection):
+    table = _source_table(connection)
+    connection.execute(
+        table.insert(),
+        {
+            "id": 1,
+            "event_value": "Alpha",
+            "event_timestamp": None,
+        },
+    )
+    dataset = DatasetConfig(
+        name="stage_events",
+        delta_table_schema="source",
+        input_config={"type": "dsv", "search_paths": []},
+        valid_time=[
+            {
+                "schema": "source",
+                "table": "events",
+                "from_column": "event_timestamp",
+            }
+        ],
+        pipeline=[
+            {
+                "schema": "source",
+                "table": "events",
+                "type": "primary",
+                "columns": [
+                    {"source": "id", "target": "id"},
+                    {"source": "event_value", "target": "event_value"},
+                ],
+            }
+        ],
+    )
+    tables = TableConfigs(
+        items=[
+            {
+                "schema": "source",
+                "name": "events",
+                "primary_keys": ["id"],
+                "columns": [
+                    {"name": "id", "data_type": "INT", "nullable": False},
+                    {"name": "event_value", "data_type": "VARCHAR(64)"},
+                ],
+                "is_temporal": True,
+            }
+        ]
+    )
+
+    class _FakeTableConfigOps:
+        def __init__(self, _connection):
+            pass
+
+        def create(self, _table_config):
+            return _table_config
+
+    class _FakeTableOps:
+        def __init__(self, *_args):
+            pass
+
+        def get_table_metadata(self):
+            return table
+
+        def get_column_intersection(self, _selected_columns):
+            raise AssertionError("valid_time validation should fail before upsert")
+
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.primary_item.TableConfigOps", _FakeTableConfigOps
+    )
+    monkeypatch.setattr("polars_hist_db.dataset.primary_item.TableOps", _FakeTableOps)
+
+    with pytest.raises(ValueError, match="null source value.*event_timestamp"):
+        scrape_primary_item(
+            0,
+            dataset,
+            tables,
+            datetime(2030, 1, 1, tzinfo=timezone.utc),
+            connection,
+        )

--- a/tests/test_pipeline_projection.py
+++ b/tests/test_pipeline_projection.py
@@ -1,0 +1,104 @@
+from datetime import datetime, timezone
+
+import polars as pl
+import pytest
+
+from polars_hist_db.config import TableColumnConfig, TableConfig, ValidTimeConfig
+from polars_hist_db.pipeline_projection import project_staged_pipeline_item_dataframe
+
+
+class _Pipeline:
+    def __init__(self, items: pl.DataFrame):
+        self._items = items
+
+    def extract_items(self, pipeline_id: int) -> pl.DataFrame:
+        return self._items.filter(pl.col("id") == pipeline_id)
+
+
+class _Dataset:
+    def __init__(self, items: pl.DataFrame):
+        self.pipeline = _Pipeline(items)
+
+
+def _table_config() -> TableConfig:
+    return TableConfig(
+        schema="source",
+        name="events",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("events", "id", "INT", nullable=False),
+            TableColumnConfig("events", "event_value", "VARCHAR(64)"),
+        ],
+    )
+
+
+def _dataset() -> _Dataset:
+    return _Dataset(
+        pl.DataFrame(
+            {
+                "id": [0, 0],
+                "schema": ["source", "source"],
+                "table": ["events", "events"],
+                "source": ["id", "event_value"],
+                "target": ["id", "event_value"],
+            }
+        )
+    )
+
+
+def test_valid_time_source_columns_are_projected_from_staging_data():
+    event_time = datetime(2030, 1, 1, tzinfo=timezone.utc)
+
+    result = project_staged_pipeline_item_dataframe(
+        pl.DataFrame(
+            {
+                "id": [1],
+                "event_value": ["Alpha"],
+                "event_timestamp": [event_time],
+            }
+        ),
+        _dataset(),
+        0,
+        _table_config(),
+        ValidTimeConfig(table="events", from_column="event_timestamp"),
+    )
+
+    assert result.to_dict(as_series=False) == {
+        "id": [1],
+        "event_value": ["Alpha"],
+        "event_timestamp": [event_time],
+    }
+
+
+@pytest.mark.parametrize("event_timestamp", [None])
+def test_valid_time_source_columns_are_required_and_non_null(event_timestamp):
+    with pytest.raises(ValueError, match="null source value.*event_timestamp"):
+        project_staged_pipeline_item_dataframe(
+            pl.DataFrame(
+                {
+                    "id": [1],
+                    "event_value": ["Alpha"],
+                    "event_timestamp": [event_timestamp],
+                }
+            ),
+            _dataset(),
+            0,
+            _table_config(),
+            ValidTimeConfig(table="events", from_column="event_timestamp"),
+        )
+
+
+def test_missing_valid_time_source_column_is_rejected_before_backend_write():
+    with pytest.raises(ValueError, match="missing source column.*event_timestamp"):
+        project_staged_pipeline_item_dataframe(
+            pl.DataFrame(
+                {
+                    "id": [1],
+                    "event_value": ["Alpha"],
+                }
+            ),
+            _dataset(),
+            0,
+            _table_config(),
+            ValidTimeConfig(table="events", from_column="event_timestamp"),
+        )


### PR DESCRIPTION
## Summary
- Document valid_time as a backend-neutral dataset ingestion contract.
- Require mapped from_column/to_column values to exist and be non-null during projection before backend writes.
- Keep XTDB direct temporal_upsert defensive checks for null mapped valid-time values.

## Test Plan
- uv run pytest tests/test_pipeline_projection.py -q
- uv run pytest tests/backends/test_xtdb_backend.py::test_xtdb_temporal_upsert_rejects_missing_valid_time_source_column tests/backends/test_xtdb_backend.py::test_xtdb_temporal_upsert_rejects_null_valid_time_source_column tests/backends/test_xtdb_backend.py::test_xtdb_temporal_upsert_maps_configured_valid_time_columns -q
- uv run pytest tests/backends/test_xtdb_backend.py tests/test_pipeline_projection.py tests/config/test_valid_time_config.py -q
- make check