### PR TITLE
feat: prepare CRDT commits in memory (JWL-13)

### DIFF
--- a/polars_hist_db/overrides/__init__.py
+++ b/polars_hist_db/overrides/__init__.py
@@ -4,7 +4,18 @@ from .config import (
     build_override_table_config,
     build_override_valid_time_config,
 )
-from .crdt import CrdtAppendResult, CrdtDocument, InMemoryCrdtDocumentStore
+from .crdt import (
+    AtomicInsert,
+    CrdtAppendResult,
+    CrdtCommitResult,
+    CrdtDocument,
+    CrdtPreconditionFailed,
+    CrdtRevisionConflict,
+    InMemoryCrdtDocumentStore,
+    PreparedCrdtCommit,
+    RowGuard,
+    prepare_crdt_update,
+)
 from .ledger import InMemoryOverrideLedgerStore, OverrideLedger
 from .replicated import (
     InMemoryReplicatedOverrideLedger,
@@ -27,6 +38,7 @@ from .types import (
 __all__ = [
     "InMemoryOverrideLedgerStore",
     "InMemoryCrdtDocumentStore",
+    "AtomicInsert",
     "InMemoryReplicatedOverrideLedger",
     "OverrideLedger",
     "OverrideLedgerConfig",
@@ -34,11 +46,15 @@ __all__ = [
     "OverrideOperationType",
     "OverrideTypedValue",
     "CrdtAppendResult",
+    "CrdtCommitResult",
     "CrdtDocument",
+    "CrdtPreconditionFailed",
+    "CrdtRevisionConflict",
     "CrdtDocumentStoreConfig",
     "build_crdt_document_table_config",
     "build_crdt_update_table_config",
     "OverrideFrontier",
+    "PreparedCrdtCommit",
     "ReplicatedOverrideAppendResult",
     "ReplicatedOverrideOperation",
     "build_override_table_config",
@@ -46,5 +62,7 @@ __all__ = [
     "finalize_replicated_override_operation",
     "operation_payload_hash",
     "project_replicated_override_operations",
+    "prepare_crdt_update",
+    "RowGuard",
     "validate_replicated_override_operation",
 ]

--- a/polars_hist_db/overrides/config.py
+++ b/polars_hist_db/overrides/config.py
@@ -14,8 +14,10 @@ def build_crdt_document_table_config(config: CrdtDocumentStoreConfig) -> TableCo
         columns=[
             TableColumnConfig(table, "document_id", "VARCHAR(128)", nullable=False),
             TableColumnConfig(table, "revision", "BIGINT", nullable=False),
-            TableColumnConfig(table, "state_vector_base64", "MEDIUMTEXT"),
+            TableColumnConfig(table, "head_state_vector_base64", "MEDIUMTEXT"),
             TableColumnConfig(table, "snapshot_update_base64", "MEDIUMTEXT"),
+            TableColumnConfig(table, "snapshot_update_hash", "VARCHAR(64)"),
+            TableColumnConfig(table, "snapshot_state_vector_base64", "MEDIUMTEXT"),
             TableColumnConfig(table, "snapshot_through_revision", "BIGINT"),
             TableColumnConfig(table, "updated_at", "DATETIME(6)", nullable=False),
         ],
@@ -34,15 +36,18 @@ def build_crdt_update_table_config(config: CrdtDocumentStoreConfig) -> TableConf
                 "document_id",
                 "VARCHAR(128)",
                 nullable=False,
-                unique_constraint=["document_update_hash"],
+                unique_constraint=["document_source_update_hash"],
             ),
             TableColumnConfig(table, "revision", "BIGINT", nullable=False),
             TableColumnConfig(
                 table,
-                "update_hash",
+                "source_update_hash",
                 "VARCHAR(64)",
                 nullable=False,
-                unique_constraint=["document_update_hash"],
+                unique_constraint=["document_source_update_hash"],
+            ),
+            TableColumnConfig(
+                table, "accepted_update_hash", "VARCHAR(64)", nullable=False
             ),
             TableColumnConfig(table, "update_base64", "MEDIUMTEXT", nullable=False),
             TableColumnConfig(table, "accepted_at", "DATETIME(6)", nullable=False),
@@ -94,6 +99,8 @@ def build_override_table_config(config: OverrideLedgerConfig) -> TableConfig:
             TableColumnConfig(table, "removes_operation_ids_json", "JSON"),
             TableColumnConfig(table, "recorded_at", "DATETIME(6)"),
             TableColumnConfig(table, "payload_hash", "VARCHAR(64)"),
+            TableColumnConfig(table, "crdt_document_id", "VARCHAR(128)"),
+            TableColumnConfig(table, "crdt_document_revision", "BIGINT"),
         ],
     )
 

--- a/polars_hist_db/overrides/crdt.py
+++ b/polars_hist_db/overrides/crdt.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from datetime import datetime
 from hashlib import sha256
-from typing import Any
+from typing import Any, Mapping, Sequence
+
+from polars_hist_db.config import TableConfig
+
+from .replicated import (
+    ReplicatedOverrideOperation,
+    finalize_replicated_override_operation,
+    operation_payload_hash,
+    validate_replicated_override_operation,
+)
+from .types import OverrideTypedValue
 
 
 @dataclass(frozen=True)
@@ -14,19 +25,142 @@ class CrdtDocument:
 
 
 @dataclass(frozen=True)
-class CrdtAppendResult:
-    document: CrdtDocument
+class PreparedCrdtCommit:
+    document_id: str
+    base_revision: int
+    source_update_hash: str
+    accepted_update: bytes
+    accepted_update_hash: str
+    state_vector: bytes
+    operations: tuple[ReplicatedOverrideOperation, ...]
+    is_noop: bool = False
+
+
+@dataclass(frozen=True)
+class CrdtCommitResult:
+    document: CrdtDocument | None
+    revision: int
+    accepted_update: bytes
     accepted: bool
+    duplicate: bool = False
+
+
+# Backwards-compatible name for callers of the original in-memory store.
+CrdtAppendResult = CrdtCommitResult
+
+
+@dataclass(frozen=True)
+class RowGuard:
+    table_config: TableConfig
+    key_values: Mapping[str, object]
+    expected_values: Mapping[str, object]
+
+
+@dataclass(frozen=True)
+class AtomicInsert:
+    table_config: TableConfig
+    row: Mapping[str, object]
+
+
+class CrdtRevisionConflict(ValueError):
+    pass
+
+
+class CrdtPreconditionFailed(ValueError):
+    pass
+
+
+def prepare_crdt_update(
+    document_id: str,
+    current_document: CrdtDocument | None,
+    source_update: bytes,
+    *,
+    actor_id: str,
+    recorded_at: datetime,
+) -> PreparedCrdtCommit:
+    document = _doc()
+    base_revision = 0
+    if current_document is not None:
+        if current_document.document_id != document_id:
+            raise ValueError("CRDT document ID does not match current document")
+        document.apply_update(current_document.update)
+        base_revision = current_document.revision
+
+    base_state = document.get_state()
+    before = _operations(document, actor_id=None, recorded_at=None)
+    for operation in before.values():
+        validate_replicated_override_operation(operation, before.values())
+    document.apply_update(source_update)
+    if document.get_state() == base_state:
+        return PreparedCrdtCommit(
+            document_id=document_id,
+            base_revision=base_revision,
+            source_update_hash=_hash(source_update),
+            accepted_update=b"",
+            accepted_update_hash=_hash(b""),
+            state_vector=base_state,
+            operations=(),
+            is_noop=True,
+        )
+
+    operations_map = _operations_map(document, create=False)
+    after = (
+        {}
+        if operations_map is None
+        else {
+            operation_id: _operation_from_yjs(
+                operation_id,
+                raw,
+                actor_id=None if operation_id in before else actor_id,
+                recorded_at=None if operation_id in before else recorded_at,
+            )
+            for operation_id, raw in operations_map.to_py().items()
+        }
+    )
+    if before.keys() - after.keys():
+        raise ValueError("published CRDT operations cannot be deleted")
+    for operation_id, operation in before.items():
+        if operation_payload_hash(after[operation_id]) != operation_payload_hash(
+            operation
+        ):
+            raise ValueError("published CRDT operations cannot be mutated")
+
+    new_operations: list[ReplicatedOverrideOperation] = []
+    known_operations = list(before.values())
+    for operation_id in sorted(after.keys() - before.keys()):
+        operation = after[operation_id]
+        validate_replicated_override_operation(operation, known_operations)
+        finalized = finalize_replicated_override_operation(operation)
+        new_operations.append(finalized)
+        known_operations.append(finalized)
+        final_operations_map = _operations_map(document, create=True)
+        assert final_operations_map is not None
+        final_operations_map[operation_id] = _operation_to_yjs(finalized)
+
+    accepted_update = document.get_update(base_state)
+    return PreparedCrdtCommit(
+        document_id=document_id,
+        base_revision=base_revision,
+        source_update_hash=_hash(source_update),
+        accepted_update=accepted_update,
+        accepted_update_hash=_hash(accepted_update),
+        state_vector=document.get_state(),
+        operations=tuple(new_operations),
+    )
 
 
 class InMemoryCrdtDocumentStore:
-    """Yjs-compatible document storage for tests and embedded applications."""
+    """Reference prepared-commit store for tests and embedded applications."""
 
     def __init__(self) -> None:
         self._documents: dict[str, Any] = {}
         self._revisions: dict[str, int] = {}
-        self._update_hashes: dict[str, set[str]] = {}
+        self._source_results: dict[str, dict[str, CrdtCommitResult]] = {}
+        self._operations: dict[str, dict[str, ReplicatedOverrideOperation]] = {}
         self._snapshots: dict[str, CrdtDocument] = {}
+        self._rows: dict[
+            tuple[str, str, tuple[tuple[str, object], ...]], dict[str, object]
+        ] = {}
 
     def append_update(
         self,
@@ -35,33 +169,91 @@ class InMemoryCrdtDocumentStore:
         *,
         expected_revision: int | None = None,
     ) -> CrdtAppendResult:
+        prior = self._source_results.get(document_id, {}).get(_hash(update))
+        if prior is not None:
+            return replace(prior, accepted=False, duplicate=True)
+        current = self.load_document(document_id)
+        if expected_revision is not None and expected_revision != (
+            0 if current is None else current.revision
+        ):
+            raise CrdtRevisionConflict(
+                "CRDT document revision does not match expected revision"
+            )
+        prepared = prepare_crdt_update(
+            document_id,
+            current,
+            update,
+            actor_id="system",
+            recorded_at=datetime.now().astimezone(),
+        )
+        return self.commit(prepared)
+
+    def commit(
+        self,
+        prepared: PreparedCrdtCommit,
+        *,
+        guards: Sequence[RowGuard] = (),
+        inserts: Sequence[AtomicInsert] = (),
+    ) -> CrdtCommitResult:
+        prior = self._source_results.get(prepared.document_id, {}).get(
+            prepared.source_update_hash
+        )
+        if prior is not None:
+            return replace(prior, accepted=False, duplicate=True)
+
+        current = self.load_document(prepared.document_id)
+        revision = 0 if current is None else current.revision
+        if revision != prepared.base_revision:
+            raise CrdtRevisionConflict(
+                "CRDT document revision does not match prepared revision"
+            )
+        if prepared.is_noop:
+            return CrdtCommitResult(
+                current, revision, b"", accepted=False, duplicate=True
+            )
+
+        self._validate_guards(guards)
+        insert_keys = [
+            self._row_key(insert.table_config, insert.row) for insert in inserts
+        ]
+        if len(insert_keys) != len(set(insert_keys)) or any(
+            key in self._rows for key in insert_keys
+        ):
+            raise ValueError("atomic insert conflicts with an existing row")
+        known_operations = self._operations.setdefault(prepared.document_id, {})
+        for operation in prepared.operations:
+            existing = known_operations.get(operation.operation_id)
+            if existing is not None and operation_payload_hash(
+                existing
+            ) != operation_payload_hash(operation):
+                raise ValueError("operation ID was reused with different content")
+
+        document = self._documents.setdefault(prepared.document_id, _doc())
+        if _hash(prepared.accepted_update) != prepared.accepted_update_hash:
+            raise ValueError("accepted CRDT update hash does not match update")
+        document.apply_update(prepared.accepted_update)
+        self._revisions[prepared.document_id] = revision + 1
+        known_operations.update(
+            {operation.operation_id: operation for operation in prepared.operations}
+        )
+        for insert, key in zip(inserts, insert_keys, strict=True):
+            self._rows[key] = dict(insert.row)
+
+        result = CrdtCommitResult(
+            self.load_document(prepared.document_id),
+            revision + 1,
+            prepared.accepted_update,
+            accepted=True,
+        )
+        self._source_results.setdefault(prepared.document_id, {})[
+            prepared.source_update_hash
+        ] = result
+        return result
+
+    def load_document(self, document_id: str) -> CrdtDocument | None:
         document = self._documents.get(document_id)
-        revision = self._revisions.get(document_id, 0)
         if document is None:
-            if expected_revision not in {None, 0}:
-                raise ValueError(
-                    "CRDT document revision does not match expected revision"
-                )
-            document = _doc()
-            self._documents[document_id] = document
-            self._revisions[document_id] = revision
-        update_hash = sha256(update).hexdigest()
-        hashes = self._update_hashes.setdefault(document_id, set())
-
-        if update_hash in hashes:
-            return CrdtAppendResult(self.load_document(document_id), accepted=False)
-        if expected_revision is not None and expected_revision != revision:
-            raise ValueError("CRDT document revision does not match expected revision")
-
-        document.apply_update(update)
-        hashes.add(update_hash)
-        self._revisions[document_id] = revision + 1
-        return CrdtAppendResult(self.load_document(document_id), accepted=True)
-
-    def load_document(self, document_id: str) -> CrdtDocument:
-        document = self._documents.get(document_id)
-        if document is None:
-            raise KeyError(f"unknown CRDT document: {document_id}")
+            return None
         return CrdtDocument(
             document_id=document_id,
             revision=self._revisions[document_id],
@@ -70,15 +262,237 @@ class InMemoryCrdtDocumentStore:
         )
 
     def diff(self, document_id: str, state_vector: bytes) -> bytes:
-        return self._documents[document_id].get_update(state_vector)
+        document = self._documents.get(document_id)
+        if document is None:
+            raise KeyError(f"unknown CRDT document: {document_id}")
+        return document.get_update(state_vector)
 
-    def write_snapshot(self, document_id: str) -> CrdtDocument:
-        snapshot = self.load_document(document_id)
-        self._snapshots[document_id] = snapshot
-        return snapshot
+    def write_snapshot(
+        self, document_id: str, expected_revision: int | None = None
+    ) -> CrdtDocument:
+        document = self.load_document(document_id)
+        if document is None:
+            raise KeyError(f"unknown CRDT document: {document_id}")
+        if expected_revision is not None and expected_revision != document.revision:
+            raise CrdtRevisionConflict(
+                "CRDT document revision does not match expected revision"
+            )
+        self._snapshots[document_id] = document
+        return document
 
     def snapshot(self, document_id: str) -> CrdtDocument | None:
         return self._snapshots.get(document_id)
+
+    def seed_row(self, table_config: TableConfig, row: Mapping[str, object]) -> None:
+        self._rows[self._row_key(table_config, row)] = dict(row)
+
+    def projected_operations(
+        self, document_id: str
+    ) -> tuple[ReplicatedOverrideOperation, ...]:
+        return tuple(self._operations.get(document_id, {}).values())
+
+    def _validate_guards(self, guards: Sequence[RowGuard]) -> None:
+        for guard in guards:
+            row = self._rows.get(self._row_key(guard.table_config, guard.key_values))
+            if row is None or any(
+                row.get(column) != value
+                for column, value in guard.expected_values.items()
+            ):
+                raise CrdtPreconditionFailed("CRDT commit guard no longer matches")
+
+    @staticmethod
+    def _row_key(
+        table_config: TableConfig, row: Mapping[str, object]
+    ) -> tuple[str, str, tuple[tuple[str, object], ...]]:
+        key_columns = tuple(table_config.primary_keys)
+        if not key_columns or any(column not in row for column in key_columns):
+            raise ValueError("atomic rows require every configured primary key")
+        return (
+            table_config.schema,
+            table_config.name,
+            tuple((column, row[column]) for column in key_columns),
+        )
+
+
+def _operations(
+    document: Any,
+    *,
+    actor_id: str | None,
+    recorded_at: datetime | None,
+) -> dict[str, ReplicatedOverrideOperation]:
+    result: dict[str, ReplicatedOverrideOperation] = {}
+    operations_map = _operations_map(document, create=False)
+    if operations_map is None:
+        return result
+    for operation_id, raw in operations_map.to_py().items():
+        result[operation_id] = _operation_from_yjs(
+            operation_id,
+            raw,
+            actor_id=actor_id,
+            recorded_at=recorded_at,
+        )
+    return result
+
+
+def _operations_map(document: Any, *, create: bool) -> Any | None:
+    from pycrdt import Map
+
+    operations = document.get("operations", type=Map)
+    if operations is None and create:
+        operations = Map()
+        document["operations"] = operations
+    return operations
+
+
+def _operation_from_yjs(
+    operation_id: str,
+    raw: object,
+    *,
+    actor_id: str | None,
+    recorded_at: datetime | None,
+) -> ReplicatedOverrideOperation:
+    if not isinstance(raw, dict):
+        raise ValueError("CRDT operation entries must be objects")
+    provisional = actor_id is not None and recorded_at is not None
+    if provisional and any(
+        raw.get(field) is not None
+        for field in ("actor_id", "recorded_at", "payload_hash")
+    ):
+        raise ValueError("client CRDT operations cannot set authoritative fields")
+    value_raw = raw.get("value")
+    if value_raw is None:
+        value = None
+    elif isinstance(value_raw, dict) and isinstance(value_raw.get("value_json"), dict):
+        value = OverrideTypedValue(
+            value_type=_string(value_raw.get("value_type"), "value.value_type"),
+            value_json=dict(value_raw["value_json"]),
+            unit=_optional_string(value_raw.get("unit"), "value.unit"),
+        )
+    else:
+        raise ValueError("CRDT operation value must be an object")
+    declared_id = _string(raw.get("operation_id"), "operation_id")
+    if declared_id != operation_id:
+        raise ValueError("CRDT operation map key must match operation_id")
+    resolved_actor_id = (
+        actor_id if provisional else _string(raw.get("actor_id"), "actor_id")
+    )
+    resolved_recorded_at = (
+        recorded_at
+        if provisional
+        else _timestamp(raw.get("recorded_at"), "recorded_at")
+    )
+    assert resolved_actor_id is not None
+    assert resolved_recorded_at is not None
+    return ReplicatedOverrideOperation(
+        format_version=_integer(raw.get("format_version"), "format_version"),
+        operation_id=operation_id,
+        change_set_id=_string(raw.get("change_set_id"), "change_set_id"),
+        layer_id=_string(raw.get("layer_id"), "layer_id"),
+        actor_id=resolved_actor_id,
+        feed_id=_string(raw.get("feed_id"), "feed_id"),
+        entity_id=_string(raw.get("entity_id"), "entity_id"),
+        field_path=_string(raw.get("field_path"), "field_path"),
+        operation_type=_string(raw.get("operation_type"), "operation_type"),  # type: ignore[arg-type]
+        value=value,
+        supersedes_operation_ids=_string_tuple(raw.get("supersedes_operation_ids")),
+        removes_operation_ids=_string_tuple(raw.get("removes_operation_ids")),
+        valid_from=_timestamp(raw.get("valid_from"), "valid_from"),
+        valid_to=_optional_timestamp(raw.get("valid_to"), "valid_to"),
+        recorded_at=resolved_recorded_at,
+        observed_canonical_value_json=_optional_dict(
+            raw.get("observed_canonical_value_json"), "observed_canonical_value_json"
+        ),
+        comment=_optional_string(raw.get("comment"), "comment"),
+        metadata_json=_optional_dict(raw.get("metadata_json"), "metadata_json"),
+        payload_hash=None
+        if provisional
+        else _string(raw.get("payload_hash"), "payload_hash"),
+    )
+
+
+def _operation_to_yjs(operation: ReplicatedOverrideOperation) -> dict[str, object]:
+    return {
+        "format_version": operation.format_version,
+        "operation_id": operation.operation_id,
+        "change_set_id": operation.change_set_id,
+        "layer_id": operation.layer_id,
+        "actor_id": operation.actor_id,
+        "feed_id": operation.feed_id,
+        "entity_id": operation.entity_id,
+        "field_path": operation.field_path,
+        "operation_type": operation.operation_type,
+        "value": None
+        if operation.value is None
+        else {
+            "value_type": operation.value.value_type,
+            "value_json": operation.value.value_json,
+            "unit": operation.value.unit,
+        },
+        "supersedes_operation_ids": list(operation.supersedes_operation_ids),
+        "removes_operation_ids": list(operation.removes_operation_ids),
+        "valid_from": operation.valid_from.isoformat(),
+        "valid_to": None
+        if operation.valid_to is None
+        else operation.valid_to.isoformat(),
+        "recorded_at": operation.recorded_at.isoformat(),
+        "observed_canonical_value_json": operation.observed_canonical_value_json,
+        "comment": operation.comment,
+        "metadata_json": operation.metadata_json or {},
+        "payload_hash": operation.payload_hash,
+    }
+
+
+def _hash(value: bytes) -> str:
+    return sha256(value).hexdigest()
+
+
+def _string(value: object, name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"CRDT operation {name} must be a string")
+    return value
+
+
+def _optional_string(value: object, name: str) -> str | None:
+    if value is None:
+        return None
+    return _string(value, name)
+
+
+def _integer(value: object, name: str) -> int:
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if not isinstance(value, int):
+        raise ValueError(f"CRDT operation {name} must be an integer")
+    return value
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError("CRDT operation references must be string arrays")
+    return tuple(value)
+
+
+def _optional_dict(value: object, name: str) -> dict[str, object] | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError(f"CRDT operation {name} must be an object")
+    return dict(value)
+
+
+def _timestamp(value: object, name: str) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError(f"CRDT operation {name} must be an ISO timestamp")
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"CRDT operation {name} must be an ISO timestamp") from exc
+
+
+def _optional_timestamp(value: object, name: str) -> datetime | None:
+    return None if value is None else _timestamp(value, name)
 
 
 def _doc() -> Any:

