### PR TITLE
fix: expose guard on in-memory document access store

### DIFF
--- a/polars_hist_db/overrides/access.py
+++ b/polars_hist_db/overrides/access.py
@@ -6,6 +6,10 @@ from hashlib import sha256
 import json
 from typing import Iterable
 
+from .config import build_document_access_table_configs
+from .crdt import RowGuard
+from .types import DocumentAccessStoreConfig
+
 
 class DocumentAccessError(ValueError):
     pass
@@ -120,6 +124,13 @@ class InMemoryDocumentAccessStore:
 
     def get(self, document_id: str) -> AccessDocument | None:
         return self._documents.get(document_id)
+
+    def guard(self, document_id: str, expected_revision: int) -> RowGuard:
+        return RowGuard(
+            build_document_access_table_configs(DocumentAccessStoreConfig())[0],
+            {"document_id": document_id},
+            {"status": "active", "revision": expected_revision},
+        )
 
     def list_for_groups(
         self, groups: Iterable[str], *, include_archived: bool = False

--- a/tests/overrides/test_document_access_store.py
+++ b/tests/overrides/test_document_access_store.py
@@ -72,3 +72,10 @@ def test_idempotency_and_revision_conflicts_are_explicit():
         store.create("doc-2", "Other", None, "admin", TIME, idempotency_key="create-1")
     with pytest.raises(DocumentRevisionConflict):
         store.archive("doc-1", "admin", TIME, 2, idempotency_key="archive-1")
+
+
+def test_guard_matches_the_portable_active_revision_contract():
+    guard = InMemoryDocumentAccessStore().guard("doc-1", 4)
+
+    assert guard.key_values == {"document_id": "doc-1"}
+    assert guard.expected_values == {"status": "active", "revision": 4}


### PR DESCRIPTION
## Summary
- expose the same active-document revision guard from the in-memory access store as MariaDB and XTDB stores
- cover the portable guard shape with a focused unit test

## Validation
- uv run pytest tests/overrides/test_document_access_store.py
- uv run mypy polars_hist_db/overrides/access.py