### PR TITLE
feat: add replicated override CRDT core (JWL-13)

### DIFF
--- a/polars_hist_db/overrides/__init__.py
+++ b/polars_hist_db/overrides/__init__.py
@@ -1,5 +1,16 @@
 from .config import build_override_table_config, build_override_valid_time_config
+from .crdt import CrdtAppendResult, CrdtDocument, InMemoryCrdtDocumentStore
 from .ledger import InMemoryOverrideLedgerStore, OverrideLedger
+from .replicated import (
+    InMemoryReplicatedOverrideLedger,
+    OverrideFrontier,
+    ReplicatedOverrideAppendResult,
+    ReplicatedOverrideOperation,
+    finalize_replicated_override_operation,
+    operation_payload_hash,
+    project_replicated_override_operations,
+    validate_replicated_override_operation,
+)
 from .types import (
     OverrideLedgerConfig,
     OverrideOperation,
@@ -9,11 +20,22 @@ from .types import (
 
 __all__ = [
     "InMemoryOverrideLedgerStore",
+    "InMemoryCrdtDocumentStore",
+    "InMemoryReplicatedOverrideLedger",
     "OverrideLedger",
     "OverrideLedgerConfig",
     "OverrideOperation",
     "OverrideOperationType",
     "OverrideTypedValue",
+    "CrdtAppendResult",
+    "CrdtDocument",
+    "OverrideFrontier",
+    "ReplicatedOverrideAppendResult",
+    "ReplicatedOverrideOperation",
     "build_override_table_config",
     "build_override_valid_time_config",
+    "finalize_replicated_override_operation",
+    "operation_payload_hash",
+    "project_replicated_override_operations",
+    "validate_replicated_override_operation",
 ]

--- a/polars_hist_db/overrides/config.py
+++ b/polars_hist_db/overrides/config.py
@@ -40,6 +40,14 @@ def build_override_table_config(config: OverrideLedgerConfig) -> TableConfig:
             TableColumnConfig(table, "reason", "VARCHAR(128)"),
             TableColumnConfig(table, "comment", "VARCHAR(2048)"),
             TableColumnConfig(table, "metadata_json", "JSON"),
+            # Nullable fields preserve compatibility with existing personal rows.
+            TableColumnConfig(table, "format_version", "INT"),
+            TableColumnConfig(table, "layer_id", "VARCHAR(128)"),
+            TableColumnConfig(table, "actor_id", "VARCHAR(128)"),
+            TableColumnConfig(table, "supersedes_operation_ids_json", "JSON"),
+            TableColumnConfig(table, "removes_operation_ids_json", "JSON"),
+            TableColumnConfig(table, "recorded_at", "DATETIME(6)"),
+            TableColumnConfig(table, "payload_hash", "VARCHAR(64)"),
         ],
     )
 

--- a/polars_hist_db/overrides/crdt.py
+++ b/polars_hist_db/overrides/crdt.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CrdtDocument:
+    document_id: str
+    revision: int
+    state_vector: bytes
+    update: bytes
+
+
+@dataclass(frozen=True)
+class CrdtAppendResult:
+    document: CrdtDocument
+    accepted: bool
+
+
+class InMemoryCrdtDocumentStore:
+    """Yjs-compatible document storage for tests and embedded applications."""
+
+    def __init__(self) -> None:
+        self._documents: dict[str, Any] = {}
+        self._revisions: dict[str, int] = {}
+        self._update_hashes: dict[str, set[str]] = {}
+        self._snapshots: dict[str, CrdtDocument] = {}
+
+    def append_update(
+        self,
+        document_id: str,
+        update: bytes,
+        *,
+        expected_revision: int | None = None,
+    ) -> CrdtAppendResult:
+        document = self._documents.get(document_id)
+        revision = self._revisions.get(document_id, 0)
+        if document is None:
+            if expected_revision not in {None, 0}:
+                raise ValueError(
+                    "CRDT document revision does not match expected revision"
+                )
+            document = _doc()
+            self._documents[document_id] = document
+            self._revisions[document_id] = revision
+        update_hash = sha256(update).hexdigest()
+        hashes = self._update_hashes.setdefault(document_id, set())
+
+        if update_hash in hashes:
+            return CrdtAppendResult(self.load_document(document_id), accepted=False)
+        if expected_revision is not None and expected_revision != revision:
+            raise ValueError("CRDT document revision does not match expected revision")
+
+        document.apply_update(update)
+        hashes.add(update_hash)
+        self._revisions[document_id] = revision + 1
+        return CrdtAppendResult(self.load_document(document_id), accepted=True)
+
+    def load_document(self, document_id: str) -> CrdtDocument:
+        document = self._documents.get(document_id)
+        if document is None:
+            raise KeyError(f"unknown CRDT document: {document_id}")
+        return CrdtDocument(
+            document_id=document_id,
+            revision=self._revisions[document_id],
+            state_vector=document.get_state(),
+            update=document.get_update(),
+        )
+
+    def diff(self, document_id: str, state_vector: bytes) -> bytes:
+        return self._documents[document_id].get_update(state_vector)
+
+    def write_snapshot(self, document_id: str) -> CrdtDocument:
+        snapshot = self.load_document(document_id)
+        self._snapshots[document_id] = snapshot
+        return snapshot
+
+    def snapshot(self, document_id: str) -> CrdtDocument | None:
+        return self._snapshots.get(document_id)
+
+
+def _doc() -> Any:
+    try:
+        from pycrdt import Doc
+    except ImportError as exc:
+        raise RuntimeError(
+            "CRDT support requires the 'crdt' extra: pip install polars-hist-db[crdt]"
+        ) from exc
+    return Doc()

