### PR TITLE
feat: persist CRDT commits in MariaDB (JWL-13)

### DIFF
--- a/polars_hist_db/backends/mariadb.py
+++ b/polars_hist_db/backends/mariadb.py
@@ -13,6 +13,8 @@ from .temporal import system_time_hint_clause
 
 if TYPE_CHECKING:
     from ..config import TableConfig
+    from ..overrides import CrdtDocumentStoreConfig, OverrideLedgerConfig
+    from ..overrides.sql import MariaDbCrdtDocumentStore
 
 
 @dataclass(frozen=True)
@@ -39,6 +41,16 @@ class MariaDbBackend:
 
     def table_configs(self, connection: Any) -> TableConfigOps:
         return TableConfigOps(connection)
+
+    def crdt_documents(
+        self,
+        connection: Any,
+        document_store: "CrdtDocumentStoreConfig",
+        projection: "OverrideLedgerConfig",
+    ) -> "MariaDbCrdtDocumentStore":
+        from ..overrides.sql import MariaDbCrdtDocumentStore
+
+        return MariaDbCrdtDocumentStore(connection, document_store, projection)
 
     def tables(self, table_schema: str, table_name: str, connection: Any) -> TableOps:
         return TableOps(table_schema, table_name, connection)

--- a/polars_hist_db/overrides/__init__.py
+++ b/polars_hist_db/overrides/__init__.py
@@ -18,6 +18,7 @@ from .crdt import (
     prepare_crdt_update,
 )
 from .ledger import InMemoryOverrideLedgerStore, OverrideLedger
