### PR TITLE
feat: add persistent CRDT state-vector diffs

### DIFF
--- a/polars_hist_db/overrides/sql.py
+++ b/polars_hist_db/overrides/sql.py
@@ -102,6 +102,14 @@ class MariaDbCrdtDocumentStore:
             update=document.get_update(),
         )
 
+    def diff(self, document_id: str, state_vector: bytes) -> bytes:
+        document = self.load_document(document_id)
+        if document is None:
+            raise KeyError(f"unknown CRDT document: {document_id}")
+        current = _doc()
+        current.apply_update(document.update)
+        return current.get_update(state_vector)
+
     def commit(
         self,
         prepared: PreparedCrdtCommit,

--- a/polars_hist_db/overrides/xtdb.py
+++ b/polars_hist_db/overrides/xtdb.py
@@ -100,6 +100,14 @@ class XtdbCrdtDocumentStore:
             update=document.get_update(),
         )
 
+    def diff(self, document_id: str, state_vector: bytes) -> bytes:
+        document = self.load_document(document_id)
+        if document is None:
+            raise KeyError(f"unknown CRDT document: {document_id}")
+        current = _doc()
+        current.apply_update(document.update)
+        return current.get_update(state_vector)
+
     def commit(
         self,
         prepared: PreparedCrdtCommit,

--- a/tests/overrides/test_crdt_document_store.py
+++ b/tests/overrides/test_crdt_document_store.py
@@ -13,6 +13,8 @@ from polars_hist_db.overrides import (
     CrdtRevisionConflict,
     InMemoryCrdtDocumentStore,
     RowGuard,
+    CrdtDocument,
+    MariaDbCrdtDocumentStore,
     prepare_crdt_update,
 )
 
@@ -57,6 +59,24 @@ def test_document_store_merges_offline_updates_and_rebuilds_from_snapshot():
         caught_up.get("drafts", type=Map).to_py()
         == rebuilt.get("drafts", type=Map).to_py()
     )
+
+
+def test_mariadb_store_diff_uses_current_document(monkeypatch):
+    source = Doc()
+    source["drafts"] = Map({"title": "Current"})
+    store = object.__new__(MariaDbCrdtDocumentStore)
+    monkeypatch.setattr(
+        store,
+        "load_document",
+        lambda _: CrdtDocument(
+            "document-1", 1, source.get_state(), source.get_update()
+        ),
+    )
+
+    caught_up = Doc()
+    caught_up.apply_update(store.diff("document-1", b"\x00"))
+
+    assert caught_up.get("drafts", type=Map).to_py() == {"title": "Current"}
 
 
 def test_document_store_deduplicates_exact_updates_and_checks_revisions():

--- a/tests/overrides/test_xtdb_crdt_document_store.py
+++ b/tests/overrides/test_xtdb_crdt_document_store.py
@@ -89,3 +89,23 @@ def test_xtdb_store_bootstraps_every_configured_column(monkeypatch):
     assert "document_id" in statements[0][0]
     assert "head_state_vector_base64" in statements[0][0]
     assert statements[0][1].startswith("ERASE FROM overrides.crdt_documents")
+
+
+def test_xtdb_store_diff_uses_current_document(monkeypatch):
+    source = Doc()
+    source["drafts"] = Map({"title": "Current"})
+    store = XtdbCrdtDocumentStore(
+        object(), CrdtDocumentStoreConfig(), OverrideLedgerConfig()
+    )
+    monkeypatch.setattr(
+        store,
+        "load_document",
+        lambda _: CrdtDocument(
+            "document-1", 1, source.get_state(), source.get_update()
+        ),
+    )
+
+    caught_up = Doc()
+    caught_up.apply_update(store.diff("document-1", b"\x00"))
+
+    assert caught_up.get("drafts", type=Map).to_py() == {"title": "Current"}

--- a/tests/sql/test_crdt_document_store.py
+++ b/tests/sql/test_crdt_document_store.py
@@ -81,6 +81,8 @@ def test_mariadb_crdt_store_persists_prepared_commit_and_projection():
 
             accepted = store.commit(prepared)
             duplicate = store.commit(prepared)
+            caught_up = Doc()
+            caught_up.apply_update(store.diff("document-1", b"\x00"))
             conflicting = prepare_crdt_update(
                 "document-2",
                 None,
@@ -101,6 +103,9 @@ def test_mariadb_crdt_store_persists_prepared_commit_and_projection():
 
             assert accepted.accepted is True
             assert accepted.revision == 1
+            assert (
+                caught_up.get_state() == store.load_document("document-1").state_vector
+            )
             assert duplicate.accepted is False
             assert duplicate.duplicate is True
             assert duplicate.revision == 1


### PR DESCRIPTION
Adds the documented diff(document_id, state_vector) contract to MariaDB and XTDB CRDT stores.\n\nTests cover reconstructed document diffs for both adapters.