### PR TITLE
fix: repair CRDT adapter integration paths

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -831,6 +831,7 @@ def _execute_xtdb_transaction(connection: Any, statements: Iterable[str]) -> Non
         raise ValueError("XTDB transactions require a live DBAPI connection")
     if getattr(connection, "in_transaction", lambda: False)():
         connection.commit()
+    driver_connection.commit()
 
     driver_connection.execute("BEGIN READ WRITE")
     try:

--- a/polars_hist_db/overrides/sql.py
+++ b/polars_hist_db/overrides/sql.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import json
 from datetime import datetime, timezone
 from hashlib import sha256
 from typing import Sequence
@@ -234,23 +235,27 @@ class MariaDbCrdtDocumentStore:
                     value_type=None
                     if operation.value is None
                     else operation.value.value_type,
-                    value_json=None
-                    if operation.value is None
-                    else operation.value.value_json,
+                    value_json=_json(
+                        None if operation.value is None else operation.value.value_json
+                    ),
                     unit=None if operation.value is None else operation.value.unit,
-                    observed_canonical_value_json=operation.observed_canonical_value_json,
+                    observed_canonical_value_json=_json(
+                        operation.observed_canonical_value_json
+                    ),
                     created_against_stale_source=False,
                     valid_from=operation.valid_from,
                     valid_to=operation.valid_to,
                     comment=operation.comment,
-                    metadata_json=operation.metadata_json or {},
+                    metadata_json=_json(operation.metadata_json or {}),
                     format_version=operation.format_version,
                     layer_id=operation.layer_id,
                     actor_id=operation.actor_id,
-                    supersedes_operation_ids_json=list(
-                        operation.supersedes_operation_ids
+                    supersedes_operation_ids_json=_json(
+                        list(operation.supersedes_operation_ids)
                     ),
-                    removes_operation_ids_json=list(operation.removes_operation_ids),
+                    removes_operation_ids_json=_json(
+                        list(operation.removes_operation_ids)
+                    ),
                     recorded_at=operation.recorded_at,
                     payload_hash=operation.payload_hash,
                     crdt_document_id=prepared.document_id,
@@ -269,3 +274,7 @@ def _encode(value: bytes) -> str:
 
 def _decode(value: str) -> bytes:
     return base64.b64decode(value)
+
+
+def _json(value: object | None) -> str | None:
+    return None if value is None else json.dumps(value, separators=(",", ":"))

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -12,6 +12,7 @@ from polars_hist_db.backends.xtdb import (
     XtdbAdbcDataframeOps,
     XtdbDataframeOps,
     XtdbTableConfigOps,
+    _execute_xtdb_transaction,
     _xtdb_cast_type,
     _xtdb_declared_columns,
 )
@@ -44,6 +45,20 @@ def test_xtdb_backend_builds_crdt_document_store(monkeypatch):
     )
 
     assert isinstance(store, Store)
+
+
+def test_xtdb_transaction_commits_implicit_read_before_begin():
+    driver_connection = Mock()
+    connection = Mock()
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+
+    _execute_xtdb_transaction(
+        connection, ["ASSERT TRUE", "INSERT INTO test.x (_id) VALUES ('x')"]
+    )
+
+    assert driver_connection.execute.call_args_list[0].args == ("BEGIN READ WRITE",)
+    assert driver_connection.commit.call_count == 2
 
 
 def test_xtdb_create_engine_includes_configured_credentials(monkeypatch):


### PR DESCRIPTION
## Fixes
- commit implicit pgwire reads before beginning an XTDB DML transaction
- serialize MariaDB JSON projection values before binding reflected text columns

## Verification
- focused adapter suite: 51 passed
- ruff and mypy passed
- the MariaDB and XTDB live integration tests run in CI