### PR TITLE
feat: add persistent CRDT storage contract (JWL-13)

### DIFF
--- a/docs/replicated-overrides.qmd
+++ b/docs/replicated-overrides.qmd
@@ -156,16 +156,17 @@ The pure override projector is shared by every backend.
 Every backend exposes equivalent logical tables:
 
 ```text
-crdt_documents(document_id, revision, snapshot_bytes, state_vector,
+crdt_documents(document_id, revision, snapshot_update_base64, state_vector_base64,
                snapshot_through_revision, updated_at)
-crdt_updates(document_id, revision, update_hash, update_bytes,
+crdt_updates(document_id, revision, update_hash, update_base64,
              accepted_at, metadata_json)
 ```
 
 `(document_id, revision)` and `(document_id, update_hash)` are unique. Update
-bytes and snapshots are opaque binary values. MariaDB uses binary large-object
-columns; XTDB stores the same bytes through its supported binary value type.
-In-memory storage follows the same revision and deduplication rules.
+bytes, snapshots, and state vectors are opaque binary values at the API boundary
+and base64-encoded `MEDIUMTEXT` in relational storage. This gives MariaDB and
+XTDB the same logical schema without backend-specific blob types. In-memory
+storage follows the same revision and deduplication rules.
 
 Snapshots contain a full merged Yjs update and state vector through a known
 revision. Updates covered by a verified snapshot may be archived, but the

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -388,7 +388,7 @@ def _xtdb_id_policy(table_config: TableConfig) -> str:
 
 def _xtdb_cast_type(data_type: str) -> str:
     normalized = data_type.upper()
-    if normalized.startswith(("VARCHAR", "CHAR", "TEXT")):
+    if normalized.startswith(("VARCHAR", "CHAR")) or "TEXT" in normalized:
         return "TEXT"
     if normalized in {"DOUBLE", "DOUBLE PRECISION"}:
         return "DOUBLE PRECISION"