--- a/tests/overrides/test_crdt_document_store.py
+++ b/tests/overrides/test_crdt_document_store.py
@@ -1,8 +1,19 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
 from pycrdt import Doc, Map
 import pytest
 from typing import Any
 
-from polars_hist_db.overrides import InMemoryCrdtDocumentStore
+from polars_hist_db.config import TableColumnConfig, TableConfig
+from polars_hist_db.overrides import (
+    AtomicInsert,
+    CrdtPreconditionFailed,
+    CrdtRevisionConflict,
+    InMemoryCrdtDocumentStore,
+    RowGuard,
+    prepare_crdt_update,
+)
 
 
 def _document_update() -> bytes:
@@ -60,5 +71,114 @@ def test_document_store_deduplicates_exact_updates_and_checks_revisions():
 
     with pytest.raises(ValueError, match="expected revision"):
         store.append_update("document-2", update, expected_revision=1)
-    with pytest.raises(KeyError):
-        store.load_document("document-2")
+    assert store.load_document("document-2") is None
+
+
+def _operation_update(operation_id: str) -> bytes:
+    document: Any = Doc()
+    document["operations"] = Map(
+        {
+            operation_id: {
+                "format_version": 1,
+                "operation_id": operation_id,
+                "change_set_id": str(uuid4()),
+                "layer_id": "team",
+                "feed_id": "records",
+                "entity_id": "record-1",
+                "field_path": "status",
+                "operation_type": "set",
+                "value": {"value_type": "enum", "value_json": {"value": "open"}},
+                "supersedes_operation_ids": [],
+                "removes_operation_ids": [],
+                "valid_from": "2026-07-12T10:00:00+00:00",
+                "valid_to": None,
+            }
+        }
+    )
+    return document.get_update()
+
+
+def test_prepared_commit_finalizes_operations_and_rejects_later_mutation():
+    operation_id = str(uuid4())
+    source_update = _operation_update(operation_id)
+    accepted_at = datetime(2026, 7, 12, 11, tzinfo=timezone.utc)
+
+    prepared = prepare_crdt_update(
+        "document-1",
+        None,
+        source_update,
+        actor_id="user-1",
+        recorded_at=accepted_at,
+    )
+    store = InMemoryCrdtDocumentStore()
+    committed = store.commit(prepared)
+
+    assert committed.accepted is True
+    assert committed.revision == 1
+    assert prepared.source_update_hash != prepared.accepted_update_hash
+    assert store.projected_operations("document-1")[0].actor_id == "user-1"
+    assert store.projected_operations("document-1")[0].payload_hash is not None
+
+    document: Any = Doc()
+    assert committed.document is not None
+    document.apply_update(committed.document.update)
+    operations = document.get("operations", type=Map)
+    operation = operations.get(operation_id)
+    operations[operation_id] = {**operation, "comment": "changed"}
+
+    with pytest.raises(ValueError, match="cannot be mutated"):
+        prepare_crdt_update(
+            "document-1",
+            committed.document,
+            document.get_update(committed.document.state_vector),
+            actor_id="user-1",
+            recorded_at=accepted_at,
+        )
+
+
+def test_prepared_commit_checks_revision_guards_and_atomic_inserts():
+    table = TableConfig(
+        name="outbox",
+        schema="overrides",
+        primary_keys=("id",),
+        columns=[TableColumnConfig("outbox", "id", "VARCHAR(64)", nullable=False)],
+    )
+    store = InMemoryCrdtDocumentStore()
+    store.seed_row(table, {"id": "layer-1", "version": 2})
+    prepared = prepare_crdt_update(
+        "document-1",
+        None,
+        _document_update(),
+        actor_id="user-1",
+        recorded_at=datetime(2026, 7, 12, 11, tzinfo=timezone.utc),
+    )
+
+    result = store.commit(
+        prepared,
+        guards=[RowGuard(table, {"id": "layer-1"}, {"version": 2})],
+        inserts=[AtomicInsert(table, {"id": "outbox-1"})],
+    )
+
+    assert result.accepted is True
+    stale = prepare_crdt_update(
+        "document-1",
+        None,
+        _document_update(),
+        actor_id="user-1",
+        recorded_at=datetime(2026, 7, 12, 11, tzinfo=timezone.utc),
+    )
+    with pytest.raises(CrdtRevisionConflict):
+        store.commit(stale)
+
+    rejected = prepare_crdt_update(
+        "document-2",
+        None,
+        _document_update(),
+        actor_id="user-1",
+        recorded_at=datetime(2026, 7, 12, 11, tzinfo=timezone.utc),
+    )
+    with pytest.raises(CrdtPreconditionFailed):
+        store.commit(
+            rejected,
+            guards=[RowGuard(table, {"id": "layer-1"}, {"version": 3})],
+        )

