### PR TITLE
feat: add backend-neutral document access store

### DIFF
--- a/polars_hist_db/backends/mariadb.py
+++ b/polars_hist_db/backends/mariadb.py
@@ -13,7 +13,12 @@ from .temporal import system_time_hint_clause
 
 if TYPE_CHECKING:
     from ..config import TableConfig
-    from ..overrides import CrdtDocumentStoreConfig, OverrideLedgerConfig
+    from ..overrides import (
+        CrdtDocumentStoreConfig,
+        DocumentAccessStoreConfig,
+        OverrideLedgerConfig,
+    )
+    from ..overrides.sql import MariaDbDocumentAccessStore
     from ..overrides.sql import MariaDbCrdtDocumentStore
 
 
@@ -51,6 +56,13 @@ class MariaDbBackend:
         from ..overrides.sql import MariaDbCrdtDocumentStore
 
         return MariaDbCrdtDocumentStore(connection, document_store, projection)
+
+    def document_access(
+        self, connection: Any, config: "DocumentAccessStoreConfig"
+    ) -> "MariaDbDocumentAccessStore":
+        from ..overrides.sql import MariaDbDocumentAccessStore
+
+        return MariaDbDocumentAccessStore(connection, config)
 
     def tables(self, table_schema: str, table_name: str, connection: Any) -> TableOps:
         return TableOps(table_schema, table_name, connection)

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -29,7 +29,12 @@ from .config import DbEngineConfig
 from .temporal import system_time_hint_clause
 
 if TYPE_CHECKING:
-    from ..overrides import CrdtDocumentStoreConfig, OverrideLedgerConfig
+    from ..overrides import (
+        CrdtDocumentStoreConfig,
+        DocumentAccessStoreConfig,
+        OverrideLedgerConfig,
+    )
+    from ..overrides.xtdb import XtdbDocumentAccessStore
     from ..overrides.xtdb import XtdbCrdtDocumentStore
 
 LOGGER = logging.getLogger(__name__)
@@ -2214,6 +2219,13 @@ class XtdbBackend:
         from ..overrides.xtdb import XtdbCrdtDocumentStore
 
         return XtdbCrdtDocumentStore(connection, document_store, projection)