+from .sql import MariaDbCrdtDocumentStore
 from .replicated import (
     InMemoryReplicatedOverrideLedger,
     OverrideFrontier,
@@ -39,6 +40,7 @@ from .types import (
 __all__ = [
     "InMemoryOverrideLedgerStore",
     "InMemoryCrdtDocumentStore",
+    "MariaDbCrdtDocumentStore",
     "AtomicInsert",
     "InMemoryReplicatedOverrideLedger",
     "OverrideLedger",

--- a/polars_hist_db/overrides/config.py
+++ b/polars_hist_db/overrides/config.py
@@ -15,7 +15,13 @@ def build_crdt_document_table_config(config: CrdtDocumentStoreConfig) -> TableCo
         schema=config.schema,
         primary_keys=("document_id",),
         columns=[
-            TableColumnConfig(table, "document_id", "VARCHAR(128)", nullable=False),
+            TableColumnConfig(
+                table,
+                "document_id",
+                "VARCHAR(128)",
+                nullable=False,
+                unique_constraint=["document_source_update_hash"],
+            ),
             TableColumnConfig(table, "revision", "BIGINT", nullable=False),
             TableColumnConfig(table, "head_state_vector_base64", "MEDIUMTEXT"),
             TableColumnConfig(table, "snapshot_update_base64", "MEDIUMTEXT"),

--- a/polars_hist_db/overrides/sql.py
+++ b/polars_hist_db/overrides/sql.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timezone
+from hashlib import sha256
+from typing import Sequence
+
+from sqlalchemy import Connection, MetaData, Table, and_, select
+from sqlalchemy.exc import IntegrityError
+
+from polars_hist_db.config import TableConfig
+
+from .config import (
+    build_crdt_document_table_config,
+    build_crdt_update_table_config,
+    build_override_table_config,
+)
+from .crdt import (
+    AtomicInsert,
+    CrdtCommitResult,
+    CrdtDocument,
+    CrdtPreconditionFailed,
+    CrdtRevisionConflict,
+    PreparedCrdtCommit,
+    RowGuard,
+    _doc,
+)
+from .types import CrdtDocumentStoreConfig, OverrideLedgerConfig
+
+
+class MariaDbCrdtDocumentStore:
+    """SQLAlchemy repository for the prepared CRDT document contract."""
+
+    def __init__(
+        self,
+        connection: Connection,
+        config: CrdtDocumentStoreConfig,
+        projection_config: OverrideLedgerConfig,
+    ) -> None:
+        self.connection = connection
+        self.config = config
+        self.documents = _table(connection, build_crdt_document_table_config(config))
+        self.updates = _table(connection, build_crdt_update_table_config(config))
+        self.projection = _table(
+            connection, build_override_table_config(projection_config)
+        )
+
+    def load_document(self, document_id: str) -> CrdtDocument | None:
+        head = (
+            self.connection.execute(
+                select(self.documents).where(
+                    self.documents.c.document_id == document_id
+                )
+            )
+            .mappings()
+            .first()
+        )
+        if head is None:
+            return None
+        document = _doc()
+        rows = self.connection.execute(
+            select(
+                self.updates.c.update_base64,
+                self.updates.c.accepted_update_hash,
+            )
+            .where(self.updates.c.document_id == document_id)
+            .order_by(self.updates.c.revision)
+        ).mappings()
+        for row in rows:
+            update = _decode(row["update_base64"])
+            if sha256(update).hexdigest() != row["accepted_update_hash"]:
+                raise ValueError(
+                    "stored accepted CRDT update hash does not match update"
+                )
+            document.apply_update(update)
+        return CrdtDocument(
+            document_id=document_id,
+            revision=head["revision"],
+            state_vector=document.get_state(),
+            update=document.get_update(),
+        )
+
+    def commit(
+        self,
+        prepared: PreparedCrdtCommit,
+        *,
+        guards: Sequence[RowGuard] = (),
+        inserts: Sequence[AtomicInsert] = (),
+    ) -> CrdtCommitResult:
+        if (
+            sha256(prepared.accepted_update).hexdigest()
+            != prepared.accepted_update_hash
+        ):
+            raise ValueError("accepted CRDT update hash does not match update")
+        duplicate = self._duplicate_result(prepared)
+        if duplicate is not None:
+            return duplicate
+        if prepared.is_noop:
+            current = self.load_document(prepared.document_id)
+            return CrdtCommitResult(
+                current,
+                0 if current is None else current.revision,
+                b"",
+                accepted=False,
+                duplicate=True,
+            )
+
+        try:
+            with self.connection.begin_nested():
+                return self._commit(prepared, guards=guards, inserts=inserts)
+        except IntegrityError as exc:
+            duplicate = self._duplicate_result(prepared)
+            if duplicate is not None:
+                return duplicate
+            current = self.load_document(prepared.document_id)
+            if (0 if current is None else current.revision) != prepared.base_revision:
+                raise CrdtRevisionConflict(
+                    "CRDT document revision changed during commit"
+                ) from exc
+            raise ValueError("CRDT commit conflicts with an immutable row") from exc
+
+    def _commit(
+        self,
+        prepared: PreparedCrdtCommit,
+        *,
+        guards: Sequence[RowGuard],
+        inserts: Sequence[AtomicInsert],
+    ) -> CrdtCommitResult:
+        self._check_guards(guards)
+        current = self.load_document(prepared.document_id)
+        revision = 0 if current is None else current.revision
+        if revision != prepared.base_revision:
+            raise CrdtRevisionConflict(
+                "CRDT document revision does not match prepared revision"
+            )
+        next_revision = revision + 1
+        if current is None:
+            self.connection.execute(
+                self.documents.insert().values(
+                    document_id=prepared.document_id,
+                    revision=next_revision,
+                    head_state_vector_base64=_encode(prepared.state_vector),
+                    updated_at=datetime.now(timezone.utc),
+                )
+            )
+        else:
+            result = self.connection.execute(
+                self.documents.update()
+                .where(self.documents.c.document_id == prepared.document_id)
+                .where(self.documents.c.revision == prepared.base_revision)
+                .values(
+                    revision=next_revision,
+                    head_state_vector_base64=_encode(prepared.state_vector),
+                    updated_at=datetime.now(timezone.utc),
+                )
+            )
+            if result.rowcount != 1:
+                raise CrdtRevisionConflict(
+                    "CRDT document revision changed during commit"
+                )
+        self.connection.execute(
+            self.updates.insert().values(
+                document_id=prepared.document_id,
+                revision=next_revision,
+                source_update_hash=prepared.source_update_hash,
+                accepted_update_hash=prepared.accepted_update_hash,
+                update_base64=_encode(prepared.accepted_update),
+                accepted_at=datetime.now(timezone.utc),
+            )
+        )
+        self._insert_operations(prepared, next_revision)
+        for insert in inserts:
+            self.connection.execute(
+                _table(self.connection, insert.table_config).insert().values(insert.row)
+            )
+        return CrdtCommitResult(
+            self.load_document(prepared.document_id),
+            next_revision,
+            prepared.accepted_update,
+            accepted=True,
+        )
+
+    def _duplicate_result(
+        self, prepared: PreparedCrdtCommit
+    ) -> CrdtCommitResult | None:
+        duplicate = (
+            self.connection.execute(
+                select(self.updates)
+                .where(self.updates.c.document_id == prepared.document_id)
+                .where(self.updates.c.source_update_hash == prepared.source_update_hash)
+            )
+            .mappings()
+            .first()
+        )
+        if duplicate is None:
+            return None
+        return CrdtCommitResult(
+            self.load_document(prepared.document_id),
+            duplicate["revision"],
+            _decode(duplicate["update_base64"]),
+            accepted=False,
+            duplicate=True,
+        )
+
+    def _check_guards(self, guards: Sequence[RowGuard]) -> None:
+        for guard in guards:
+            table = _table(self.connection, guard.table_config)
+            predicates = [
+                table.c[name] == value for name, value in guard.key_values.items()
+            ]
+            predicates.extend(
+                table.c[name] == value for name, value in guard.expected_values.items()
+            )
+            if (
+                self.connection.execute(
+                    select(table).where(and_(*predicates)).with_for_update()
+                ).first()
+                is None
+            ):
+                raise CrdtPreconditionFailed("CRDT commit guard no longer matches")
+
+    def _insert_operations(self, prepared: PreparedCrdtCommit, revision: int) -> None:
+        for operation in prepared.operations:
+            self.connection.execute(
+                self.projection.insert().values(
+                    operation_id=operation.operation_id,
+                    change_set_id=operation.change_set_id,
+                    owner_user_id=None,
+                    actor_user_id=operation.actor_id,
+                    feed_id=operation.feed_id,
+                    entity_id=operation.entity_id,
+                    field_path=operation.field_path,
+                    operation_type=operation.operation_type,
+                    value_type=None
+                    if operation.value is None
+                    else operation.value.value_type,
+                    value_json=None
+                    if operation.value is None
+                    else operation.value.value_json,
+                    unit=None if operation.value is None else operation.value.unit,
+                    observed_canonical_value_json=operation.observed_canonical_value_json,
+                    created_against_stale_source=False,
+                    valid_from=operation.valid_from,
+                    valid_to=operation.valid_to,
+                    comment=operation.comment,
+                    metadata_json=operation.metadata_json or {},
+                    format_version=operation.format_version,
+                    layer_id=operation.layer_id,
+                    actor_id=operation.actor_id,
+                    supersedes_operation_ids_json=list(
+                        operation.supersedes_operation_ids
+                    ),
+                    removes_operation_ids_json=list(operation.removes_operation_ids),
+                    recorded_at=operation.recorded_at,
+                    payload_hash=operation.payload_hash,
+                    crdt_document_id=prepared.document_id,
+                    crdt_document_revision=revision,
+                )
+            )
+
+
+def _table(connection: Connection, config: TableConfig) -> Table:
+    return Table(config.name, MetaData(schema=config.schema), autoload_with=connection)
+
+
+def _encode(value: bytes) -> str:
+    return base64.b64encode(value).decode("ascii")
+
+
+def _decode(value: str) -> bytes:
+    return base64.b64decode(value)

--- a/tests/backends/test_mariadb_backend.py
+++ b/tests/backends/test_mariadb_backend.py
@@ -1,5 +1,6 @@
 from polars_hist_db.backends import MariaDbBackend
 from polars_hist_db.core import DataframeOps, TableConfigOps, TableOps
+from polars_hist_db.overrides import CrdtDocumentStoreConfig, OverrideLedgerConfig
 
 
 def test_mariadb_backend_returns_existing_operation_wrappers():
@@ -9,3 +10,18 @@ def test_mariadb_backend_returns_existing_operation_wrappers():
     assert isinstance(backend.dataframes(connection), DataframeOps)
     assert isinstance(backend.table_configs(connection), TableConfigOps)
     assert isinstance(backend.tables("schema", "table", connection), TableOps)
+
+
+def test_mariadb_backend_builds_crdt_document_store(monkeypatch):
+    class Store:
+        def __init__(self, connection, document_store, projection):
+            self.connection = connection
+            self.document_store = document_store
+            self.projection = projection
+
+    monkeypatch.setattr("polars_hist_db.overrides.sql.MariaDbCrdtDocumentStore", Store)
+    store = MariaDbBackend().crdt_documents(
+        object(), CrdtDocumentStoreConfig(), OverrideLedgerConfig()
+    )
+
+    assert isinstance(store, Store)

--- a/tests/overrides/test_crdt_table_config.py
+++ b/tests/overrides/test_crdt_table_config.py
@@ -34,6 +34,15 @@ def test_crdt_document_tables_use_portable_base64_payload_columns():
         "snapshot_state_vector_base64",
     }
     assert updates.primary_keys == ("document_id", "revision")
+    source_hash_constraint = [
+        column
+        for column in updates.columns
+        if "document_source_update_hash" in column.unique_constraint
+    ]
+    assert {column.name for column in source_hash_constraint} == {
+        "document_id",
+        "source_update_hash",
+    }
     assert {
         column.name for column in updates.columns if column.data_type == "VARCHAR(64)"
     } == {"source_update_hash", "accepted_update_hash"}

--- a/tests/sql/test_crdt_document_store.py
+++ b/tests/sql/test_crdt_document_store.py
@@ -1,0 +1,125 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from pycrdt import Doc, Map
+import pytest
+from sqlalchemy import select
+from typing import Any
+
+from polars_hist_db.core import TableConfigOps
+from polars_hist_db.overrides import (
+    CrdtDocumentStoreConfig,
+    MariaDbCrdtDocumentStore,
+    OverrideLedgerConfig,
+    build_crdt_document_table_config,
+    build_crdt_update_table_config,
+    build_override_table_config,
+    prepare_crdt_update,
+)
+
+from ..utils.dsv_helper import mariadb_engine_test
+
+pytestmark = pytest.mark.integration
+
+
+def _operation_update(operation_id: str) -> bytes:
+    document: Any = Doc()
+    document["operations"] = Map(
+        {
+            operation_id: {
+                "format_version": 1,
+                "operation_id": operation_id,
+                "change_set_id": str(uuid4()),
+                "layer_id": "shared",
+                "feed_id": "records",
+                "entity_id": "record-1",
+                "field_path": "status",
+                "operation_type": "set",
+                "value": {"value_type": "enum", "value_json": {"value": "open"}},
+                "supersedes_operation_ids": [],
+                "removes_operation_ids": [],
+                "valid_from": "2026-07-12T10:00:00+00:00",
+                "valid_to": None,
+            }
+        }
+    )
+    return document.get_update()
+
+
+def test_mariadb_crdt_store_persists_prepared_commit_and_projection():
+    document_config = CrdtDocumentStoreConfig(
+        schema="test",
+        documents_table="crdt_documents_store_test",
+        updates_table="crdt_updates_store_test",
+    )
+    projection_config = OverrideLedgerConfig(
+        schema="test", table="crdt_operations_store_test"
+    )
+    document_table = build_crdt_document_table_config(document_config)
+    update_table = build_crdt_update_table_config(document_config)
+    projection_table = build_override_table_config(projection_config)
+    source_update = _operation_update(str(uuid4()))
+    prepared = prepare_crdt_update(
+        "document-1",
+        None,
+        source_update,
+        actor_id="user-1",
+        recorded_at=datetime(2026, 7, 12, 11, tzinfo=timezone.utc),
+    )
+
+    engine = mariadb_engine_test()
+    with engine.begin() as connection:
+        table_ops = TableConfigOps(connection)
+        for config in (projection_table, update_table, document_table):
+            table_ops.drop(config)
+        try:
+            for config in (document_table, update_table, projection_table):
+                table_ops.create(config)
+            store = MariaDbCrdtDocumentStore(
+                connection, document_config, projection_config
+            )
+
+            accepted = store.commit(prepared)
+            duplicate = store.commit(prepared)
+            conflicting = prepare_crdt_update(
+                "document-2",
+                None,
+                source_update,
+                actor_id="user-1",
+                recorded_at=datetime(2026, 7, 12, 11, tzinfo=timezone.utc),
+            )
+            operation = (
+                connection.execute(
+                    select(store.projection).where(
+                        store.projection.c.operation_id
+                        == prepared.operations[0].operation_id
+                    )
+                )
+                .mappings()
+                .one()
+            )
+
+            assert accepted.accepted is True
+            assert accepted.revision == 1
+            assert duplicate.accepted is False
+            assert duplicate.duplicate is True
+            assert duplicate.revision == 1
+            assert operation["owner_user_id"] is None
+            assert operation["actor_id"] == "user-1"
+            assert operation["crdt_document_id"] == "document-1"
+            assert operation["crdt_document_revision"] == 1
+
+            with pytest.raises(ValueError, match="immutable row"):
+                store.commit(conflicting)
+            assert store.load_document("document-2") is None
+            assert (
+                connection.execute(
+                    select(store.updates.c.document_id).where(
+                        store.updates.c.document_id == "document-2"
+                    )
+                ).first()
+                is None
+            )
+        finally:
+            for config in (projection_table, update_table, document_table):
+                table_ops.drop(config)


### PR DESCRIPTION
## Summary
- persist prepared CRDT commits and finalized override projections through the MariaDB backend
- enforce per-document source-update idempotency and translate persistence races to portable conflicts
- cover projection provenance, deduplication, and rollback on projection conflict

## Verification
- uv run pytest (175 passed, 1 skipped)
- uv run ruff check --config .shared/ruff.toml .
- uv run ruff format --config .shared/ruff.toml --check .
- uv run mypy .
- MariaDB integration test added; local Docker daemon was unavailable