--- a/tests/overrides/test_crdt_table_config.py
+++ b/tests/overrides/test_crdt_table_config.py
@@ -19,15 +19,24 @@ def test_crdt_document_tables_use_portable_base64_payload_columns():
     assert {column.name for column in documents.columns} == {
         "document_id",
         "revision",
-        "state_vector_base64",
+        "head_state_vector_base64",
         "snapshot_update_base64",
+        "snapshot_update_hash",
+        "snapshot_state_vector_base64",
         "snapshot_through_revision",
         "updated_at",
     }
     assert {
         column.name for column in documents.columns if column.data_type == "MEDIUMTEXT"
-    } == {"state_vector_base64", "snapshot_update_base64"}
+    } == {
+        "head_state_vector_base64",
+        "snapshot_update_base64",
+        "snapshot_state_vector_base64",
+    }
     assert updates.primary_keys == ("document_id", "revision")
+    assert {
+        column.name for column in updates.columns if column.data_type == "VARCHAR(64)"
+    } == {"source_update_hash", "accepted_update_hash"}
     assert (
         next(
             column for column in updates.columns if column.name == "update_base64"

--- a/tests/overrides/test_override_table_config.py
+++ b/tests/overrides/test_override_table_config.py
@@ -55,6 +55,8 @@ def test_build_override_table_config_contains_required_columns():
         "removes_operation_ids_json",
         "recorded_at",
         "payload_hash",
+        "crdt_document_id",
+        "crdt_document_revision",
     }
 
 


### PR DESCRIPTION
## Summary
- prepare client Yjs updates against a base document and finalize new immutable operations
- add source/accepted update hashes, compare-and-swap commits, idempotency, guards, and insert-only side effects to the in-memory reference store
- correct document/update/projection table contracts for separate hashes, vectors, and CRDT provenance
- cover offline convergence, immutable-operation rejection, revision conflicts, guards, and atomic inserts

## Boundary
This establishes the tested backend-neutral behavior. MariaDB and XTDB repositories are the next implementation slice.

## Verification
- uv run pytest: 174 passed, 1 skipped
- uv run ruff check --config .shared/ruff.toml .
- uv run ruff format --config .shared/ruff.toml --check .
- uv run mypy .