+
+    def document_access(
+        self, connection: Any, config: "DocumentAccessStoreConfig"
+    ) -> "XtdbDocumentAccessStore":
+        from ..overrides.xtdb import XtdbDocumentAccessStore
+
+        return XtdbDocumentAccessStore(connection, config)
 
     def staging(
         self,

--- a/polars_hist_db/overrides/__init__.py
+++ b/polars_hist_db/overrides/__init__.py
@@ -1,6 +1,7 @@
 from .config import (
     build_crdt_document_table_config,
     build_crdt_update_table_config,
+    build_document_access_table_configs,
     build_override_table_config,
     build_override_valid_time_config,
     migrate_override_owner_nullable,
@@ -19,8 +20,20 @@ from .crdt import (
     prepare_crdt_update,
 )
 from .ledger import InMemoryOverrideLedgerStore, OverrideLedger
-from .sql import MariaDbCrdtDocumentStore
-from .xtdb import XtdbCrdtDocumentStore
+from .access import (
+    AccessDocument,
+    AccessGrant,
+    AccessGrantInput,
+    AccessMutationResult,
+    DocumentAccessError,
+    DocumentArchived,
+    DocumentNotFound,
+    DocumentRevisionConflict,
+    IdempotencyConflict,
+    InMemoryDocumentAccessStore,
+)
+from .sql import MariaDbCrdtDocumentStore, MariaDbDocumentAccessStore
+from .xtdb import XtdbCrdtDocumentStore, XtdbDocumentAccessStore
 from .replicated import (
     InMemoryReplicatedOverrideLedger,
     OverrideFrontier,
@@ -33,6 +46,7 @@ from .replicated import (
 )
 from .types import (
     CrdtDocumentStoreConfig,
+    DocumentAccessStoreConfig,
     OverrideLedgerConfig,
     OverrideOperation,
     OverrideOperationType,
@@ -41,9 +55,12 @@ from .types import (
 
 __all__ = [
     "InMemoryOverrideLedgerStore",
+    "InMemoryDocumentAccessStore",
     "InMemoryCrdtDocumentStore",
     "MariaDbCrdtDocumentStore",
+    "MariaDbDocumentAccessStore",
     "XtdbCrdtDocumentStore",
+    "XtdbDocumentAccessStore",
     "AtomicInsert",
     "AtomicUpdate",
     "InMemoryReplicatedOverrideLedger",
@@ -52,14 +69,25 @@ __all__ = [
     "OverrideOperation",
     "OverrideOperationType",
     "OverrideTypedValue",
+    "AccessDocument",
+    "AccessGrant",
+    "AccessGrantInput",
+    "AccessMutationResult",
+    "DocumentAccessError",
+    "DocumentArchived",
+    "DocumentNotFound",
+    "DocumentRevisionConflict",
+    "IdempotencyConflict",
     "CrdtAppendResult",
     "CrdtCommitResult",
     "CrdtDocument",
     "CrdtPreconditionFailed",
     "CrdtRevisionConflict",
     "CrdtDocumentStoreConfig",
+    "DocumentAccessStoreConfig",
     "build_crdt_document_table_config",
     "build_crdt_update_table_config",
+    "build_document_access_table_configs",
     "OverrideFrontier",
     "PreparedCrdtCommit",
     "ReplicatedOverrideAppendResult",

--- a/polars_hist_db/overrides/access.py
+++ b/polars_hist_db/overrides/access.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime
+from hashlib import sha256
+import json
+from typing import Iterable
+
+
+class DocumentAccessError(ValueError):
+    pass
+
+
+class DocumentNotFound(DocumentAccessError):
+    pass
+
+
+class DocumentArchived(DocumentAccessError):
+    pass
+
+
+class DocumentRevisionConflict(DocumentAccessError):
+    pass
+
+
+class IdempotencyConflict(DocumentAccessError):
+    pass
+
+
+@dataclass(frozen=True)
+class AccessDocument:
+    document_id: str
+    name: str
+    normalized_name: str
+    description: str | None
+    status: str
+    revision: int
+    created_by: str
+    created_at: datetime
+    archived_by: str | None = None
+    archived_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class AccessGrant:
+    grant_id: str
+    document_id: str
+    group_name: str
+    role: str
+    granted_by: str
+    granted_at: datetime
+    document_revision: int
+    revoked_by: str | None = None
+    revoked_at: datetime | None = None
+
+    @property
+    def active(self) -> bool:
+        return self.revoked_at is None
+
+
+@dataclass(frozen=True)
+class AccessGrantInput:
+    grant_id: str
+    group_name: str
+    role: str
+
+
+@dataclass(frozen=True)
+class AccessMutationResult:
+    document: AccessDocument
+    grants: tuple[AccessGrant, ...]
+    accepted: bool
+    duplicate: bool = False
+
+
+class InMemoryDocumentAccessStore:
+    def __init__(self) -> None:
+        self._documents: dict[str, AccessDocument] = {}
+        self._grants: dict[str, AccessGrant] = {}
+        self._commands: dict[str, tuple[str, AccessMutationResult]] = {}
+
+    def create(
+        self,
+        document_id: str,
+        name: str,
+        description: str | None,
+        actor_id: str,
+        recorded_at: datetime,
+        *,
+        initial_grants: Iterable[AccessGrantInput] = (),
+        idempotency_key: str,
+    ) -> AccessMutationResult:
+        grants = tuple(initial_grants)
+        payload = _payload("create", document_id, name, description, actor_id, grants)
+        duplicate = self._duplicate(idempotency_key, payload)
+        if duplicate is not None:
+            return duplicate
+        if document_id in self._documents:
+            raise DocumentAccessError("document already exists")
+        normalized_name = _normalized(name)
+        if any(
+            doc.normalized_name == normalized_name for doc in self._documents.values()
+        ):
+            raise DocumentAccessError("document name already exists")
+        _require_time(recorded_at)
+        document = AccessDocument(
+            document_id,
+            name,
+            normalized_name,
+            description,
+            "active",
+            1,
+            actor_id,
+            recorded_at,
+        )
+        self._documents[document_id] = document
+        for grant in grants:
+            self._insert_grant(document, grant, actor_id, recorded_at)
+        return self._record(idempotency_key, payload, document)
+
+    def get(self, document_id: str) -> AccessDocument | None:
+        return self._documents.get(document_id)
+
+    def list_for_groups(
+        self, groups: Iterable[str], *, include_archived: bool = False
+    ) -> list[AccessDocument]:
+        group_set = set(groups)
+        document_ids = {
+            grant.document_id
+            for grant in self._grants.values()
+            if grant.active and grant.group_name in group_set
+        }
+        return [
+            doc
+            for doc in self._documents.values()
+            if doc.document_id in document_ids
+            and (include_archived or doc.status == "active")
+        ]
+
+    def list_all(self, *, include_archived: bool = False) -> list[AccessDocument]:
+        return [
+            doc
+            for doc in self._documents.values()
+            if include_archived or doc.status == "active"
+        ]
+
+    def grants(
+        self, document_id: str, *, include_revoked: bool = False
+    ) -> tuple[AccessGrant, ...]:
+        return tuple(
+            grant
+            for grant in self._grants.values()
+            if grant.document_id == document_id and (include_revoked or grant.active)
+        )
+
+    def grant(
+        self,
+        document_id: str,
+        grant: AccessGrantInput,
+        actor_id: str,
+        recorded_at: datetime,
+        expected_revision: int,
+        *,
+        idempotency_key: str,
+    ) -> AccessMutationResult:
+        payload = _payload("grant", document_id, grant, actor_id, expected_revision)
+        duplicate = self._duplicate(idempotency_key, payload)
+        if duplicate is not None:
+            return duplicate
+        document = self._active(document_id, expected_revision)
+        _require_time(recorded_at)
+        if any(
+            item.active and item.group_name == grant.group_name
+            for item in self.grants(document_id)
+        ):
+            raise DocumentAccessError("group already has an active grant")
+        document = self._advance(document)
+        self._documents[document_id] = document
+        self._insert_grant(document, grant, actor_id, recorded_at)
+        return self._record(idempotency_key, payload, document)
+
+    def revoke(
+        self,
+        document_id: str,
+        group_name: str,
+        actor_id: str,
+        recorded_at: datetime,
+        expected_revision: int,
+        *,
+        idempotency_key: str,
+    ) -> AccessMutationResult:
+        payload = _payload(
+            "revoke", document_id, group_name, actor_id, expected_revision
+        )
+        duplicate = self._duplicate(idempotency_key, payload)
+        if duplicate is not None:
+            return duplicate
+        document = self._active(document_id, expected_revision)
+        _require_time(recorded_at)
+        grant = next(
+            (
+                item
+                for item in self.grants(document_id)
+                if item.group_name == group_name
+            ),
+            None,
+        )
+        if grant is None:
+            raise DocumentAccessError("active group grant not found")
+        document = self._advance(document)
+        self._documents[document_id] = document
+        self._grants[grant.grant_id] = replace(
+            grant,
+            revoked_by=actor_id,
+            revoked_at=recorded_at,
+            document_revision=document.revision,
+        )
+        return self._record(idempotency_key, payload, document)
+
+    def archive(
+        self,
+        document_id: str,
+        actor_id: str,
+        recorded_at: datetime,
+        expected_revision: int,
+        *,
+        idempotency_key: str,
+    ) -> AccessMutationResult:
+        payload = _payload("archive", document_id, actor_id, expected_revision)
+        duplicate = self._duplicate(idempotency_key, payload)
+        if duplicate is not None:
+            return duplicate
+        document = self._active(document_id, expected_revision)
+        _require_time(recorded_at)
+        document = replace(
+            self._advance(document),
+            status="archived",
+            archived_by=actor_id,
+            archived_at=recorded_at,
+        )
+        self._documents[document_id] = document
+        return self._record(idempotency_key, payload, document)
+
+    def _active(self, document_id: str, expected_revision: int) -> AccessDocument:
+        document = self._documents.get(document_id)
+        if document is None:
+            raise DocumentNotFound("document not found")
+        if document.status != "active":
+            raise DocumentArchived("document archived")
+        if document.revision != expected_revision:
+            raise DocumentRevisionConflict("document revision changed")
+        return document
+
+    def _insert_grant(
+        self,
+        document: AccessDocument,
+        grant: AccessGrantInput,
+        actor_id: str,
+        recorded_at: datetime,
+    ) -> None:
+        if grant.grant_id in self._grants:
+            raise DocumentAccessError("grant already exists")
+        self._grants[grant.grant_id] = AccessGrant(
+            grant.grant_id,
+            document.document_id,
+            grant.group_name,
+            grant.role,
+            actor_id,
+            recorded_at,
+            document.revision,
+        )
+
+    def _advance(self, document: AccessDocument) -> AccessDocument:
+        return replace(document, revision=document.revision + 1)
+
+    def _duplicate(
+        self, idempotency_key: str, payload: str
+    ) -> AccessMutationResult | None:
+        prior = self._commands.get(idempotency_key)
+        if prior is None:
+            return None
+        if prior[0] != payload:
+            raise IdempotencyConflict(
+                "idempotency key was reused with different content"
+            )
+        return replace(prior[1], accepted=False, duplicate=True)
+
+    def _record(
+        self, idempotency_key: str, payload: str, document: AccessDocument
+    ) -> AccessMutationResult:
+        result = AccessMutationResult(
+            document, self.grants(document.document_id), accepted=True
+        )
+        self._commands[idempotency_key] = (payload, result)
+        return result
+
+
+def _normalized(value: str) -> str:
+    normalized = value.strip().casefold()
+    if not normalized:
+        raise DocumentAccessError("name is required")
+    return normalized
+
+
+def _require_time(value: datetime) -> None:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise DocumentAccessError("recorded_at must be timezone-aware")
+
+
+def _payload(action: str, *values: object) -> str:
+    return sha256(
+        json.dumps(
+            [action, *values], default=lambda value: value.__dict__, sort_keys=True
+        ).encode()
+    ).hexdigest()

--- a/polars_hist_db/overrides/access.py
+++ b/polars_hist_db/overrides/access.py
@@ -289,7 +289,9 @@ class InMemoryDocumentAccessStore:
         self, idempotency_key: str, payload: str, document: AccessDocument
     ) -> AccessMutationResult:
         result = AccessMutationResult(
-            document, self.grants(document.document_id), accepted=True
+            document,
+            self.grants(document.document_id, include_revoked=True),
+            accepted=True,
         )
         self._commands[idempotency_key] = (payload, result)
         return result

--- a/polars_hist_db/overrides/config.py
+++ b/polars_hist_db/overrides/config.py
@@ -5,7 +5,110 @@ from sqlalchemy.schema import CreateColumn
 
 from polars_hist_db.config import TableColumnConfig, TableConfig, ValidTimeConfig
 
-from .types import CrdtDocumentStoreConfig, OverrideLedgerConfig
+from .types import (
+    CrdtDocumentStoreConfig,
+    DocumentAccessStoreConfig,
+    OverrideLedgerConfig,
+)
+
+
+def build_document_access_table_configs(
+    config: DocumentAccessStoreConfig,
+) -> tuple[TableConfig, TableConfig, TableConfig]:
+    documents = TableConfig(
+        name=config.documents_table,
+        schema=config.schema,
+        primary_keys=("document_id",),
+        columns=[
+            TableColumnConfig(
+                config.documents_table, "document_id", "VARCHAR(128)", nullable=False
+            ),
+            TableColumnConfig(
+                config.documents_table, "name", "VARCHAR(255)", nullable=False
+            ),
+            TableColumnConfig(
+                config.documents_table,
+                "normalized_name",
+                "VARCHAR(255)",
+                nullable=False,
+                unique_constraint=["document_access_normalized_name"],
+            ),
+            TableColumnConfig(config.documents_table, "description", "MEDIUMTEXT"),
+            TableColumnConfig(
+                config.documents_table, "status", "VARCHAR(16)", nullable=False
+            ),
+            TableColumnConfig(
+                config.documents_table, "revision", "BIGINT", nullable=False
+            ),
+            TableColumnConfig(
+                config.documents_table, "created_by", "VARCHAR(128)", nullable=False
+            ),
+            TableColumnConfig(
+                config.documents_table, "created_at", "DATETIME(6)", nullable=False
+            ),
+            TableColumnConfig(config.documents_table, "archived_by", "VARCHAR(128)"),
+            TableColumnConfig(config.documents_table, "archived_at", "DATETIME(6)"),
+        ],
+    )
+    grants = TableConfig(
+        name=config.grants_table,
+        schema=config.schema,
+        primary_keys=("grant_id",),
+        columns=[
+            TableColumnConfig(
+                config.grants_table, "grant_id", "VARCHAR(128)", nullable=False
+            ),
+            TableColumnConfig(
+                config.grants_table, "document_id", "VARCHAR(128)", nullable=False
+            ),
+            TableColumnConfig(
+                config.grants_table, "group_name", "VARCHAR(255)", nullable=False
+            ),
+            TableColumnConfig(
+                config.grants_table,
+                "active_group_key",
+                "VARCHAR(512)",
+                unique_constraint=["document_access_active_group"],
+            ),
+            TableColumnConfig(
+                config.grants_table, "role", "VARCHAR(128)", nullable=False
+            ),
+            TableColumnConfig(
+                config.grants_table, "granted_by", "VARCHAR(128)", nullable=False
+            ),
+            TableColumnConfig(
+                config.grants_table, "granted_at", "DATETIME(6)", nullable=False
+            ),
+            TableColumnConfig(
+                config.grants_table, "document_revision", "BIGINT", nullable=False
+            ),
+            TableColumnConfig(config.grants_table, "revoked_by", "VARCHAR(128)"),
+            TableColumnConfig(config.grants_table, "revoked_at", "DATETIME(6)"),
+        ],
+    )
+    commands = TableConfig(
+        name=config.commands_table,
+        schema=config.schema,
+        primary_keys=("idempotency_key",),
+        columns=[
+            TableColumnConfig(
+                config.commands_table, "idempotency_key", "VARCHAR(128)", nullable=False
+            ),
+            TableColumnConfig(
+                config.commands_table, "payload_hash", "VARCHAR(64)", nullable=False
+            ),
+            TableColumnConfig(
+                config.commands_table, "command_kind", "VARCHAR(32)", nullable=False
+            ),
+            TableColumnConfig(
+                config.commands_table, "result_json", "JSON", nullable=False
+            ),
+            TableColumnConfig(
+                config.commands_table, "recorded_at", "DATETIME(6)", nullable=False
+            ),
+        ],
+    )
+    return documents, grants, commands
 
 
 def build_crdt_document_table_config(config: CrdtDocumentStoreConfig) -> TableConfig:

--- a/polars_hist_db/overrides/sql.py
+++ b/polars_hist_db/overrides/sql.py
@@ -626,7 +626,9 @@ class MariaDbDocumentAccessStore:
         document: AccessDocument,
     ) -> AccessMutationResult:
         result = AccessMutationResult(
-            document, self.grants(document.document_id), accepted=True
+            document,
+            self.grants(document.document_id, include_revoked=True),
+            accepted=True,
         )
         self.connection.execute(
             self.commands.insert().values(

--- a/polars_hist_db/overrides/sql.py
+++ b/polars_hist_db/overrides/sql.py
@@ -2,18 +2,34 @@ from __future__ import annotations
 
 import base64
 import json
+from dataclasses import asdict
 from datetime import datetime, timezone
 from hashlib import sha256
-from typing import Sequence
+from typing import Any, Sequence
 
 from sqlalchemy import Connection, MetaData, Table, and_, select
 from sqlalchemy.exc import IntegrityError
 
 from polars_hist_db.config import TableConfig
 
+from .access import (
+    AccessDocument,
+    AccessGrant,
+    AccessGrantInput,
+    AccessMutationResult,
+    DocumentAccessError,
+    DocumentArchived,
+    DocumentNotFound,
+    DocumentRevisionConflict,
+    IdempotencyConflict,
+    _normalized,
+    _payload,
+    _require_time,
+)
 from .config import (
     build_crdt_document_table_config,
     build_crdt_update_table_config,
+    build_document_access_table_configs,
     build_override_table_config,
 )
 from .crdt import (
@@ -27,7 +43,11 @@ from .crdt import (
     RowGuard,
     _doc,
 )
-from .types import CrdtDocumentStoreConfig, OverrideLedgerConfig
+from .types import (
+    CrdtDocumentStoreConfig,
+    DocumentAccessStoreConfig,
+    OverrideLedgerConfig,
+)
 
 
 class MariaDbCrdtDocumentStore:
@@ -286,6 +306,385 @@ class MariaDbCrdtDocumentStore:
                     crdt_document_revision=revision,
                 )
             )
+
+
+class MariaDbDocumentAccessStore:
+    """MariaDB implementation of the document access contract."""
+
+    def __init__(
+        self, connection: Connection, config: DocumentAccessStoreConfig
+    ) -> None:
+        self.connection = connection
+        document_config, grants_config, commands_config = (
+            build_document_access_table_configs(config)
+        )
+        self.document_config = document_config
+        self.documents = _table(connection, document_config)
+        self.grants_table = _table(connection, grants_config)
+        self.commands = _table(connection, commands_config)
+
+    def get(self, document_id: str) -> AccessDocument | None:
+        row = (
+            self.connection.execute(
+                select(self.documents).where(
+                    self.documents.c.document_id == document_id
+                )
+            )
+            .mappings()
+            .first()
+        )
+        return _access_document(row) if row else None
+
+    def grants(
+        self, document_id: str, *, include_revoked: bool = False
+    ) -> tuple[AccessGrant, ...]:
+        query = select(self.grants_table).where(
+            self.grants_table.c.document_id == document_id
+        )
+        if not include_revoked:
+            query = query.where(self.grants_table.c.revoked_at.is_(None))
+        return tuple(
+            _access_grant(row) for row in self.connection.execute(query).mappings()
+        )
+
+    def list_for_groups(
+        self, groups: Sequence[str], *, include_archived: bool = False
+    ) -> list[AccessDocument]:
+        if not groups:
+            return []
+        query = (
+            select(self.documents)
+            .distinct()
+            .join(self.grants_table)
+            .where(
+                self.grants_table.c.group_name.in_(groups),
+                self.grants_table.c.revoked_at.is_(None),
+            )
+        )
+        if not include_archived:
+            query = query.where(self.documents.c.status == "active")
+        return [
+            _access_document(row) for row in self.connection.execute(query).mappings()
+        ]
+
+    def list_all(self, *, include_archived: bool = False) -> list[AccessDocument]:
+        query = select(self.documents)
+        if not include_archived:
+            query = query.where(self.documents.c.status == "active")
+        return [
+            _access_document(row) for row in self.connection.execute(query).mappings()
+        ]
+
+    def guard(self, document_id: str, expected_revision: int) -> RowGuard:
+        return RowGuard(
+            self.document_config,
+            {"document_id": document_id},
+            {"status": "active", "revision": expected_revision},
+        )
+
+    def create(
+        self,
+        document_id: str,
+        name: str,
+        description: str | None,
+        actor_id: str,
+        recorded_at: datetime,
+        *,
+        initial_grants: Sequence[AccessGrantInput] = (),
+        idempotency_key: str,
+    ) -> AccessMutationResult:
+        payload = _payload(
+            "create", document_id, name, description, actor_id, initial_grants
+        )
+        duplicate = self._duplicate(idempotency_key, payload)
+        if duplicate:
+            return duplicate
+        _require_time(recorded_at)
+        document = AccessDocument(
+            document_id,
+            name,
+            _normalized(name),
+            description,
+            "active",
+            1,
+            actor_id,
+            recorded_at,
+        )
+        try:
+            with self.connection.begin_nested():
+                self.connection.execute(
+                    self.documents.insert().values(**asdict(document))
+                )
+                for grant in initial_grants:
+                    self._insert_grant(document, grant, actor_id, recorded_at)
+                return self._record(
+                    idempotency_key, payload, "create", recorded_at, document
+                )
+        except IntegrityError as exc:
+            duplicate = self._duplicate(idempotency_key, payload)
+            if duplicate:
+                return duplicate
+            raise DocumentAccessError("document or grant already exists") from exc
+
+    def grant(
+        self,
+        document_id: str,
+        grant: AccessGrantInput,
+        actor_id: str,
+        recorded_at: datetime,
+        expected_revision: int,
+        *,
+        idempotency_key: str,
+    ) -> AccessMutationResult:
+        payload = _payload("grant", document_id, grant, actor_id, expected_revision)
+        duplicate = self._duplicate(idempotency_key, payload)
+        if duplicate:
+            return duplicate
+        _require_time(recorded_at)
+        try:
+            with self.connection.begin_nested():
+                document = self._active(document_id, expected_revision)
+                updated = self._advance(document)
+                self._insert_grant(updated, grant, actor_id, recorded_at)
+                return self._record(
+                    idempotency_key, payload, "grant", recorded_at, updated
+                )
+        except IntegrityError as exc:
+            duplicate = self._duplicate(idempotency_key, payload)
+            if duplicate:
+                return duplicate
+            raise DocumentAccessError("grant already exists") from exc
+
+    def archive(
+        self,
+        document_id: str,
+        actor_id: str,
+        recorded_at: datetime,
+        expected_revision: int,
+        *,
+        idempotency_key: str,
+    ) -> AccessMutationResult:
+        payload = _payload("archive", document_id, actor_id, expected_revision)
+        duplicate = self._duplicate(idempotency_key, payload)
+        if duplicate:
+            return duplicate
+        _require_time(recorded_at)
+        try:
+            with self.connection.begin_nested():
+                document = self._active(document_id, expected_revision)
+                updated = self._advance(
+                    document,
+                    status="archived",
+                    archived_by=actor_id,
+                    archived_at=recorded_at,
+                )
+                return self._record(
+                    idempotency_key, payload, "archive", recorded_at, updated
+                )
+        except IntegrityError as exc:
+            duplicate = self._duplicate(idempotency_key, payload)
+            if duplicate:
+                return duplicate
+            raise DocumentAccessError("archive conflicts with another command") from exc
+
+    def revoke(
+        self,
+        document_id: str,
+        group_name: str,
+        actor_id: str,
+        recorded_at: datetime,
+        expected_revision: int,
+        *,
+        idempotency_key: str,
+    ) -> AccessMutationResult:
+        payload = _payload(
+            "revoke", document_id, group_name, actor_id, expected_revision
+        )
+        duplicate = self._duplicate(idempotency_key, payload)
+        if duplicate:
+            return duplicate
+        _require_time(recorded_at)
+        try:
+            with self.connection.begin_nested():
+                document = self._active(document_id, expected_revision)
+                row = (
+                    self.connection.execute(
+                        select(self.grants_table)
+                        .where(
+                            self.grants_table.c.document_id == document_id,
+                            self.grants_table.c.group_name == group_name,
+                            self.grants_table.c.revoked_at.is_(None),
+                        )
+                        .with_for_update()
+                    )
+                    .mappings()
+                    .first()
+                )
+                if row is None:
+                    raise DocumentAccessError("active group grant not found")
+                updated = self._advance(document)
+                self.connection.execute(
+                    self.grants_table.update()
+                    .where(self.grants_table.c.grant_id == row["grant_id"])
+                    .values(
+                        active_group_key=None,
+                        revoked_by=actor_id,
+                        revoked_at=recorded_at,
+                        document_revision=updated.revision,
+                    )
+                )
+                return self._record(
+                    idempotency_key, payload, "revoke", recorded_at, updated
+                )
+        except IntegrityError as exc:
+            duplicate = self._duplicate(idempotency_key, payload)
+            if duplicate:
+                return duplicate
+            raise DocumentAccessError("revoke conflicts with another command") from exc
+
+    def _active(self, document_id: str, revision: int) -> AccessDocument:
+        row = (
+            self.connection.execute(
+                select(self.documents)
+                .where(self.documents.c.document_id == document_id)
+                .with_for_update()
+            )
+            .mappings()
+            .first()
+        )
+        if row is None:
+            raise DocumentNotFound("document not found")
+        document = _access_document(row)
+        if document.status != "active":
+            raise DocumentArchived("document archived")
+        if document.revision != revision:
+            raise DocumentRevisionConflict("document revision changed")
+        return document
+
+    def _advance(self, document: AccessDocument, **extra: object) -> AccessDocument:
+        values = {"revision": document.revision + 1, **extra}
+        result = self.connection.execute(
+            self.documents.update()
+            .where(
+                and_(
+                    self.documents.c.document_id == document.document_id,
+                    self.documents.c.revision == document.revision,
+                    self.documents.c.status == "active",
+                )
+            )
+            .values(values)
+        )
+        if result.rowcount != 1:
+            raise DocumentRevisionConflict("document revision changed")
+        return AccessDocument(**{**asdict(document), **values})
+
+    def _insert_grant(
+        self,
+        document: AccessDocument,
+        grant: AccessGrantInput,
+        actor_id: str,
+        recorded_at: datetime,
+    ) -> None:
+        self.connection.execute(
+            self.grants_table.insert().values(
+                grant_id=grant.grant_id,
+                document_id=document.document_id,
+                group_name=grant.group_name,
+                active_group_key=f"{document.document_id}:{grant.group_name.casefold()}",
+                role=grant.role,
+                granted_by=actor_id,
+                granted_at=recorded_at,
+                document_revision=document.revision,
+            )
+        )
+
+    def _duplicate(self, key: str, payload: str) -> AccessMutationResult | None:
+        row = (
+            self.connection.execute(
+                select(self.commands).where(self.commands.c.idempotency_key == key)
+            )
+            .mappings()
+            .first()
+        )
+        if row is None:
+            return None
+        if row["payload_hash"] != payload:
+            raise IdempotencyConflict(
+                "idempotency key was reused with different content"
+            )
+        value = row["result_json"]
+        return _access_result(
+            json.loads(value) if isinstance(value, str) else value, duplicate=True
+        )
+
+    def _record(
+        self,
+        key: str,
+        payload: str,
+        kind: str,
+        recorded_at: datetime,
+        document: AccessDocument,
+    ) -> AccessMutationResult:
+        result = AccessMutationResult(
+            document, self.grants(document.document_id), accepted=True
+        )
+        self.connection.execute(
+            self.commands.insert().values(
+                idempotency_key=key,
+                payload_hash=payload,
+                command_kind=kind,
+                result_json=json.dumps(
+                    _access_result_json(result), default=_json_default
+                ),
+                recorded_at=recorded_at,
+            )
+        )
+        return result
+
+
+def _access_document(row: Any) -> AccessDocument:
+    return AccessDocument(**_datetime_fields(dict(row), "created_at", "archived_at"))
+
+
+def _access_grant(row: Any) -> AccessGrant:
+    values = dict(row)
+    values.pop("active_group_key", None)
+    return AccessGrant(**_datetime_fields(values, "granted_at", "revoked_at"))
+
+
+def _access_result_json(result: AccessMutationResult) -> dict[str, Any]:
+    return {
+        "document": asdict(result.document),
+        "grants": [asdict(grant) for grant in result.grants],
+    }
+
+
+def _access_result(value: dict[str, Any], *, duplicate: bool) -> AccessMutationResult:
+    return AccessMutationResult(
+        AccessDocument(
+            **_datetime_fields(value["document"], "created_at", "archived_at")
+        ),
+        tuple(
+            AccessGrant(**_datetime_fields(grant, "granted_at", "revoked_at"))
+            for grant in value["grants"]
+        ),
+        accepted=not duplicate,
+        duplicate=duplicate,
+    )
+
+
+def _datetime_fields(value: dict[str, Any], *names: str) -> dict[str, Any]:
+    result = dict(value)
+    for name in names:
+        if isinstance(result.get(name), str):
+            result[name] = datetime.fromisoformat(result[name])
+    return result
+
+
+def _json_default(value: object) -> object:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    raise TypeError(f"not JSON serializable: {type(value).__name__}")
 
 
 def _table(connection: Connection, config: TableConfig) -> Table:

--- a/polars_hist_db/overrides/types.py
+++ b/polars_hist_db/overrides/types.py
@@ -52,3 +52,11 @@ class CrdtDocumentStoreConfig:
     schema: str = "overrides"
     documents_table: str = "crdt_documents"
     updates_table: str = "crdt_updates"
+
+
+@dataclass(frozen=True)
+class DocumentAccessStoreConfig:
+    schema: str = "overrides"
+    documents_table: str = "document_access"
+    grants_table: str = "document_access_grants"
+    commands_table: str = "document_access_commands"

--- a/polars_hist_db/overrides/xtdb.py
+++ b/polars_hist_db/overrides/xtdb.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+from dataclasses import replace
 from datetime import date, datetime, timezone
 from hashlib import sha256
 from typing import Any, Mapping, Sequence
@@ -20,9 +21,24 @@ from polars_hist_db.backends.xtdb import (
 )
 from polars_hist_db.config import TableConfig
 
+from .access import (
+    AccessDocument,
+    AccessGrant,
+    AccessGrantInput,
+    AccessMutationResult,
+    DocumentAccessError,
+    DocumentArchived,
+    DocumentNotFound,
+    DocumentRevisionConflict,
+    IdempotencyConflict,
+    _normalized,
+    _payload,
+    _require_time,
+)
 from .config import (
     build_crdt_document_table_config,
     build_crdt_update_table_config,
+    build_document_access_table_configs,
     build_override_table_config,
 )
 from .crdt import (
@@ -36,7 +52,11 @@ from .crdt import (
     RowGuard,
     _doc,
 )
-from .types import CrdtDocumentStoreConfig, OverrideLedgerConfig
+from .types import (
+    CrdtDocumentStoreConfig,
+    DocumentAccessStoreConfig,
+    OverrideLedgerConfig,
+)
 
 
 class XtdbCrdtDocumentStore:
@@ -302,6 +322,560 @@ class XtdbCrdtDocumentStore:
                 raise
             _rollback_xtdb_connection(self.connection)
             return []
+
+
+class XtdbDocumentAccessStore:
+    """XTDB implementation of the backend-neutral document access contract."""
+
+    def __init__(self, connection: Any, config: DocumentAccessStoreConfig) -> None:
+        self.connection = connection
+        self.documents, self.grants_table, self.commands = (
+            build_document_access_table_configs(config)
+        )
+
+    def get(self, document_id: str) -> AccessDocument | None:
+        rows = self._rows(
+            f"SELECT {_access_document_columns()} FROM {_table_name(self.documents)} "
+            f"WHERE _id = {_literal(document_id, 'VARCHAR(128)')}"
+        )
+        return _access_document_from_row(rows[0]) if rows else None
+
+    def grants(
+        self, document_id: str, *, include_revoked: bool = False
+    ) -> tuple[AccessGrant, ...]:
+        predicate = f"document_id = {_literal(document_id, 'VARCHAR(128)')}"
+        if not include_revoked:
+            predicate += " AND revoked_at IS NULL"
+        return tuple(
+            _access_grant_from_row(row)
+            for row in self._rows(
+                f"SELECT {_access_grant_columns()} FROM {_table_name(self.grants_table)} "
+                f"WHERE {predicate} ORDER BY granted_at, grant_id"
+            )
+        )
+
+    def list_for_groups(
+        self, groups: Sequence[str], *, include_archived: bool = False
+    ) -> list[AccessDocument]:
+        if not groups:
+            return []
+        group_sql = ", ".join(_literal(group, "VARCHAR(255)") for group in groups)
+        status = "" if include_archived else " AND d.status = 'active'"
+        rows = self._rows(
+            f"SELECT DISTINCT {_access_document_columns('d')} "
+            f"FROM {_table_name(self.documents)} d "
+            f"JOIN {_table_name(self.grants_table)} g ON d.document_id = g.document_id "
+            f"WHERE g.group_name IN ({group_sql}) AND g.revoked_at IS NULL{status}"
+        )
+        return [_access_document_from_row(row) for row in rows]
+
+    def list_all(self, *, include_archived: bool = False) -> list[AccessDocument]:
+        predicate = "" if include_archived else " WHERE status = 'active'"
+        return [
+            _access_document_from_row(row)
+            for row in self._rows(
+                f"SELECT {_access_document_columns()} FROM {_table_name(self.documents)}"
+                f"{predicate} ORDER BY created_at, document_id"
+            )
+        ]
+
+    def guard(self, document_id: str, expected_revision: int) -> RowGuard:
+        return RowGuard(
+            self.documents,
+            {"document_id": document_id},
+            {"status": "active", "revision": expected_revision},
+        )
+
+    def create(
+        self,
+        document_id: str,
+        name: str,
+        description: str | None,
+        actor_id: str,
+        recorded_at: datetime,
+        *,
+        initial_grants: Sequence[AccessGrantInput] = (),
+        idempotency_key: str,
+    ) -> AccessMutationResult:
+        grants = tuple(initial_grants)
+        payload = _payload("create", document_id, name, description, actor_id, grants)
+        duplicate = self._duplicate(idempotency_key, payload)
+        if duplicate:
+            return duplicate
+        _require_time(recorded_at)
+        normalized_name = _normalized(name)
+        if len({grant.grant_id for grant in grants}) != len(grants) or len(
+            {grant.group_name.casefold() for grant in grants}
+        ) != len(grants):
+            raise DocumentAccessError("initial grants must be unique")
+        document = AccessDocument(
+            document_id,
+            name,
+            normalized_name,
+            description,
+            "active",
+            1,
+            actor_id,
+            recorded_at,
+        )
+        result = AccessMutationResult(
+            document,
+            tuple(
+                _new_grant(document, grant, actor_id, recorded_at) for grant in grants
+            ),
+            accepted=True,
+        )
+        statements = [
+            self._command_assertion(idempotency_key),
+            f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.documents)} WHERE _id = {_literal(document_id, 'VARCHAR(128)')}), 'document already exists'",
+            f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.documents)} WHERE normalized_name = {_literal(normalized_name, 'VARCHAR(255)')}), 'document name already exists'",
+            *(
+                f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.grants_table)} WHERE _id = {_literal(grant.grant_id, 'VARCHAR(128)')}), 'grant already exists'"
+                for grant in grants
+            ),
+            _insert_statement(self.documents, _document_row(document)),
+            *(
+                _insert_statement(self.grants_table, _grant_row(grant))
+                for grant in result.grants
+            ),
+            self._command_insert(
+                idempotency_key, payload, "create", result, recorded_at
+            ),
+        ]
+        duplicate = self._run(statements, idempotency_key, payload, document_id, None)
+        return result if duplicate is None else duplicate
+
+    def grant(
+        self,
+        document_id: str,
+        grant: AccessGrantInput,
+        actor_id: str,
+        recorded_at: datetime,
+        expected_revision: int,
+        *,
+        idempotency_key: str,
+    ) -> AccessMutationResult:
+        payload = _payload("grant", document_id, grant, actor_id, expected_revision)
+        duplicate = self._duplicate(idempotency_key, payload)
+        if duplicate:
+            return duplicate
+        _require_time(recorded_at)
+        document = self._active(document_id, expected_revision)
+        updated = _updated_document(document)
+        new_grant = _new_grant(updated, grant, actor_id, recorded_at)
+        result = AccessMutationResult(
+            updated, (*self.grants(document_id), new_grant), accepted=True
+        )
+        statements = [
+            self._command_assertion(idempotency_key),
+            self._active_assertion(document_id, expected_revision),
+            f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.grants_table)} WHERE _id = {_literal(grant.grant_id, 'VARCHAR(128)')}), 'grant already exists'",
+            f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.grants_table)} WHERE active_group_key = {_literal(_active_group_key(document_id, grant.group_name), 'VARCHAR(512)')}), 'group already has an active grant'",
+            _access_update(self.documents, document_id, {"revision": updated.revision}),
+            _insert_statement(self.grants_table, _grant_row(new_grant)),
+            self._command_insert(
+                idempotency_key, payload, "grant", result, recorded_at
+            ),
+        ]
+        duplicate = self._run(
+            statements, idempotency_key, payload, document_id, expected_revision
+        )
+        return result if duplicate is None else duplicate
+
+    def revoke(
+        self,
+        document_id: str,
+        group_name: str,
+        actor_id: str,
+        recorded_at: datetime,
+        expected_revision: int,
+        *,
+        idempotency_key: str,
+    ) -> AccessMutationResult:
+        payload = _payload(
+            "revoke", document_id, group_name, actor_id, expected_revision
+        )
+        duplicate = self._duplicate(idempotency_key, payload)
+        if duplicate:
+            return duplicate
+        _require_time(recorded_at)
+        document = self._active(document_id, expected_revision)
+        active_grant = self._active_grant(document_id, group_name)
+        if active_grant is None:
+            raise DocumentAccessError("active group grant not found")
+        updated = _updated_document(document)
+        revoked = AccessGrant(
+            grant_id=active_grant.grant_id,
+            document_id=active_grant.document_id,
+            group_name=active_grant.group_name,
+            role=active_grant.role,
+            granted_by=active_grant.granted_by,
+            granted_at=active_grant.granted_at,
+            document_revision=updated.revision,
+            revoked_by=actor_id,
+            revoked_at=recorded_at,
+        )
+        grants = tuple(
+            revoked if item.grant_id == revoked.grant_id else item
+            for item in self.grants(document_id, include_revoked=True)
+        )
+        result = AccessMutationResult(updated, grants, accepted=True)
+        statements = [
+            self._command_assertion(idempotency_key),
+            self._active_assertion(document_id, expected_revision),
+            f"ASSERT EXISTS (SELECT 1 FROM {_table_name(self.grants_table)} WHERE _id = {_literal(active_grant.grant_id, 'VARCHAR(128)')} AND revoked_at IS NULL), 'active group grant not found'",
+            _access_update(self.documents, document_id, {"revision": updated.revision}),
+            _access_update(
+                self.grants_table,
+                active_grant.grant_id,
+                {
+                    "active_group_key": None,
+                    "revoked_by": actor_id,
+                    "revoked_at": recorded_at,
+                    "document_revision": updated.revision,
+                },
+            ),
+            self._command_insert(
+                idempotency_key, payload, "revoke", result, recorded_at
+            ),
+        ]
+        duplicate = self._run(
+            statements, idempotency_key, payload, document_id, expected_revision
+        )
+        return result if duplicate is None else duplicate
+
+    def archive(
+        self,
+        document_id: str,
+        actor_id: str,
+        recorded_at: datetime,
+        expected_revision: int,
+        *,
+        idempotency_key: str,
+    ) -> AccessMutationResult:
+        payload = _payload("archive", document_id, actor_id, expected_revision)
+        duplicate = self._duplicate(idempotency_key, payload)
+        if duplicate:
+            return duplicate
+        _require_time(recorded_at)
+        document = self._active(document_id, expected_revision)
+        updated = _updated_document(
+            document,
+            status="archived",
+            archived_by=actor_id,
+            archived_at=recorded_at,
+        )
+        result = AccessMutationResult(updated, self.grants(document_id), accepted=True)
+        statements = [
+            self._command_assertion(idempotency_key),
+            self._active_assertion(document_id, expected_revision),
+            _access_update(
+                self.documents,
+                document_id,
+                {
+                    "revision": updated.revision,
+                    "status": "archived",
+                    "archived_by": actor_id,
+                    "archived_at": recorded_at,
+                },
+            ),
+            self._command_insert(
+                idempotency_key, payload, "archive", result, recorded_at
+            ),
+        ]
+        duplicate = self._run(
+            statements, idempotency_key, payload, document_id, expected_revision
+        )
+        return result if duplicate is None else duplicate
+
+    def _active(self, document_id: str, expected_revision: int) -> AccessDocument:
+        document = self.get(document_id)
+        if document is None:
+            raise DocumentNotFound("document not found")
+        if document.status != "active":
+            raise DocumentArchived("document archived")
+        if document.revision != expected_revision:
+            raise DocumentRevisionConflict("document revision changed")
+        return document
+
+    def _active_grant(self, document_id: str, group_name: str) -> AccessGrant | None:
+        rows = self._rows(
+            f"SELECT {_access_grant_columns()} FROM {_table_name(self.grants_table)} "
+            f"WHERE active_group_key = {_literal(_active_group_key(document_id, group_name), 'VARCHAR(512)')}"
+        )
+        return _access_grant_from_row(rows[0]) if rows else None
+
+    def _duplicate(self, key: str, payload: str) -> AccessMutationResult | None:
+        rows = self._rows(
+            f"SELECT payload_hash, result_json FROM {_table_name(self.commands)} "
+            f"WHERE _id = {_literal(key, 'VARCHAR(128)')}"
+        )
+        if not rows:
+            return None
+        if rows[0]["payload_hash"] != payload:
+            raise IdempotencyConflict(
+                "idempotency key was reused with different content"
+            )
+        return _access_result_from_json(rows[0]["result_json"], duplicate=True)
+
+    def _command_assertion(self, key: str) -> str:
+        return f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.commands)} WHERE _id = {_literal(key, 'VARCHAR(128)')}), 'idempotency key already exists'"
+
+    def _active_assertion(self, document_id: str, revision: int) -> str:
+        return (
+            f"ASSERT EXISTS (SELECT 1 FROM {_table_name(self.documents)} WHERE "
+            f"_id = {_literal(document_id, 'VARCHAR(128)')} AND status = 'active' "
+            f"AND revision = {revision}::BIGINT), 'document revision changed'"
+        )
+
+    def _command_insert(
+        self,
+        key: str,
+        payload: str,
+        kind: str,
+        result: AccessMutationResult,
+        recorded_at: datetime,
+    ) -> str:
+        return _insert_statement(
+            self.commands,
+            {
+                "idempotency_key": key,
+                "payload_hash": payload,
+                "command_kind": kind,
+                "result_json": _access_result_json(result),
+                "recorded_at": recorded_at,
+            },
+        )
+
+    def _run(
+        self,
+        statements: Sequence[str],
+        key: str,
+        payload: str,
+        document_id: str,
+        revision: int | None,
+    ) -> AccessMutationResult | None:
+        self._ensure_tables()
+        try:
+            _execute_xtdb_transaction(self.connection, statements)
+        except Exception:
+            duplicate = self._duplicate(key, payload)
+            if duplicate:
+                return duplicate
+            if revision is not None:
+                self._active(document_id, revision)
+            raise DocumentAccessError("access command conflicts") from None
+        return None
+
+    def _ensure_tables(self) -> None:
+        for config in (self.documents, self.grants_table, self.commands):
+            if self._rows(
+                "SELECT table_name FROM information_schema.tables WHERE "
+                f"table_schema = {_literal(config.schema, 'TEXT')} AND "
+                f"table_name = {_literal(config.name, 'TEXT')}"
+            ):
+                continue
+            bootstrap_row = {
+                column.name: _bootstrap_value(column.data_type)
+                for column in config.columns
+            }
+            bootstrap_id = _document_id(config, bootstrap_row)
+            _execute_xtdb_transaction(
+                self.connection,
+                [
+                    _insert_statement(config, bootstrap_row),
+                    f"ERASE FROM {_table_name(config)} WHERE _id = {_literal(bootstrap_id, 'TEXT')}",
+                ],
+            )
+
+    def _rows(self, sql: str) -> list[Mapping[str, object]]:
+        try:
+            return [dict(row) for row in self.connection.execute(text(sql)).mappings()]
+        except Exception as exc:
+            if not _is_xtdb_table_not_found_error(exc):
+                raise
+            _rollback_xtdb_connection(self.connection)
+            return []
+
+
+def _access_document_columns(prefix: str | None = None) -> str:
+    names = (
+        "document_id",
+        "name",
+        "normalized_name",
+        "description",
+        "status",
+        "revision",
+        "created_by",
+        "created_at",
+        "archived_by",
+        "archived_at",
+    )
+    return ", ".join(f"{prefix}.{name}" if prefix else name for name in names)
+
+
+def _access_grant_columns() -> str:
+    return ", ".join(
+        (
+            "grant_id",
+            "document_id",
+            "group_name",
+            "role",
+            "granted_by",
+            "granted_at",
+            "document_revision",
+            "revoked_by",
+            "revoked_at",
+        )
+    )
+
+
+def _access_document_from_row(row: Mapping[str, object]) -> AccessDocument:
+    return AccessDocument(
+        document_id=str(row["document_id"]),
+        name=str(row["name"]),
+        normalized_name=str(row["normalized_name"]),
+        description=None if row["description"] is None else str(row["description"]),
+        status=str(row["status"]),
+        revision=int(str(row["revision"])),
+        created_by=str(row["created_by"]),
+        created_at=_datetime(row["created_at"]),
+        archived_by=None if row["archived_by"] is None else str(row["archived_by"]),
+        archived_at=None
+        if row["archived_at"] is None
+        else _datetime(row["archived_at"]),
+    )
+
+
+def _access_grant_from_row(row: Mapping[str, object]) -> AccessGrant:
+    return AccessGrant(
+        grant_id=str(row["grant_id"]),
+        document_id=str(row["document_id"]),
+        group_name=str(row["group_name"]),
+        role=str(row["role"]),
+        granted_by=str(row["granted_by"]),
+        granted_at=_datetime(row["granted_at"]),
+        document_revision=int(str(row["document_revision"])),
+        revoked_by=None if row["revoked_by"] is None else str(row["revoked_by"]),
+        revoked_at=None if row["revoked_at"] is None else _datetime(row["revoked_at"]),
+    )
+
+
+def _datetime(value: object) -> datetime:
+    return value if isinstance(value, datetime) else datetime.fromisoformat(str(value))
+
+
+def _document_row(document: AccessDocument) -> dict[str, object]:
+    return {
+        "document_id": document.document_id,
+        "name": document.name,
+        "normalized_name": document.normalized_name,
+        "description": document.description,
+        "status": document.status,
+        "revision": document.revision,
+        "created_by": document.created_by,
+        "created_at": document.created_at,
+        "archived_by": document.archived_by,
+        "archived_at": document.archived_at,
+    }
+
+
+def _grant_row(grant: AccessGrant) -> dict[str, object]:
+    return {
+        "grant_id": grant.grant_id,
+        "document_id": grant.document_id,
+        "group_name": grant.group_name,
+        "active_group_key": None
+        if grant.revoked_at is not None
+        else _active_group_key(grant.document_id, grant.group_name),
+        "role": grant.role,
+        "granted_by": grant.granted_by,
+        "granted_at": grant.granted_at,
+        "document_revision": grant.document_revision,
+        "revoked_by": grant.revoked_by,
+        "revoked_at": grant.revoked_at,
+    }
+
+
+def _new_grant(
+    document: AccessDocument,
+    grant: AccessGrantInput,
+    actor_id: str,
+    recorded_at: datetime,
+) -> AccessGrant:
+    return AccessGrant(
+        grant.grant_id,
+        document.document_id,
+        grant.group_name,
+        grant.role,
+        actor_id,
+        recorded_at,
+        document.revision,
+    )
+
+
+def _updated_document(
+    document: AccessDocument,
+    *,
+    status: str | None = None,
+    archived_by: str | None = None,
+    archived_at: datetime | None = None,
+) -> AccessDocument:
+    return replace(
+        document,
+        revision=document.revision + 1,
+        status=document.status if status is None else status,
+        archived_by=document.archived_by if archived_by is None else archived_by,
+        archived_at=document.archived_at if archived_at is None else archived_at,
+    )
+
+
+def _active_group_key(document_id: str, group_name: str) -> str:
+    return f"{document_id}:{group_name.casefold()}"
+
+
+def _access_update(
+    config: TableConfig, document_id: str, values: Mapping[str, object]
+) -> str:
+    columns = {column.name: column.data_type for column in config.columns}
+    assignments = ", ".join(
+        f"{_xtdb_column_identifier(name)} = {_literal(value, columns[name])}"
+        for name, value in values.items()
+    )
+    return (
+        f"UPDATE {_table_name(config)} SET {assignments} WHERE "
+        f"_id = {_literal(document_id, 'VARCHAR(128)')}"
+    )
+
+
+def _access_result_json(result: AccessMutationResult) -> dict[str, object]:
+    return {
+        "document": {
+            name: _json_value(value)
+            for name, value in _document_row(result.document).items()
+        },
+        "grants": [
+            {
+                name: _json_value(value)
+                for name, value in _grant_row(grant).items()
+                if name != "active_group_key"
+            }
+            for grant in result.grants
+        ],
+    }
+
+
+def _json_value(value: object) -> object:
+    return value.isoformat() if isinstance(value, datetime) else value
+
+
+def _access_result_from_json(value: object, *, duplicate: bool) -> AccessMutationResult:
+    parsed = json.loads(value) if isinstance(value, str) else value
+    if not isinstance(parsed, Mapping):
+        raise ValueError("stored access command result is invalid")
+    document = _access_document_from_row(parsed["document"])
+    grants = tuple(_access_grant_from_row(grant) for grant in parsed["grants"])
+    return AccessMutationResult(document, grants, accepted=False, duplicate=duplicate)
 
 
 def _insert_statement(

--- a/tests/overrides/test_document_access_store.py
+++ b/tests/overrides/test_document_access_store.py
@@ -40,6 +40,7 @@ def test_lifecycle_is_versioned_and_preserves_grant_history():
 
     assert created.document.revision == 1
     assert revoked.document.revision == 2
+    assert revoked.grants[0].active is False
     assert granted.document.revision == 3
     assert archived.document.status == "archived"
     assert archived.document.revision == 4

--- a/tests/overrides/test_document_access_store.py
+++ b/tests/overrides/test_document_access_store.py
@@ -1,0 +1,73 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from polars_hist_db.overrides import (
+    AccessGrantInput,
+    DocumentArchived,
+    DocumentRevisionConflict,
+    IdempotencyConflict,
+    InMemoryDocumentAccessStore,
+)
+
+
+TIME = datetime(2026, 7, 13, 12, tzinfo=timezone.utc)
+
+
+def test_lifecycle_is_versioned_and_preserves_grant_history():
+    store = InMemoryDocumentAccessStore()
+    created = store.create(
+        "doc-1",
+        "Analysts",
+        None,
+        "admin",
+        TIME,
+        initial_grants=[AccessGrantInput("grant-1", "analysts", "editor")],
+        idempotency_key="create-1",
+    )
+    revoked = store.revoke(
+        "doc-1", "analysts", "admin", TIME, 1, idempotency_key="revoke-1"
+    )
+    granted = store.grant(
+        "doc-1",
+        AccessGrantInput("grant-2", "analysts", "resolver"),
+        "admin",
+        TIME,
+        2,
+        idempotency_key="grant-2",
+    )
+    archived = store.archive("doc-1", "admin", TIME, 3, idempotency_key="archive-1")
+
+    assert created.document.revision == 1
+    assert revoked.document.revision == 2
+    assert granted.document.revision == 3
+    assert archived.document.status == "archived"
+    assert archived.document.revision == 4
+    assert len(store.grants("doc-1", include_revoked=True)) == 2
+    assert store.grants("doc-1")[0].role == "resolver"
+    with pytest.raises(DocumentArchived):
+        store.grant(
+            "doc-1",
+            AccessGrantInput("grant-3", "reviewers", "viewer"),
+            "admin",
+            TIME,
+            4,
+            idempotency_key="grant-3",
+        )
+
+
+def test_idempotency_and_revision_conflicts_are_explicit():
+    store = InMemoryDocumentAccessStore()
+    accepted = store.create(
+        "doc-1", "Analysts", None, "admin", TIME, idempotency_key="create-1"
+    )
+    duplicate = store.create(
+        "doc-1", "Analysts", None, "admin", TIME, idempotency_key="create-1"
+    )
+
+    assert accepted.accepted
+    assert duplicate.duplicate
+    with pytest.raises(IdempotencyConflict):
+        store.create("doc-2", "Other", None, "admin", TIME, idempotency_key="create-1")
+    with pytest.raises(DocumentRevisionConflict):
+        store.archive("doc-1", "admin", TIME, 2, idempotency_key="archive-1")

--- a/tests/overrides/test_xtdb_document_access_store.py
+++ b/tests/overrides/test_xtdb_document_access_store.py
@@ -1,0 +1,48 @@
+from datetime import datetime, timezone
+
+from polars_hist_db.overrides import (
+    AccessGrantInput,
+    DocumentAccessStoreConfig,
+    XtdbDocumentAccessStore,
+)
+
+
+def test_xtdb_access_create_submits_one_asserted_transaction(monkeypatch):
+    statements: list[str] = []
+    store = XtdbDocumentAccessStore(object(), DocumentAccessStoreConfig())
+    monkeypatch.setattr(store, "_duplicate", lambda *_: None)
+    monkeypatch.setattr(store, "_ensure_tables", lambda: None)
+    monkeypatch.setattr(
+        "polars_hist_db.overrides.xtdb._execute_xtdb_transaction",
+        lambda _, transaction: statements.extend(transaction),
+    )
+
+    result = store.create(
+        "document-1",
+        "Shared corrections",
+        None,
+        "user-1",
+        datetime(2026, 7, 12, 11, tzinfo=timezone.utc),
+        initial_grants=(AccessGrantInput("grant-1", "operators", "editor"),),
+        idempotency_key="command-1",
+    )
+
+    assert result.accepted is True
+    assert result.document.revision == 1
+    assert statements[0].startswith("ASSERT NOT EXISTS")
+    assert any("INSERT INTO overrides.document_access" in item for item in statements)
+    assert any(
+        "INSERT INTO overrides.document_access_grants" in item for item in statements
+    )
+    assert any(
+        "INSERT INTO overrides.document_access_commands" in item for item in statements
+    )
+
+
+def test_xtdb_access_guard_uses_active_revision():
+    store = XtdbDocumentAccessStore(object(), DocumentAccessStoreConfig())
+
+    guard = store.guard("document-1", 3)
+
+    assert guard.key_values == {"document_id": "document-1"}
+    assert guard.expected_values == {"status": "active", "revision": 3}

--- a/tests/sql/test_document_access_store.py
+++ b/tests/sql/test_document_access_store.py
@@ -1,0 +1,84 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from polars_hist_db.core import TableConfigOps
+from polars_hist_db.overrides import (
+    AccessGrantInput,
+    DocumentAccessStoreConfig,
+    DocumentArchived,
+    MariaDbDocumentAccessStore,
+    build_document_access_table_configs,
+)
+
+from ..utils.dsv_helper import mariadb_engine_test
+
+
+pytestmark = pytest.mark.integration
+
+
+def test_mariadb_access_store_persists_lifecycle_and_idempotency():
+    config = DocumentAccessStoreConfig(
+        schema="test",
+        documents_table="access_documents_store_test",
+        grants_table="access_grants_store_test",
+        commands_table="access_commands_store_test",
+    )
+    tables = build_document_access_table_configs(config)
+    now = datetime(2026, 7, 12, 11, tzinfo=timezone.utc)
+    engine = mariadb_engine_test()
+    with engine.begin() as connection:
+        table_ops = TableConfigOps(connection)
+        for table in reversed(tables):
+            table_ops.drop(table)
+        try:
+            for table in tables:
+                table_ops.create(table)
+            store = MariaDbDocumentAccessStore(connection, config)
+            created = store.create(
+                "document-1",
+                "Shared corrections",
+                None,
+                "user-1",
+                now,
+                initial_grants=(AccessGrantInput("grant-1", "operators", "editor"),),
+                idempotency_key="command-1",
+            )
+            duplicate = store.create(
+                "document-1",
+                "Shared corrections",
+                None,
+                "user-1",
+                now,
+                initial_grants=(AccessGrantInput("grant-1", "operators", "editor"),),
+                idempotency_key="command-1",
+            )
+            revoked = store.revoke(
+                "document-1",
+                "operators",
+                "user-1",
+                now,
+                1,
+                idempotency_key="command-2",
+            )
+            archived = store.archive(
+                "document-1", "user-1", now, 2, idempotency_key="command-3"
+            )
+
+            assert created.document.revision == 1
+            assert duplicate.duplicate is True
+            assert duplicate.document.created_at == now
+            assert revoked.grants[0].active is False
+            assert archived.document.status == "archived"
+            with pytest.raises(DocumentArchived):
+                store.grant(
+                    "document-1",
+                    AccessGrantInput("grant-2", "operators", "editor"),
+                    "user-1",
+                    now,
+                    3,
+                    idempotency_key="command-4",
+                )
+        finally:
+            for table in reversed(tables):
+                table_ops.drop(table)

--- a/uv.lock
+++ b/uv.lock
@@ -1483,7 +1483,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1529,7 +1529,7 @@ sqlalchemy = [
 
 [[package]]
 name = "polars-hist-db"
-version = "0.12.37"
+version = "0.12.38"
 source = { editable = "." }
 dependencies = [
     { name = "nats-py" },


### PR DESCRIPTION
Summary:
- Add a backend-neutral document access contract with revisions, grants, archive lifecycle, idempotency, and CRDT row guards.
- Implement it for MariaDB and XTDB, using asserted XTDB transactions and MariaDB row locking.
- Add in-memory, XTDB transaction-shape, and MariaDB integration coverage.

Verification:
- Ruff and mypy pass for the changed modules.
- The overrides suite passes: 26 tests.
- The MariaDB integration test is included but could not run locally because Docker is unavailable; CI will exercise it.