--- a/polars_hist_db/overrides/__init__.py
+++ b/polars_hist_db/overrides/__init__.py
@@ -1,4 +1,9 @@
-from .config import build_override_table_config, build_override_valid_time_config
+from .config import (
+    build_crdt_document_table_config,
+    build_crdt_update_table_config,
+    build_override_table_config,
+    build_override_valid_time_config,
+)
 from .crdt import CrdtAppendResult, CrdtDocument, InMemoryCrdtDocumentStore
 from .ledger import InMemoryOverrideLedgerStore, OverrideLedger
 from .replicated import (
@@ -12,6 +17,7 @@ from .replicated import (
     validate_replicated_override_operation,
 )
 from .types import (
+    CrdtDocumentStoreConfig,
     OverrideLedgerConfig,
     OverrideOperation,
     OverrideOperationType,
@@ -29,6 +35,9 @@ __all__ = [
     "OverrideTypedValue",
     "CrdtAppendResult",
     "CrdtDocument",
+    "CrdtDocumentStoreConfig",
+    "build_crdt_document_table_config",
+    "build_crdt_update_table_config",
     "OverrideFrontier",
     "ReplicatedOverrideAppendResult",
     "ReplicatedOverrideOperation",

--- a/polars_hist_db/overrides/config.py
+++ b/polars_hist_db/overrides/config.py
@@ -2,7 +2,53 @@ from __future__ import annotations
 
 from polars_hist_db.config import TableColumnConfig, TableConfig, ValidTimeConfig
 
-from .types import OverrideLedgerConfig
+from .types import CrdtDocumentStoreConfig, OverrideLedgerConfig
+
+
+def build_crdt_document_table_config(config: CrdtDocumentStoreConfig) -> TableConfig:
+    table = config.documents_table
+    return TableConfig(
+        name=table,
+        schema=config.schema,
+        primary_keys=("document_id",),
+        columns=[
+            TableColumnConfig(table, "document_id", "VARCHAR(128)", nullable=False),
+            TableColumnConfig(table, "revision", "BIGINT", nullable=False),
+            TableColumnConfig(table, "state_vector_base64", "MEDIUMTEXT"),
+            TableColumnConfig(table, "snapshot_update_base64", "MEDIUMTEXT"),
+            TableColumnConfig(table, "snapshot_through_revision", "BIGINT"),
+            TableColumnConfig(table, "updated_at", "DATETIME(6)", nullable=False),
+        ],
+    )
+
+
+def build_crdt_update_table_config(config: CrdtDocumentStoreConfig) -> TableConfig:
+    table = config.updates_table
+    return TableConfig(
+        name=table,
+        schema=config.schema,
+        primary_keys=("document_id", "revision"),
+        columns=[
+            TableColumnConfig(
+                table,
+                "document_id",
+                "VARCHAR(128)",
+                nullable=False,
+                unique_constraint=["document_update_hash"],
+            ),
+            TableColumnConfig(table, "revision", "BIGINT", nullable=False),
+            TableColumnConfig(
+                table,
+                "update_hash",
+                "VARCHAR(64)",
+                nullable=False,
+                unique_constraint=["document_update_hash"],
+            ),
+            TableColumnConfig(table, "update_base64", "MEDIUMTEXT", nullable=False),
+            TableColumnConfig(table, "accepted_at", "DATETIME(6)", nullable=False),
+            TableColumnConfig(table, "metadata_json", "JSON"),
+        ],
+    )
 
 
 def build_override_table_config(config: OverrideLedgerConfig) -> TableConfig:

--- a/polars_hist_db/overrides/types.py
+++ b/polars_hist_db/overrides/types.py
@@ -45,3 +45,10 @@ class OverrideLedgerConfig:
     table: str = "data_override_operations"
     valid_from_column: str = "valid_from"
     valid_to_column: str = "valid_to"
+
+
+@dataclass(frozen=True)
+class CrdtDocumentStoreConfig:
+    schema: str = "overrides"
+    documents_table: str = "crdt_documents"
+    updates_table: str = "crdt_updates"

--- a/polars_hist_db/types.py
+++ b/polars_hist_db/types.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     Table,
 )
 import sqlalchemy
+from sqlalchemy.dialects import mysql
 from sqlalchemy.types import TypeEngine
 from sqlalchemy.sql.sqltypes import NullType
 
@@ -124,7 +125,7 @@ class PolarsType:
         type_name, params, param_dict = _TypeConversionUtils._parse_parameterised_type(
             t
         )
-        if type_name in ["VARCHAR", "TEXT"]:
+        if type_name == "VARCHAR" or type_name.endswith("TEXT"):
             return pl.Utf8()
 
         if type_name in ["NUMERIC", "DECIMAL", "DEC", "FIXED"]:
@@ -273,9 +274,15 @@ class SQLAlchemyType:
         type_name, params, param_dict = _TypeConversionUtils._parse_parameterised_type(
             t
         )
-        if type_name in ["VARCHAR", "TEXT"]:
+        if type_name == "VARCHAR":
             length = int(param_dict.get("length") or param_dict.get("a") or params[0])
             return sqlalchemy.types.VARCHAR(length=length)
+        if type_name == "TEXT":
+            return sqlalchemy.types.TEXT()
+        if type_name == "MEDIUMTEXT":
+            return mysql.MEDIUMTEXT()
+        if type_name == "LONGTEXT":
+            return mysql.LONGTEXT()
 
         if type_name in ["NUMERIC", "DECIMAL", "DEC", "FIXED"]:
             precision = int(

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -12,6 +12,7 @@ from polars_hist_db.backends.xtdb import (
     XtdbAdbcDataframeOps,
     XtdbDataframeOps,
     XtdbTableConfigOps,
+    _xtdb_cast_type,
     _xtdb_declared_columns,
 )
 from polars_hist_db.config import (
@@ -22,6 +23,10 @@ from polars_hist_db.config import (
 )
 
 _NON_TEMPORAL_VALID_FROM = _XTDB_NON_TEMPORAL_VALID_FROM
+
+
+def test_xtdb_casts_mediumtext_as_text():
+    assert _xtdb_cast_type("MEDIUMTEXT") == "TEXT"
 
 
 def test_xtdb_create_engine_includes_configured_credentials(monkeypatch):

--- a/tests/overrides/test_crdt_table_config.py
+++ b/tests/overrides/test_crdt_table_config.py
@@ -1,0 +1,50 @@
+from sqlalchemy import MetaData, Table
+from sqlalchemy.schema import CreateTable
+from sqlalchemy.dialects import mysql
+
+from polars_hist_db.overrides import (
+    CrdtDocumentStoreConfig,
+    build_crdt_document_table_config,
+    build_crdt_update_table_config,
+)
+
+
+def test_crdt_document_tables_use_portable_base64_payload_columns():
+    config = CrdtDocumentStoreConfig()
+    documents = build_crdt_document_table_config(config)
+    updates = build_crdt_update_table_config(config)
+
+    assert documents.name == "crdt_documents"
+    assert documents.primary_keys == ("document_id",)
+    assert {column.name for column in documents.columns} == {
+        "document_id",
+        "revision",
+        "state_vector_base64",
+        "snapshot_update_base64",
+        "snapshot_through_revision",
+        "updated_at",
+    }
+    assert {
+        column.name for column in documents.columns if column.data_type == "MEDIUMTEXT"
+    } == {"state_vector_base64", "snapshot_update_base64"}
+    assert updates.primary_keys == ("document_id", "revision")
+    assert (
+        next(
+            column for column in updates.columns if column.name == "update_base64"
+        ).data_type
+        == "MEDIUMTEXT"
+    )
+
+
+def test_crdt_document_tables_compile_mediumtext_for_mariadb():
+    config = CrdtDocumentStoreConfig()
+    table_config = build_crdt_document_table_config(config)
+    table = Table(
+        table_config.name,
+        MetaData(schema=table_config.schema),
+        *table_config.build_sqlalchemy_columns(is_delta_table=False),
+    )
+
+    ddl = str(CreateTable(table).compile(dialect=mysql.dialect()))
+
+    assert "MEDIUMTEXT" in ddl


### PR DESCRIPTION
## Summary
- add portable document and update table configurations for CRDT persistence
- persist binary Yjs values as base64 MEDIUMTEXT so MariaDB and XTDB share one logical schema
- map text storage deterministically in XTDB and verify MariaDB DDL
- document the persistence representation and cover it with tests

## Boundary
This defines the backend-neutral table contract only. SQL repository and sync transport implementations remain separate work.

## Verification
- uv run pytest (172 passed, 1 skipped, 14 deselected)
- uv run ruff check --config .shared/ruff.toml .
- uv run ruff format --config .shared/ruff.toml --check .
- uv run mypy .
- uv run quarto render docs/replicated-overrides.qmd --to html