--- a/polars_hist_db/overrides/replicated.py
+++ b/polars_hist_db/overrides/replicated.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from hashlib import sha256
+import json
+from typing import Iterable, Literal
+from uuid import UUID
+
+from .types import OverrideTypedValue
+
+ReplicatedOverrideOperationType = Literal["set", "remove"]
+OverrideFrontierState = Literal["none", "clean", "conflict"]
+
+
+@dataclass(frozen=True)
+class ReplicatedOverrideOperation:
+    format_version: int
+    operation_id: str
+    change_set_id: str
+    layer_id: str
+    actor_id: str
+    feed_id: str
+    entity_id: str
+    field_path: str
+    operation_type: ReplicatedOverrideOperationType
+    value: OverrideTypedValue | None
+    supersedes_operation_ids: tuple[str, ...]
+    removes_operation_ids: tuple[str, ...]
+    valid_from: datetime
+    valid_to: datetime | None
+    recorded_at: datetime
+    observed_canonical_value_json: dict[str, object] | None = None
+    comment: str | None = None
+    metadata_json: dict[str, object] | None = None
+    payload_hash: str | None = None
+
+
+@dataclass(frozen=True)
+class ReplicatedOverrideAppendResult:
+    operation: ReplicatedOverrideOperation
+    accepted: bool
+
+
+@dataclass(frozen=True)
+class OverrideFrontier:
+    field_path: str
+    state: OverrideFrontierState
+    operations: tuple[ReplicatedOverrideOperation, ...]
+
+
+class InMemoryReplicatedOverrideLedger:
+    def __init__(self) -> None:
+        self._operations: dict[str, ReplicatedOverrideOperation] = {}
+
+    def append(
+        self, operation: ReplicatedOverrideOperation
+    ) -> ReplicatedOverrideAppendResult:
+        return self.append_batch([operation])[0]
+
+    def append_batch(
+        self, operations: Iterable[ReplicatedOverrideOperation]
+    ) -> list[ReplicatedOverrideAppendResult]:
+        pending = list(operations)
+        known = dict(self._operations)
+        results: list[ReplicatedOverrideAppendResult] = []
+
+        for operation in pending:
+            existing = known.get(operation.operation_id)
+            if existing is not None:
+                if operation_payload_hash(existing) != operation_payload_hash(
+                    operation
+                ):
+                    raise ValueError("operation ID was reused with different content")
+                results.append(ReplicatedOverrideAppendResult(existing, accepted=False))
+                continue
+
+            validate_replicated_override_operation(operation, known.values())
+            finalized = finalize_replicated_override_operation(operation)
+            known[finalized.operation_id] = finalized
+            results.append(ReplicatedOverrideAppendResult(finalized, accepted=True))
+
+        self._operations = known
+        return results
+
+    def history_for_entity(
+        self, layer_id: str, feed_id: str, entity_id: str
+    ) -> list[ReplicatedOverrideOperation]:
+        return [
+            operation
+            for operation in self._operations.values()
+            if operation.layer_id == layer_id
+            and operation.feed_id == feed_id
+            and operation.entity_id == entity_id
+        ]
+
+
+def finalize_replicated_override_operation(
+    operation: ReplicatedOverrideOperation,
+) -> ReplicatedOverrideOperation:
+    return replace(operation, payload_hash=operation_payload_hash(operation))
+
+
+def operation_payload_hash(operation: ReplicatedOverrideOperation) -> str:
+    payload = {
+        "format_version": operation.format_version,
+        "operation_id": operation.operation_id,
+        "change_set_id": operation.change_set_id,
+        "layer_id": operation.layer_id,
+        "actor_id": operation.actor_id,
+        "feed_id": operation.feed_id,
+        "entity_id": operation.entity_id,
+        "field_path": operation.field_path,
+        "operation_type": operation.operation_type,
+        "value": None
+        if operation.value is None
+        else {
+            "value_type": operation.value.value_type,
+            "value_json": operation.value.value_json,
+            "unit": operation.value.unit,
+        },
+        "supersedes_operation_ids": operation.supersedes_operation_ids,
+        "removes_operation_ids": operation.removes_operation_ids,
+        "valid_from": _timestamp(operation.valid_from),
+        "valid_to": _timestamp(operation.valid_to),
+        "recorded_at": _timestamp(operation.recorded_at),
+        "observed_canonical_value_json": operation.observed_canonical_value_json,
+        "comment": operation.comment,
+        "metadata_json": operation.metadata_json or {},
+    }
+    return sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def validate_replicated_override_operation(
+    operation: ReplicatedOverrideOperation,
+    known_operations: Iterable[ReplicatedOverrideOperation] = (),
+) -> None:
+    if operation.format_version != 1:
+        raise ValueError("unsupported replicated override format version")
+    _require_uuid(operation.operation_id, "operation_id")
+    _require_uuid(operation.change_set_id, "change_set_id")
+    _require_timestamp(operation.valid_from, "valid_from")
+    _require_timestamp(operation.recorded_at, "recorded_at")
+    if operation.valid_to is not None:
+        _require_timestamp(operation.valid_to, "valid_to")
+    if operation.operation_type == "set":
+        if operation.value is None:
+            raise ValueError("set replicated override operations require a value")
+        if operation.removes_operation_ids:
+            raise ValueError("set replicated override operations cannot remove values")
+        if (
+            operation.valid_to is not None
+            and operation.valid_to <= operation.valid_from
+        ):
+            raise ValueError("set valid_to must be greater than valid_from")
+    elif operation.operation_type == "remove":
+        if operation.value is not None:
+            raise ValueError(
+                "remove replicated override operations cannot carry a value"
+            )
+        if operation.supersedes_operation_ids:
+            raise ValueError(
+                "remove replicated override operations cannot supersede values"
+            )
+        if operation.valid_to is not None:
+            raise ValueError(
+                "remove replicated override operations cannot have valid_to"
+            )
+    else:
+        raise ValueError("unsupported replicated override operation type")
+
+    references = operation.supersedes_operation_ids + operation.removes_operation_ids
+    if len(references) != len(set(references)):
+        raise ValueError("operation references must be unique")
+    if operation.operation_id in references:
+        raise ValueError("operation cannot reference itself")
+
+    known = {known.operation_id: known for known in known_operations}
+    for reference in references:
+        _require_uuid(reference, "operation reference")
+        target = known.get(reference)
+        if target is None:
+            raise ValueError("operation reference must already exist")
+        if _scope(target) != _scope(operation):
+            raise ValueError("operation reference must target the same override field")
+
+    if (
+        operation.payload_hash is not None
+        and operation.payload_hash != operation_payload_hash(operation)
+    ):
+        raise ValueError("operation payload hash does not match content")
+
+
+def project_replicated_override_operations(
+    operations: Iterable[ReplicatedOverrideOperation], valid_at: datetime
+) -> dict[str, OverrideFrontier]:
+    _require_timestamp(valid_at, "valid_at")
+    grouped: dict[str, list[ReplicatedOverrideOperation]] = {}
+    for operation in operations:
+        if operation.valid_from <= valid_at:
+            grouped.setdefault(operation.field_path, []).append(operation)
+
+    frontiers: dict[str, OverrideFrontier] = {}
+    for field_path, field_operations in grouped.items():
+        removed = {
+            reference
+            for operation in field_operations
+            for reference in operation.supersedes_operation_ids
+            + operation.removes_operation_ids
+        }
+        active = tuple(
+            sorted(
+                (
+                    operation
+                    for operation in field_operations
+                    if operation.operation_type == "set"
+                    and operation.operation_id not in removed
+                    and (operation.valid_to is None or valid_at < operation.valid_to)
+                ),
+                key=lambda operation: operation.operation_id,
+            )
+        )
+        values = {_value_key(operation.value) for operation in active}
+        state: OverrideFrontierState = (
+            "none" if not active else "clean" if len(values) == 1 else "conflict"
+        )
+        frontiers[field_path] = OverrideFrontier(field_path, state, active)
+    return frontiers
+
+
+def _scope(operation: ReplicatedOverrideOperation) -> tuple[str, str, str, str]:
+    return (
+        operation.layer_id,
+        operation.feed_id,
+        operation.entity_id,
+        operation.field_path,
+    )
+
+
+def _timestamp(value: datetime | None) -> str | None:
+    return None if value is None else value.astimezone(timezone.utc).isoformat()
+
+
+def _value_key(value: OverrideTypedValue | None) -> str:
+    assert value is not None
+    return json.dumps(
+        {
+            "value_type": value.value_type,
+            "value_json": value.value_json,
+            "unit": value.unit,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _require_uuid(value: str, name: str) -> None:
+    try:
+        UUID(value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a UUID") from exc
+
+
+def _require_timestamp(value: datetime, name: str) -> None:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{name} must be timezone-aware")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dependencies = [
 sqlalchemy = ["polars[sqlalchemy]"]
 nats = ["nats-py"]
 xtdb = ["adbc-driver-flightsql>=1.11.0", "psycopg[binary]>=3.3.4"]
+crdt = [
+    "pycrdt>=0.14.1",
+]
 
 [project.urls]
 Repository = "https://github.com/jr200-labs/polars-hist-db"
@@ -43,6 +46,7 @@ dev = [
     "types-pytz>=2026.2.0.20260518",
     "types-pyyaml>=6.0.12.20260518",
     "pyarrow-stubs>=20.0.0.20260625",
+    "pycrdt>=0.14.1",
 ]
 
 [tool.setuptools.package-data]

--- a/tests/backends/test_override_table_contract.py
+++ b/tests/backends/test_override_table_contract.py
@@ -17,6 +17,13 @@ def test_override_table_config_builds_sqlalchemy_columns_for_mariadb_path():
         "valid_from",
         "valid_to",
         "metadata_json",
+        "format_version",
+        "layer_id",
+        "actor_id",
+        "supersedes_operation_ids_json",
+        "removes_operation_ids_json",
+        "recorded_at",
+        "payload_hash",
     }
     operation_id = next(column for column in columns if column.name == "operation_id")
     assert operation_id.primary_key is True

--- a/tests/overrides/test_crdt_document_store.py
+++ b/tests/overrides/test_crdt_document_store.py
@@ -1,11 +1,12 @@
 from pycrdt import Doc, Map
 import pytest
+from typing import Any
 
 from polars_hist_db.overrides import InMemoryCrdtDocumentStore
 
 
 def _document_update() -> bytes:
-    document = Doc()
+    document: Any = Doc()
     document["drafts"] = Map({"title": "Initial"})
     return document.get_update()
 

--- a/tests/overrides/test_crdt_document_store.py
+++ b/tests/overrides/test_crdt_document_store.py
@@ -1,0 +1,63 @@
+from pycrdt import Doc, Map
+import pytest
+
+from polars_hist_db.overrides import InMemoryCrdtDocumentStore
+
+
+def _document_update() -> bytes:
+    document = Doc()
+    document["drafts"] = Map({"title": "Initial"})
+    return document.get_update()
+
+
+def test_document_store_merges_offline_updates_and_rebuilds_from_snapshot():
+    base_update = _document_update()
+    left = Doc()
+    right = Doc()
+    left.apply_update(base_update)
+    right.apply_update(base_update)
+    base_state = left.get_state()
+
+    left.get("drafts", type=Map)["left"] = "offline"
+    right.get("drafts", type=Map)["right"] = "offline"
+
+    store = InMemoryCrdtDocumentStore()
+    store.append_update("document-1", base_update)
+    store.append_update("document-1", left.get_update(base_state), expected_revision=1)
+    store.append_update("document-1", right.get_update(base_state), expected_revision=2)
+    snapshot = store.write_snapshot("document-1")
+
+    rebuilt = Doc()
+    rebuilt.apply_update(snapshot.update)
+    caught_up = Doc()
+    caught_up.apply_update(base_update)
+    caught_up.apply_update(store.diff("document-1", base_state))
+
+    assert rebuilt.get("drafts", type=Map).to_py() == {
+        "title": "Initial",
+        "left": "offline",
+        "right": "offline",
+    }
+    assert snapshot.revision == 3
+    assert store.snapshot("document-1") == snapshot
+    assert (
+        caught_up.get("drafts", type=Map).to_py()
+        == rebuilt.get("drafts", type=Map).to_py()
+    )
+
+
+def test_document_store_deduplicates_exact_updates_and_checks_revisions():
+    update = _document_update()
+    store = InMemoryCrdtDocumentStore()
+
+    first = store.append_update("document-1", update, expected_revision=0)
+    duplicate = store.append_update("document-1", update, expected_revision=0)
+
+    assert first.accepted is True
+    assert duplicate.accepted is False
+    assert duplicate.document.revision == 1
+
+    with pytest.raises(ValueError, match="expected revision"):
+        store.append_update("document-2", update, expected_revision=1)
+    with pytest.raises(KeyError):
+        store.load_document("document-2")

--- a/tests/overrides/test_override_table_config.py
+++ b/tests/overrides/test_override_table_config.py
@@ -48,6 +48,13 @@ def test_build_override_table_config_contains_required_columns():
         "reason",
         "comment",
         "metadata_json",
+        "format_version",
+        "layer_id",
+        "actor_id",
+        "supersedes_operation_ids_json",
+        "removes_operation_ids_json",
+        "recorded_at",
+        "payload_hash",
     }
 
 

--- a/tests/overrides/test_replicated_override_ledger.py
+++ b/tests/overrides/test_replicated_override_ledger.py
@@ -1,0 +1,123 @@
+from dataclasses import replace
+from datetime import datetime, timezone
+from typing import Literal
+from uuid import uuid4
+
+import pytest
+
+from polars_hist_db.overrides import (
+    InMemoryReplicatedOverrideLedger,
+    OverrideTypedValue,
+    ReplicatedOverrideOperation,
+    project_replicated_override_operations,
+)
+
+
+def _utc(hour: int) -> datetime:
+    return datetime(2026, 7, 12, hour, tzinfo=timezone.utc)
+
+
+def _operation(
+    *,
+    operation_type: Literal["set", "remove"] = "set",
+    value: str | None = "scheduled",
+    supersedes: tuple[str, ...] = (),
+    removes: tuple[str, ...] = (),
+    valid_from: datetime | None = None,
+    valid_to: datetime | None = None,
+) -> ReplicatedOverrideOperation:
+    return ReplicatedOverrideOperation(
+        format_version=1,
+        operation_id=str(uuid4()),
+        change_set_id=str(uuid4()),
+        layer_id="team",
+        actor_id="user-1",
+        feed_id="records",
+        entity_id="record-1",
+        field_path="status",
+        operation_type=operation_type,
+        value=None if value is None else OverrideTypedValue("enum", {"value": value}),
+        supersedes_operation_ids=supersedes,
+        removes_operation_ids=removes,
+        valid_from=valid_from or _utc(10),
+        valid_to=valid_to,
+        recorded_at=_utc(11),
+    )
+
+
+def test_concurrent_values_remain_a_conflict_in_any_delivery_order():
+    left = _operation(value="loading")
+    right = _operation(value="in_transit")
+
+    forward = project_replicated_override_operations([left, right], _utc(12))
+    reverse = project_replicated_override_operations([right, left], _utc(12))
+
+    assert forward["status"].state == "conflict"
+    assert forward == reverse
+    assert {operation.operation_id for operation in forward["status"].operations} == {
+        left.operation_id,
+        right.operation_id,
+    }
+
+
+def test_equal_values_are_clean_and_replacement_or_remove_only_affect_references():
+    original = _operation(value="loading")
+    concurrent = _operation(value="loading")
+    replacement = _operation(
+        value="in_transit", supersedes=(original.operation_id,), valid_from=_utc(13)
+    )
+    removal = _operation(
+        operation_type="remove",
+        value=None,
+        removes=(original.operation_id,),
+        valid_from=_utc(14),
+    )
+
+    assert (
+        project_replicated_override_operations([original, concurrent], _utc(12))[
+            "status"
+        ].state
+        == "clean"
+    )
+    after_replace = project_replicated_override_operations(
+        [original, concurrent, replacement], _utc(13)
+    )["status"]
+    after_remove = project_replicated_override_operations(
+        [original, concurrent, replacement, removal], _utc(14)
+    )["status"]
+
+    assert {operation.operation_id for operation in after_replace.operations} == {
+        concurrent.operation_id,
+        replacement.operation_id,
+    }
+    assert after_replace.state == "conflict"
+    assert {operation.operation_id for operation in after_remove.operations} == {
+        concurrent.operation_id,
+        replacement.operation_id,
+    }
+
+
+def test_ledger_validates_references_and_exact_replay_without_partial_append():
+    ledger = InMemoryReplicatedOverrideLedger()
+    original = _operation(value="loading")
+    replacement = _operation(value="in_transit", supersedes=(original.operation_id,))
+
+    first, second = ledger.append_batch([original, replacement])
+
+    assert first.accepted is True
+    assert second.accepted is True
+    assert ledger.append(original).accepted is False
+
+    with pytest.raises(ValueError, match="different content"):
+        ledger.append(replace(original, comment="changed"))
+    with pytest.raises(ValueError, match="must already exist"):
+        ledger.append(_operation(supersedes=(str(uuid4()),)))
+    invalid = _operation(supersedes=(str(uuid4()),))
+    uncommitted = _operation(value="delayed")
+    with pytest.raises(ValueError, match="must already exist"):
+        ledger.append_batch([uncommitted, invalid])
+
+    assert [
+        operation.operation_id
+        for operation in ledger.history_for_entity("team", "records", "record-1")
+    ] == [original.operation_id, replacement.operation_id]

--- a/uv.lock
+++ b/uv.lock
@@ -1483,7 +1483,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1545,6 +1545,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+crdt = [
+    { name = "pycrdt" },
+]
 nats = [
     { name = "nats-py" },
 ]
@@ -1562,6 +1565,7 @@ dev = [
     { name = "ipykernel" },
     { name = "mypy" },
     { name = "pyarrow-stubs" },
+    { name = "pycrdt" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "quarto-cli" },
@@ -1581,6 +1585,7 @@ requires-dist = [
     { name = "polars", extras = ["sqlalchemy"], marker = "extra == 'sqlalchemy'" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'xtdb'", specifier = ">=3.3.4" },
     { name = "pyarrow", specifier = ">=25.0.0" },
+    { name = "pycrdt", marker = "extra == 'crdt'", specifier = ">=0.14.1" },
     { name = "pymysql", specifier = ">=1.2.0" },
     { name = "pytz", specifier = ">=2026.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
@@ -1588,7 +1593,7 @@ requires-dist = [
     { name = "sql-metadata", specifier = ">=3.0.1" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.51" },
 ]
-provides-extras = ["sqlalchemy", "nats", "xtdb"]
+provides-extras = ["sqlalchemy", "nats", "xtdb", "crdt"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1596,6 +1601,7 @@ dev = [
     { name = "ipykernel", specifier = ">=7.3.0" },
     { name = "mypy", specifier = ">=2.2.0" },
     { name = "pyarrow-stubs", specifier = ">=20.0.0.20260625" },
+    { name = "pycrdt", specifier = ">=0.14.1" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "quarto-cli", git = "https://github.com/quarto-dev/quarto-cli?rev=8577ed1c69b3b9a551f1669c8256abc4a1731266" },
@@ -1801,6 +1807,56 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pycrdt"
+version = "0.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/4b/827ec39efadd52cf9dca9a663e7a5e215a4415a3ddd1b187536e21238f99/pycrdt-0.14.1.tar.gz", hash = "sha256:56e7c2d36407716f4977b5f3b972892c51758d31dafff9d043702b5c7fd1aa87", size = 95362, upload-time = "2026-06-17T14:18:04.784Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/d1/a61cb33ccaca7d5ede9f59bf16c4d4e254e57dbc1d306cf7c92cdeb56bf0/pycrdt-0.14.1-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:35a3f4bbad8b5848c653997a9cb2bc8df4c6cad8aaea55e9261d23d71a574e55", size = 1920341, upload-time = "2026-06-17T14:16:41.184Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/01/abbf4134d7353690a6ebece3beace80ec581c67deb2e264957ec9da85241/pycrdt-0.14.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:53ea32083193b8740c5409795087254dd01c4df65aca6edf1f83ceda3fc2980d", size = 1039888, upload-time = "2026-06-17T14:16:42.92Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/67/1adbb5acbc784200501851ec56d7d64b6110fa1e9b9e3dfd67c29ae1b737/pycrdt-0.14.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f301fee6960320a64075494e1ac25ba6da5e3984e126c13f9e3f890043cac0f", size = 1061004, upload-time = "2026-06-17T14:16:44.554Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/83/0e9b77b867f03cd5040b0508f05071c8903af43801e1232cfd13ff0e16c6/pycrdt-0.14.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4b9c99f44b3d89e76cd2edda5fd0ad74e03dd02abbe1524feff939909ff29e91", size = 1246302, upload-time = "2026-06-17T14:16:46.586Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3a/956e915b3d9546869a7136564d1b9a122b354b45c1264efbc0ddb4ca31eb/pycrdt-0.14.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:12ea055f21596320f00f181ec8d082049a4157703b07594ee4f6b5195e15d6c8", size = 1096588, upload-time = "2026-06-17T14:16:48.404Z" },
+    { url = "https://files.pythonhosted.org/packages/77/53/b30626fdb8dc635728b2bc3860eb0ae6966fd96595215abe09efd7f978cc/pycrdt-0.14.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:62219393c1c9aa60a00ac7a0da574746edd62f571a83aca05b1632ceabefa4db", size = 1069006, upload-time = "2026-06-17T14:16:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/7b/18efd6c541112c962515d1f181761d10953aaae3ab07083d6924af8a2f30/pycrdt-0.14.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4a6abaede60fb9d2acf0dd8ced85d0d328da7a5a03823a25eb3203acc56d3d6b", size = 1163604, upload-time = "2026-06-17T14:16:51.545Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/e8/e0299e9e8173dcf0f001ffc2ae6f8cf25b39419ef1db65b7e26623fc8b5a/pycrdt-0.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6a669c1a3ffb621c5034ce08b562196fd1d2d02b138e2cfb39345dfc16bc9d59", size = 1214943, upload-time = "2026-06-17T14:16:53.239Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/b3/7aad8b7a9797ad98ea1b2d70021a44b01af4cbea2d0cc37beb17499dd994/pycrdt-0.14.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:ca57f015894aa3b560d73b6f48d5455a61e69bcde30601295409924f47724195", size = 1337232, upload-time = "2026-06-17T14:16:54.874Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/22/ff4a93fc6b92f4173e11ce7ebce57f45b979d35da3a3e3a6899bdb9da362/pycrdt-0.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:f253e6a9ac9e9487c7d69e078e8904918f1f356e6e9565564e36cefd44faa055", size = 1332373, upload-time = "2026-06-17T14:16:56.439Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/40/eae0b6d990577fa5b59145783d117d8984b1a9540d4ba037905f4824b9f2/pycrdt-0.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc5a07a3c3b8424458793805abf9592d078dec454f9bc345e71e0d0fb788d21f", size = 1282048, upload-time = "2026-06-17T14:16:58.125Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a9/e97e637ab9703cb4d951f3ff1e62641db0ca2517f842837598eaaf3667ff/pycrdt-0.14.1-cp312-cp312-win32.whl", hash = "sha256:a638ed29386eec9b202114cbab3f35ad89d8a44c7883d9ee84cf90761dd8ae52", size = 798254, upload-time = "2026-06-17T14:17:00.201Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/b2/5cdc49f8a021732a1a7070b8cbec2073ca5045fbf6c0b5718c3e283d254e/pycrdt-0.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:b7e6876eda749d79f15c2dcc10316f08f1f47756bb25631341a3314e7356ed41", size = 863716, upload-time = "2026-06-17T14:17:02.033Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/17/d970446b932d614445dca61739f592fdd328ed435dd54e67b5c804a31ef7/pycrdt-0.14.1-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5371deb5d40d3c9ddd5757adb5556ea8566b2fb46c1553ad313e9a5dfc84154e", size = 1919734, upload-time = "2026-06-17T14:17:03.806Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/d4/9ad8ee06131ee9a8b3366698bd68b39ebdc59764f68c436b61e4f18f7278/pycrdt-0.14.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cbadc42dd0a6c3869859cf8900b59b21e8160e415a95e85d82e40cc11c887660", size = 1039641, upload-time = "2026-06-17T14:17:05.601Z" },
+    { url = "https://files.pythonhosted.org/packages/66/5c/2828a1414478e1df6c51289962bf483a55377a888439d92fc8c6e6699f8d/pycrdt-0.14.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7770624c7003198312646cea57bb0c4d7a231ef57b1975f4487dd7d790fa1196", size = 1061111, upload-time = "2026-06-17T14:17:07.369Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/02/171aa04758453db0e976b3aaf87de7dbd8f3da6145d3d48d40dbf1073eac/pycrdt-0.14.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c348b780da2792d6cdc2e4dc237b6e8d7f87fe9b1fc2f24e467bf294f0f7581", size = 1246233, upload-time = "2026-06-17T14:17:08.988Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d8/1f186f211ba1e4fffc8124d21ae9547f876c2c9c1e2d834919d5c5569f75/pycrdt-0.14.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d28a206a061cb44b284a53587561028547c3a12c4a12408bd0e499f887753a5", size = 1096827, upload-time = "2026-06-17T14:17:10.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e5/5a027de04406e92282c29c3ec49e5a60c457255aac524cf8ed88064c124b/pycrdt-0.14.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:35149ce7388788681c1d36115545b5c5ceda8d46982eb36f7ed0fab4379f8907", size = 1068703, upload-time = "2026-06-17T14:17:12.299Z" },
+    { url = "https://files.pythonhosted.org/packages/01/08/2bc8005634e5f0c067cb9d942f0a2c628e88152f218a159a1e4aea51785f/pycrdt-0.14.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b708985f4aaddeb7d7bf7888fe65f49c91fa0b36ed09a78a1041cb888cd64b50", size = 1162543, upload-time = "2026-06-17T14:17:13.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/53/b10ef7aaadfd24d74ca7d9894af9b4c925eaed5a4ee3a098728d0ac81bc1/pycrdt-0.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eeeee3284e9c9dc2dfcc45db7c55445e70f17bb12015583bd388f6c8f901237c", size = 1214684, upload-time = "2026-06-17T14:17:15.701Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9c/19af353a9b2d407cf942f8bec752dc94a7e82d40fb039be34db9a91eba6c/pycrdt-0.14.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:4e715421a47702dbf81d90a32213f6868567e751926629f60912b03af397bd9a", size = 1337139, upload-time = "2026-06-17T14:17:17.647Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/a4/e1bf0c56a9b6bae6a89cda3ac7ad2ada525c827693f531435a14922b859f/pycrdt-0.14.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:34288b0a97ccc38e1e87f55448b1c08734deb9ad3360042d4653084bee6a4f80", size = 1331647, upload-time = "2026-06-17T14:17:19.301Z" },
+    { url = "https://files.pythonhosted.org/packages/15/04/30f05d4f277f76bfefd7d856592922abaf1d17983c0b084aa347a96ad580/pycrdt-0.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:07fecd0e9275e336e46f81203778ab811ee97c7272dfd7937b66844af6fcc13b", size = 1281303, upload-time = "2026-06-17T14:17:20.896Z" },
+    { url = "https://files.pythonhosted.org/packages/da/5b/5b05f492e36f31b3e4be062675750b049ad86dbce64c5197dab660f70988/pycrdt-0.14.1-cp313-cp313-win32.whl", hash = "sha256:3b8324b7fb6fb31b2b55eb8dfeedf2e0a40d2e7143c6011d4b63ee102b44f3de", size = 798158, upload-time = "2026-06-17T14:17:22.736Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/06/e0f436b1b769dc8befd25e27dd133fb1690eba3e82734cd173aa95609340/pycrdt-0.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:1bfb808acae8e97e5725086e334c4b5dc79d693962080abf1ab97e70d7400ba1", size = 863084, upload-time = "2026-06-17T14:17:24.437Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/22/4dec10d664f3f4d09e1142504ad354f993919c9a9ad9a7bb9d3b2eb277b2/pycrdt-0.14.1-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:008b67d78cc8a99a07c2bbe876a866c5d4ef7e3a90cf33463af7521fa5837a6c", size = 1931551, upload-time = "2026-06-17T14:17:26.19Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/ec/42e16b63a70b1907301945ea3a9e85cbfad0a4a1cfd669367e02f28a8e0f/pycrdt-0.14.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389c8dda4a41a1d6d664ab5c4c66d859e75d24add7e2f5df8ce6954effbe23c6", size = 1041602, upload-time = "2026-06-17T14:17:27.974Z" },
+    { url = "https://files.pythonhosted.org/packages/89/76/ba53f5f3ebd5a104b431a4d3433dba9770bded5ece259e582530e289f89b/pycrdt-0.14.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1b89eb0020711b2faaec41bd701af64b7c201ef039e781fe5fc945d148301fde", size = 1061937, upload-time = "2026-06-17T14:17:29.755Z" },
+    { url = "https://files.pythonhosted.org/packages/88/86/6127c295d5c9fdfa13f61e569c2fb1cba3ce3bb1fbb7a912f14e3baac04a/pycrdt-0.14.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3ba13fcb11665d05f3e3a80942dda42ff0d91a33f685909c2e90d0e57cacdad5", size = 1249379, upload-time = "2026-06-17T14:17:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/46/63/fa06b2b8488788bf073d81fb8020eed5c8084465037c18478aaa91c06a8a/pycrdt-0.14.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9a64e7a2e4ea5bc27f1675b64a3669c588adb6a8f2ed33a798d42d7d1f607845", size = 1099321, upload-time = "2026-06-17T14:17:33.547Z" },
+    { url = "https://files.pythonhosted.org/packages/83/24/a19c5825f25135485527f2c83c4b4151ba6688a3fac7c7a0c8d20bd2b25f/pycrdt-0.14.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a153994b1f32ec6012d00ec645f80bf7e77ebea907759ee5fbe4e08a6f242bd7", size = 1069402, upload-time = "2026-06-17T14:17:35.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/0a/f91f8689d5abb8e0d3fa73ee71e52326185913f27ac0189223d0b7bad77c/pycrdt-0.14.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fa6f02d8272737e734033a7ec62382d3929b2ab70681aac54b9d21373d78bf82", size = 1165406, upload-time = "2026-06-17T14:17:37.264Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/59/829f7aab8706e26fd5876ff37371359ff2930211b534570cd3d11305d6f6/pycrdt-0.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e83047e92cf7248c2d40d7be7a42fd7065598c3cc31f3d422def2886499787d6", size = 1216928, upload-time = "2026-06-17T14:17:39.232Z" },
+    { url = "https://files.pythonhosted.org/packages/19/8f/a69823e4b02f1da3329d82316b2c733b1875c96e3aff5a2c1ebd8cefd1f8/pycrdt-0.14.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:9d33a6dd2dab10a6380ce9bd7fee79f7e3b868214e95e977842adf9e54906fdf", size = 1337450, upload-time = "2026-06-17T14:17:40.991Z" },
+    { url = "https://files.pythonhosted.org/packages/30/5d/040bbcaf59a0e590e3f89946afa611960d08f87c60367260a3ecf01c02de/pycrdt-0.14.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:e347942c2ac71c1ac6ef04212fcd3eb8456f88053b71bf51a288084531c27135", size = 1334972, upload-time = "2026-06-17T14:17:42.6Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e4/be739b1301575b04e85eab7d76cb557a9abd167451d7442592e3f3d65b95/pycrdt-0.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cce1a249ab5b3d9757ceb42f22da51043c50f1d5c18b0673522b41a7311ce232", size = 1280543, upload-time = "2026-06-17T14:17:45.715Z" },
+    { url = "https://files.pythonhosted.org/packages/18/06/1760c307048b431a195b41027faf48906dc8f22b8ee647817d6a15258c9c/pycrdt-0.14.1-cp314-cp314-win32.whl", hash = "sha256:fb93e7e277fc9b2cc26ce5b51d3e3b6436a762d0a0985ceaa50459ff6a33230f", size = 800359, upload-time = "2026-06-17T14:17:47.843Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5c/ef3db9970413a661680972274f6b93f961130748e581a41c0c9960e29275/pycrdt-0.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:e3334b8f9fc8caeb41ac8a754adeb9dc640bb8fa1420c38cdb8dc2001a4777c8", size = 864167, upload-time = "2026-06-17T14:17:49.65Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add optional `pycrdt` support, with the dependency also available to the CI dev group
- add an in-memory Yjs-compatible document store with revisions, state-vector diffs, exact-update idempotency, and snapshots
- add an immutable replicated override ledger with payload hashes, atomic batches, causal references, and valid-time clean/conflict projection
- extend the existing override table contract with nullable replicated-operation fields, preserving existing personal rows

## Deliberate boundary

This provides the reusable core. Persistent document adapters and authenticated WebSocket synchronization belong in subsequent implementation work; the library does not own transport or product authorization.

## Verification

- `uv run pytest` (169 passed, 1 skipped)
- `uv run ruff check polars_hist_db/overrides tests/overrides tests/backends/test_override_table_contract.py`
- `uv run mypy polars_hist_db/overrides`