### PR TITLE
fix: support shared override projection ownership (JWL-13)

### DIFF
--- a/docs/replicated-overrides.qmd
+++ b/docs/replicated-overrides.qmd
@@ -304,6 +304,11 @@ personal-ledger rows. The provenance makes per-document comparison and repair
 possible without inferring document membership from application-owned layer
 names.
 
+`owner_user_id` is required by the personal command model but nullable in the
+shared projection schema. Shared rows use `layer_id`, `actor_id`, and CRDT
+document provenance; they never invent a personal owner. Existing deployments
+must relax the legacy `NOT NULL` constraint before shared rows are written.
+
 The portable repository receives the existing two config objects:
 
 ```python

--- a/polars_hist_db/overrides/__init__.py
+++ b/polars_hist_db/overrides/__init__.py
@@ -3,6 +3,7 @@ from .config import (
     build_crdt_update_table_config,
     build_override_table_config,
     build_override_valid_time_config,
+    migrate_override_owner_nullable,
 )
 from .crdt import (
     AtomicInsert,
@@ -59,6 +60,7 @@ __all__ = [
     "ReplicatedOverrideOperation",
     "build_override_table_config",
     "build_override_valid_time_config",
+    "migrate_override_owner_nullable",
     "finalize_replicated_override_operation",
     "operation_payload_hash",
     "project_replicated_override_operations",

--- a/polars_hist_db/overrides/config.py
+++ b/polars_hist_db/overrides/config.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from sqlalchemy import Connection, inspect, text
+from sqlalchemy.schema import CreateColumn
+
 from polars_hist_db.config import TableColumnConfig, TableConfig, ValidTimeConfig
 
 from .types import CrdtDocumentStoreConfig, OverrideLedgerConfig
@@ -65,7 +68,8 @@ def build_override_table_config(config: OverrideLedgerConfig) -> TableConfig:
         columns=[
             TableColumnConfig(table, "operation_id", "VARCHAR(64)", nullable=False),
             TableColumnConfig(table, "change_set_id", "VARCHAR(64)", nullable=False),
-            TableColumnConfig(table, "owner_user_id", "VARCHAR(128)", nullable=False),
+            # Personal rows retain an owner; shared rows are scoped by layer_id.
+            TableColumnConfig(table, "owner_user_id", "VARCHAR(128)"),
             TableColumnConfig(table, "actor_user_id", "VARCHAR(128)", nullable=False),
             TableColumnConfig(table, "feed_id", "VARCHAR(128)", nullable=False),
             TableColumnConfig(table, "entity_id", "VARCHAR(256)", nullable=False),
@@ -111,4 +115,31 @@ def build_override_valid_time_config(config: OverrideLedgerConfig) -> ValidTimeC
         table=config.table,
         from_column=config.valid_from_column,
         to_column=config.valid_to_column,
+    )
+
+
+def migrate_override_owner_nullable(
+    connection: Connection, config: OverrideLedgerConfig
+) -> None:
+    """Relax the legacy personal-owner column for shared projection rows."""
+
+    inspector = inspect(connection)
+    if not inspector.has_table(config.table, schema=config.schema):
+        return
+    owner_column = next(
+        column
+        for column in inspector.get_columns(config.table, schema=config.schema)
+        if column["name"] == "owner_user_id"
+    )
+    if owner_column["nullable"]:
+        return
+    table_config = build_override_table_config(config)
+    column = next(
+        column
+        for column in table_config.build_sqlalchemy_columns(is_delta_table=False)
+        if column.name == "owner_user_id"
+    )
+    column_sql = str(CreateColumn(column).compile(connection))
+    connection.execute(
+        text(f"ALTER TABLE {config.schema}.{config.table} MODIFY COLUMN {column_sql}")
     )

--- a/tests/overrides/test_override_table_config.py
+++ b/tests/overrides/test_override_table_config.py
@@ -58,6 +58,12 @@ def test_build_override_table_config_contains_required_columns():
         "crdt_document_id",
         "crdt_document_revision",
     }
+    assert (
+        next(
+            column for column in table.columns if column.name == "owner_user_id"
+        ).nullable
+        is True
+    )
 
 
 def test_build_override_valid_time_config_uses_business_columns():


### PR DESCRIPTION
## Summary
- make owner_user_id nullable only in the shared projection schema
- retain personal ownership as a required domain-model field
- add an idempotent MariaDB migration helper for legacy NOT NULL projection tables
- document layer/actor/CRDT provenance as the authoritative shared identity

## Why
Shared operations have a layer and actor, not a personal owner. Persisting a fabricated owner would corrupt audit semantics and block the MariaDB CRDT repository.

## Verification
- uv run pytest: 174 passed, 1 skipped
- uv run ruff check --config .shared/ruff.toml .
- uv run ruff format --config .shared/ruff.toml --check .
- uv run mypy .