### PR TITLE
feat(overrides): add operations, composition, and purge contracts

### DIFF
--- a/polars_hist_db/backends/mariadb.py
+++ b/polars_hist_db/backends/mariadb.py
@@ -16,9 +16,11 @@ if TYPE_CHECKING:
     from ..overrides import (
         CrdtDocumentStoreConfig,
         DocumentAccessStoreConfig,
+        LayerCompositionStoreConfig,
         OverrideLedgerConfig,
     )
     from ..overrides.sql import MariaDbDocumentAccessStore
+    from ..overrides.sql import MariaDbLayerCompositionStore
     from ..overrides.sql import MariaDbCrdtDocumentStore
 
 
@@ -63,6 +65,13 @@ class MariaDbBackend:
         from ..overrides.sql import MariaDbDocumentAccessStore
 
         return MariaDbDocumentAccessStore(connection, config)
+
+    def layer_compositions(
+        self, connection: Any, config: "LayerCompositionStoreConfig"
+    ) -> "MariaDbLayerCompositionStore":
+        from ..overrides.sql import MariaDbLayerCompositionStore
+
+        return MariaDbLayerCompositionStore(connection, config)
 
     def tables(self, table_schema: str, table_name: str, connection: Any) -> TableOps:
         return TableOps(table_schema, table_name, connection)

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -32,9 +32,11 @@ if TYPE_CHECKING:
     from ..overrides import (
         CrdtDocumentStoreConfig,
         DocumentAccessStoreConfig,
+        LayerCompositionStoreConfig,
         OverrideLedgerConfig,
     )
     from ..overrides.xtdb import XtdbDocumentAccessStore
+    from ..overrides.xtdb import XtdbLayerCompositionStore
     from ..overrides.xtdb import XtdbCrdtDocumentStore
 
 LOGGER = logging.getLogger(__name__)
@@ -2226,6 +2228,13 @@ class XtdbBackend:
         from ..overrides.xtdb import XtdbDocumentAccessStore
 
         return XtdbDocumentAccessStore(connection, config)
+
+    def layer_compositions(
+        self, connection: Any, config: "LayerCompositionStoreConfig"
+    ) -> "XtdbLayerCompositionStore":
+        from ..overrides.xtdb import XtdbLayerCompositionStore
+
+        return XtdbLayerCompositionStore(connection, config)
 
     def staging(
         self,

--- a/polars_hist_db/overrides/__init__.py
+++ b/polars_hist_db/overrides/__init__.py
@@ -2,6 +2,8 @@ from .config import (
     build_crdt_document_table_config,
     build_crdt_update_table_config,
     build_document_access_table_configs,
+    build_layer_composition_table_config,
+    build_override_purge_table_config,
     build_override_table_config,
     build_override_valid_time_config,
     migrate_override_owner_nullable,
@@ -18,6 +20,8 @@ from .crdt import (
     PreparedCrdtCommit,
     RowGuard,
     prepare_crdt_update,
+    operation_source_update,
+    prepare_crdt_generation,
 )
 from .ledger import InMemoryOverrideLedgerStore, OverrideLedger
 from .access import (
@@ -32,8 +36,17 @@ from .access import (
     IdempotencyConflict,
     InMemoryDocumentAccessStore,
 )
-from .sql import MariaDbCrdtDocumentStore, MariaDbDocumentAccessStore
-from .xtdb import XtdbCrdtDocumentStore, XtdbDocumentAccessStore
+from .sql import (
+    MariaDbCrdtDocumentStore,
+    MariaDbDocumentAccessStore,
+    MariaDbLayerCompositionStore,
+)
+from .xtdb import (
+    XtdbCrdtDocumentStore,
+    XtdbDocumentAccessStore,
+    XtdbLayerCompositionStore,
+)
+from .composition import InMemoryLayerCompositionStore, LayerCompositionStore
 from .replicated import (
     InMemoryReplicatedOverrideLedger,
     OverrideFrontier,
@@ -47,10 +60,25 @@ from .replicated import (
 from .types import (
     CrdtDocumentStoreConfig,
     DocumentAccessStoreConfig,
+    LayerCompositionStoreConfig,
     OverrideLedgerConfig,
     OverrideOperation,
     OverrideOperationType,
     OverrideTypedValue,
+    OverridePurgeStoreConfig,
+)
+from .operations import (
+    CompositionRevision,
+    CorrectionPreview,
+    CorrectionProposal,
+    EffectiveFieldProjection,
+    InMemoryOverrideOperationsStore,
+    OperationPage,
+    OperationQuery,
+    OverrideLayer,
+    OverrideOperationsStore,
+    PurgePreview,
+    PurgeResult,
 )
 
 __all__ = [
@@ -61,6 +89,10 @@ __all__ = [
     "MariaDbDocumentAccessStore",
     "XtdbCrdtDocumentStore",
     "XtdbDocumentAccessStore",
+    "MariaDbLayerCompositionStore",
+    "XtdbLayerCompositionStore",
+    "InMemoryLayerCompositionStore",
+    "LayerCompositionStore",
     "AtomicInsert",
     "AtomicUpdate",
     "InMemoryReplicatedOverrideLedger",
@@ -85,9 +117,13 @@ __all__ = [
     "CrdtRevisionConflict",
     "CrdtDocumentStoreConfig",
     "DocumentAccessStoreConfig",
+    "LayerCompositionStoreConfig",
+    "OverridePurgeStoreConfig",
     "build_crdt_document_table_config",
     "build_crdt_update_table_config",
     "build_document_access_table_configs",
+    "build_layer_composition_table_config",
+    "build_override_purge_table_config",
     "OverrideFrontier",
     "PreparedCrdtCommit",
     "ReplicatedOverrideAppendResult",
@@ -99,6 +135,19 @@ __all__ = [
     "operation_payload_hash",
     "project_replicated_override_operations",
     "prepare_crdt_update",
+    "operation_source_update",
+    "prepare_crdt_generation",
     "RowGuard",
     "validate_replicated_override_operation",
+    "CompositionRevision",
+    "CorrectionPreview",
+    "CorrectionProposal",
+    "EffectiveFieldProjection",
+    "InMemoryOverrideOperationsStore",
+    "OperationPage",
+    "OperationQuery",
+    "OverrideLayer",
+    "OverrideOperationsStore",
+    "PurgePreview",
+    "PurgeResult",
 ]

--- a/polars_hist_db/overrides/access.py
+++ b/polars_hist_db/overrides/access.py
@@ -43,6 +43,8 @@ class AccessDocument:
     created_at: datetime
     archived_by: str | None = None
     archived_at: datetime | None = None
+    owning_group: str | None = None
+    generation: int = 1
 
 
 @dataclass(frozen=True)
@@ -93,9 +95,12 @@ class InMemoryDocumentAccessStore:
         *,
         initial_grants: Iterable[AccessGrantInput] = (),
         idempotency_key: str,
+        owning_group: str | None = None,
     ) -> AccessMutationResult:
         grants = tuple(initial_grants)
-        payload = _payload("create", document_id, name, description, actor_id, grants)
+        payload = _payload(
+            "create", document_id, name, description, actor_id, grants, owning_group
+        )
         duplicate = self._duplicate(idempotency_key, payload)
         if duplicate is not None:
             return duplicate
@@ -116,6 +121,7 @@ class InMemoryDocumentAccessStore:
             1,
             actor_id,
             recorded_at,
+            owning_group=owning_group,
         )
         self._documents[document_id] = document
         for grant in grants:
@@ -131,6 +137,19 @@ class InMemoryDocumentAccessStore:
             {"document_id": document_id},
             {"status": "active", "revision": expected_revision},
         )
+
+    def begin_purge(self, document_id: str, expected_generation: int) -> AccessDocument:
+        document = self._documents.get(document_id)
+        if document is None:
+            raise DocumentNotFound("document not found")
+        if document.generation != expected_generation or document.status not in {
+            "active",
+            "purging",
+        }:
+            raise DocumentRevisionConflict("document generation changed")
+        updated = replace(document, status="purging")
+        self._documents[document_id] = updated
+        return updated
 
     def list_for_groups(
         self, groups: Iterable[str], *, include_archived: bool = False

--- a/polars_hist_db/overrides/composition.py
+++ b/polars_hist_db/overrides/composition.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from .operations import CompositionRevision
+
+
+class LayerCompositionStore(Protocol):
+    def append(self, revision: CompositionRevision, actor_id: str) -> None: ...
+
+    def revisions(
+        self, layer_id: str | None = None
+    ) -> tuple[CompositionRevision, ...]: ...
+
+
+class InMemoryLayerCompositionStore:
+    def __init__(self) -> None:
+        self._revisions: list[CompositionRevision] = []
+
+    def append(self, revision: CompositionRevision, actor_id: str) -> None:
+        del actor_id
+        if any(item.revision_id == revision.revision_id for item in self._revisions):
+            raise ValueError("composition revision already exists")
+        self._revisions.append(revision)
+
+    def revisions(self, layer_id: str | None = None) -> tuple[CompositionRevision, ...]:
+        return tuple(
+            item
+            for item in sorted(
+                self._revisions,
+                key=lambda value: (value.recorded_at, value.revision_id),
+            )
+            if layer_id is None or item.layer_id == layer_id
+        )

--- a/polars_hist_db/overrides/config.py
+++ b/polars_hist_db/overrides/config.py
@@ -8,8 +8,54 @@ from polars_hist_db.config import TableColumnConfig, TableConfig, ValidTimeConfi
 from .types import (
     CrdtDocumentStoreConfig,
     DocumentAccessStoreConfig,
+    LayerCompositionStoreConfig,
     OverrideLedgerConfig,
+    OverridePurgeStoreConfig,
 )
+
+
+def build_layer_composition_table_config(
+    config: LayerCompositionStoreConfig,
+) -> TableConfig:
+    table = config.revisions_table
+    return TableConfig(
+        name=table,
+        schema=config.schema,
+        primary_keys=("revision_id",),
+        columns=[
+            TableColumnConfig(table, "revision_id", "VARCHAR(128)", nullable=False),
+            TableColumnConfig(table, "layer_id", "VARCHAR(128)", nullable=False),
+            TableColumnConfig(table, "child_layer_ids_json", "JSON", nullable=False),
+            TableColumnConfig(table, "valid_from", "DATETIME(6)", nullable=False),
+            TableColumnConfig(table, "valid_to", "DATETIME(6)"),
+            TableColumnConfig(table, "recorded_at", "DATETIME(6)", nullable=False),
+            TableColumnConfig(table, "actor_id", "VARCHAR(128)", nullable=False),
+            TableColumnConfig(table, "supersedes_revision_id", "VARCHAR(128)"),
+        ],
+    )
+
+
+def build_override_purge_table_config(config: OverridePurgeStoreConfig) -> TableConfig:
+    table = config.metadata_table
+    return TableConfig(
+        name=table,
+        schema=config.schema,
+        primary_keys=("request_id",),
+        columns=[
+            TableColumnConfig(table, "request_id", "VARCHAR(128)", nullable=False),
+            TableColumnConfig(table, "document_id", "VARCHAR(128)", nullable=False),
+            TableColumnConfig(table, "layer_id", "VARCHAR(128)", nullable=False),
+            TableColumnConfig(table, "actor_id", "VARCHAR(128)", nullable=False),
+            TableColumnConfig(table, "reason", "VARCHAR(2048)", nullable=False),
+            TableColumnConfig(table, "old_generation", "BIGINT", nullable=False),
+            TableColumnConfig(table, "generation", "BIGINT", nullable=False),
+            TableColumnConfig(table, "erased_count", "BIGINT", nullable=False),
+            TableColumnConfig(table, "rebuilt_count", "BIGINT", nullable=False),
+            TableColumnConfig(table, "tombstone_count", "BIGINT", nullable=False),
+            TableColumnConfig(table, "status", "VARCHAR(32)", nullable=False),
+            TableColumnConfig(table, "completed_at", "DATETIME(6)", nullable=False),
+        ],
+    )
 
 
 def build_document_access_table_configs(
@@ -45,6 +91,14 @@ def build_document_access_table_configs(
             ),
             TableColumnConfig(
                 config.documents_table, "created_at", "DATETIME(6)", nullable=False
+            ),
+            TableColumnConfig(config.documents_table, "owning_group", "VARCHAR(255)"),
+            TableColumnConfig(
+                config.documents_table,
+                "generation",
+                "BIGINT",
+                default_value="1",
+                nullable=False,
             ),
             TableColumnConfig(config.documents_table, "archived_by", "VARCHAR(128)"),
             TableColumnConfig(config.documents_table, "archived_at", "DATETIME(6)"),
@@ -126,6 +180,9 @@ def build_crdt_document_table_config(config: CrdtDocumentStoreConfig) -> TableCo
                 unique_constraint=["document_source_update_hash"],
             ),
             TableColumnConfig(table, "revision", "BIGINT", nullable=False),
+            TableColumnConfig(
+                table, "generation", "BIGINT", default_value="1", nullable=False
+            ),
             TableColumnConfig(table, "head_state_vector_base64", "MEDIUMTEXT"),
             TableColumnConfig(table, "snapshot_update_base64", "MEDIUMTEXT"),
             TableColumnConfig(table, "snapshot_update_hash", "VARCHAR(64)"),
@@ -151,6 +208,9 @@ def build_crdt_update_table_config(config: CrdtDocumentStoreConfig) -> TableConf
                 unique_constraint=["document_source_update_hash"],
             ),
             TableColumnConfig(table, "revision", "BIGINT", nullable=False),
+            TableColumnConfig(
+                table, "generation", "BIGINT", default_value="1", nullable=False
+            ),
             TableColumnConfig(
                 table,
                 "source_update_hash",
@@ -208,12 +268,16 @@ def build_override_table_config(config: OverrideLedgerConfig) -> TableConfig:
             TableColumnConfig(table, "format_version", "INT"),
             TableColumnConfig(table, "layer_id", "VARCHAR(128)"),
             TableColumnConfig(table, "actor_id", "VARCHAR(128)"),
+            TableColumnConfig(table, "actor_display_name", "VARCHAR(255)"),
             TableColumnConfig(table, "supersedes_operation_ids_json", "JSON"),
             TableColumnConfig(table, "removes_operation_ids_json", "JSON"),
             TableColumnConfig(table, "recorded_at", "DATETIME(6)"),
             TableColumnConfig(table, "payload_hash", "VARCHAR(64)"),
             TableColumnConfig(table, "crdt_document_id", "VARCHAR(128)"),
             TableColumnConfig(table, "crdt_document_revision", "BIGINT"),
+            TableColumnConfig(
+                table, "generation", "BIGINT", default_value="1", nullable=False
+            ),
         ],
     )
 

--- a/polars_hist_db/overrides/crdt.py
+++ b/polars_hist_db/overrides/crdt.py
@@ -34,6 +34,7 @@ class PreparedCrdtCommit:
     state_vector: bytes
     operations: tuple[ReplicatedOverrideOperation, ...]
     is_noop: bool = False
+    generation: int = 1
 
 
 @dataclass(frozen=True)
@@ -85,6 +86,7 @@ def prepare_crdt_update(
     *,
     actor_id: str,
     recorded_at: datetime,
+    authoritative_metadata: Mapping[str, object] | None = None,
 ) -> PreparedCrdtCommit:
     document = _doc()
     base_revision = 0
@@ -137,6 +139,14 @@ def prepare_crdt_update(
     known_operations = list(before.values())
     for operation_id in sorted(after.keys() - before.keys()):
         operation = after[operation_id]
+        if authoritative_metadata:
+            operation = replace(
+                operation,
+                metadata_json={
+                    **(operation.metadata_json or {}),
+                    **authoritative_metadata,
+                },
+            )
         validate_replicated_override_operation(operation, known_operations)
         finalized = finalize_replicated_override_operation(operation)
         new_operations.append(finalized)
@@ -154,6 +164,47 @@ def prepare_crdt_update(
         accepted_update_hash=_hash(accepted_update),
         state_vector=document.get_state(),
         operations=tuple(new_operations),
+    )
+
+
+def operation_source_update(operation: ReplicatedOverrideOperation) -> bytes:
+    """Encode one provisional operation for the normal authoritative commit path."""
+    document = _doc()
+    operations = _operations_map(document, create=True)
+    assert operations is not None
+    operations[operation.operation_id] = {
+        key: value
+        for key, value in _operation_to_yjs(operation).items()
+        if key not in {"actor_id", "recorded_at", "payload_hash"}
+    }
+    return document.get_update()
+
+
+def prepare_crdt_generation(
+    document_id: str,
+    operations: Sequence[ReplicatedOverrideOperation],
+    *,
+    generation: int,
+) -> PreparedCrdtCommit:
+    """Build a sanitized replacement generation after the prior one is erased."""
+    document = _doc()
+    operations_map = _operations_map(document, create=True)
+    assert operations_map is not None
+    finalized = tuple(
+        finalize_replicated_override_operation(item) for item in operations
+    )
+    for operation in finalized:
+        operations_map[operation.operation_id] = _operation_to_yjs(operation)
+    update = document.get_update()
+    return PreparedCrdtCommit(
+        document_id=document_id,
+        base_revision=0,
+        source_update_hash=_hash(update),
+        accepted_update=update,
+        accepted_update_hash=_hash(update),
+        state_vector=document.get_state(),
+        operations=finalized,
+        generation=generation,
     )
 
 

--- a/polars_hist_db/overrides/ledger.py
+++ b/polars_hist_db/overrides/ledger.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Protocol
 from uuid import uuid4
 
@@ -222,6 +222,18 @@ class OverrideLedger:
             reason=reason,
             comment=comment,
             metadata_json=metadata_json,
+            recorded_at=datetime.now(timezone.utc),
+            actor_display_name=(
+                str(metadata_json["actor_display_name"])
+                if metadata_json.get("actor_display_name")
+                else None
+            ),
+            document_id=(
+                str(metadata_json["document_id"])
+                if metadata_json.get("document_id")
+                else None
+            ),
+            generation=int(str(metadata_json.get("generation", 1))),
         )
 
     @staticmethod

--- a/polars_hist_db/overrides/operations.py
+++ b/polars_hist_db/overrides/operations.py
@@ -1,0 +1,766 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta, timezone
+from hashlib import sha256
+import json
+from typing import Iterable, Literal, Protocol
+from uuid import uuid4
+
+from .replicated import (
+    OverrideFrontier,
+    ReplicatedOverrideOperation,
+    finalize_replicated_override_operation,
+    project_replicated_override_operations,
+)
+from .types import OverrideTypedValue
+
+OverrideView = Literal["active", "upcoming", "history"]
+
+
+@dataclass(frozen=True)
+class OperationQuery:
+    layer_id: str | None = None
+    entity_id: str | None = None
+    field_path: str | None = None
+    actor_id: str | None = None
+    operation_types: frozenset[str] = frozenset()
+    valid_at: datetime | None = None
+    known_at: datetime | None = None
+    recorded_from: datetime | None = None
+    recorded_to: datetime | None = None
+    source_drift: bool | None = None
+    view: OverrideView = "active"
+    cursor: str | None = None
+    limit: int = 100
+
+
+@dataclass(frozen=True)
+class OperationPage:
+    operations: tuple[ReplicatedOverrideOperation, ...]
+    next_cursor: str | None
+
+
+@dataclass(frozen=True)
+class OverrideLayer:
+    layer_id: str
+    owning_group: str
+    document_id: str
+    generation: int = 1
+
+
+@dataclass(frozen=True)
+class CompositionRevision:
+    revision_id: str
+    layer_id: str
+    child_layer_ids: tuple[str, ...]
+    valid_from: datetime
+    valid_to: datetime | None
+    recorded_at: datetime
+    supersedes_revision_id: str | None = None
+
+
+@dataclass(frozen=True)
+class EffectiveFieldProjection:
+    field_path: str
+    frontier: OverrideFrontier
+    winning_layer_id: str
+    precedence_path: tuple[str, ...]
+    shadowed: tuple[tuple[str, OverrideFrontier], ...]
+
+
+@dataclass(frozen=True)
+class CorrectionProposal:
+    target_operation_id: str
+    actor_id: str
+    value: OverrideTypedValue | None
+    valid_from: datetime
+    valid_to: datetime | None
+    comment: str | None = None
+
+
+@dataclass(frozen=True)
+class CorrectionPreview:
+    changed_intervals: tuple[tuple[datetime, datetime | None], ...]
+    superseded_operation_ids: tuple[str, ...]
+    canonical_gaps_introduced: tuple[tuple[datetime, datetime | None], ...]
+    canonical_gaps_removed: tuple[tuple[datetime, datetime | None], ...]
+    conflicts_created: int
+    conflicts_resolved: int
+    frontier_token: str
+    expires_at: datetime
+
+
+@dataclass(frozen=True)
+class PurgePreview:
+    document_id: str
+    generation: int
+    operation_count: int
+    token: str
+    expires_at: datetime
+
+
+@dataclass(frozen=True)
+class PurgeResult:
+    document_id: str
+    old_generation: int
+    generation: int
+    erased_count: int
+    rebuilt_count: int
+    tombstone_count: int
+    completed_at: datetime
+
+
+class OverrideOperationsStore(Protocol):
+    def query(self, query: OperationQuery) -> OperationPage: ...
+
+    def project(
+        self,
+        layer_id: str,
+        valid_at: datetime,
+        known_at: datetime,
+        *,
+        feed_id: str | None = None,
+        entity_id: str | None = None,
+    ) -> dict[str, EffectiveFieldProjection]: ...
+
+
+class InMemoryOverrideOperationsStore:
+    """Reference implementation used to keep backend implementations equivalent."""
+
+    def __init__(self) -> None:
+        self._operations: dict[str, ReplicatedOverrideOperation] = {}
+        self._layers: dict[str, OverrideLayer] = {}
+        self._compositions: list[CompositionRevision] = []
+        self._purge_metadata: list[dict[str, object]] = []
+
+    def create_layer(
+        self,
+        layer_id: str,
+        owning_group: str,
+        document_id: str | None = None,
+        generation: int = 1,
+    ) -> OverrideLayer:
+        if not layer_id or not owning_group:
+            raise ValueError("layer_id and owning_group are required")
+        if layer_id in self._layers:
+            raise ValueError("layer already exists")
+        layer = OverrideLayer(
+            layer_id, owning_group, document_id or layer_id, generation
+        )
+        self._layers[layer_id] = layer
+        return layer
+
+    def append(self, operation: ReplicatedOverrideOperation) -> None:
+        layer = self._require_layer(operation.layer_id)
+        generation = int(str((operation.metadata_json or {}).get("generation", 1)))
+        if generation != layer.generation:
+            raise ValueError("generation_changed")
+        existing = self._operations.get(operation.operation_id)
+        finalized = finalize_replicated_override_operation(operation)
+        if existing is not None:
+            if existing.payload_hash != finalized.payload_hash:
+                raise ValueError("operation ID was reused with different content")
+            return
+        self._operations[operation.operation_id] = finalized
+
+    def query(self, query: OperationQuery) -> OperationPage:
+        if query.limit < 1 or query.limit > 500:
+            raise ValueError("limit must be between 1 and 500")
+        now = query.valid_at or datetime.now(timezone.utc)
+        rows = sorted(
+            (
+                operation
+                for operation in self._operations.values()
+                if self._matches(operation, query, now)
+            ),
+            key=lambda operation: (operation.recorded_at, operation.operation_id),
+            reverse=True,
+        )
+        if query.cursor:
+            cursor = _decode_cursor(query.cursor)
+            rows = [row for row in rows if _sort_key(row) < cursor]
+        page = rows[: query.limit]
+        next_cursor = (
+            _encode_cursor(_sort_key(page[-1])) if len(rows) > len(page) else None
+        )
+        return OperationPage(tuple(page), next_cursor)
+
+    def add_composition(self, revision: CompositionRevision) -> None:
+        _require_aware(revision.valid_from, "valid_from")
+        _require_aware(revision.recorded_at, "recorded_at")
+        if revision.valid_to is not None:
+            _require_aware(revision.valid_to, "valid_to")
+            if revision.valid_to <= revision.valid_from:
+                raise ValueError("valid_to must be greater than valid_from")
+        self._require_layer(revision.layer_id)
+        if len(revision.child_layer_ids) != len(set(revision.child_layer_ids)):
+            raise ValueError("composition contains duplicate child layers")
+        if revision.supersedes_revision_id is not None:
+            superseded = next(
+                (
+                    item
+                    for item in self._compositions
+                    if item.revision_id == revision.supersedes_revision_id
+                ),
+                None,
+            )
+            if superseded is None or superseded.layer_id != revision.layer_id:
+                raise ValueError("superseded composition revision was not found")
+        candidate = [*self._compositions, revision]
+        effective = _effective_compositions(candidate, revision.recorded_at)
+        for existing in effective:
+            if existing.revision_id == revision.revision_id:
+                continue
+            if existing.layer_id == revision.layer_id and _overlaps(
+                existing.valid_from,
+                existing.valid_to,
+                revision.valid_from,
+                revision.valid_to,
+            ):
+                raise ValueError("composition schedules overlap")
+        boundaries = {revision.valid_from}
+        if revision.valid_to:
+            boundaries.add(revision.valid_to)
+        boundaries.update(
+            boundary
+            for item in candidate
+            for boundary in (item.valid_from, item.valid_to)
+            if boundary is not None
+        )
+        known_boundaries = {item.recorded_at for item in candidate}
+        for boundary in boundaries:
+            for known_at in known_boundaries:
+                for root_layer_id in self._layers:
+                    self._composition_order(
+                        root_layer_id, boundary, known_at, candidate
+                    )
+        self._compositions.append(revision)
+
+    def project(
+        self,
+        layer_id: str,
+        valid_at: datetime,
+        known_at: datetime,
+        *,
+        feed_id: str | None = None,
+        entity_id: str | None = None,
+    ) -> dict[str, EffectiveFieldProjection]:
+        order = self._composition_order(layer_id, valid_at, known_at)
+        per_layer = {
+            current: project_replicated_override_operations(
+                (
+                    operation
+                    for operation in self._operations.values()
+                    if operation.layer_id == current
+                    and operation.recorded_at <= known_at
+                    and (feed_id is None or operation.feed_id == feed_id)
+                    and (entity_id is None or operation.entity_id == entity_id)
+                ),
+                valid_at,
+            )
+            for current in order
+        }
+        fields = {field for frontiers in per_layer.values() for field in frontiers}
+        result: dict[str, EffectiveFieldProjection] = {}
+        for field in fields:
+            nonempty = [
+                (current, per_layer[current][field])
+                for current in order
+                if field in per_layer[current]
+                and per_layer[current][field].state != "none"
+            ]
+            if nonempty:
+                winner, frontier = nonempty[0]
+                result[field] = EffectiveFieldProjection(
+                    field,
+                    frontier,
+                    winner,
+                    order[: order.index(winner) + 1],
+                    tuple(nonempty[1:]),
+                )
+        return result
+
+    def composition_order(
+        self, layer_id: str, valid_at: datetime, known_at: datetime
+    ) -> tuple[str, ...]:
+        return self._composition_order(layer_id, valid_at, known_at)
+
+    def preview_correction(
+        self, proposal: CorrectionProposal, *, now: datetime | None = None
+    ) -> CorrectionPreview:
+        clock = now or datetime.now(timezone.utc)
+        target = self._require_operation(proposal.target_operation_id)
+        overlaps = tuple(
+            operation.operation_id
+            for operation in self._operations.values()
+            if _same_field(operation, target)
+            and operation.operation_type == "set"
+            and _overlaps(
+                operation.valid_from,
+                operation.valid_to,
+                proposal.valid_from,
+                proposal.valid_to,
+            )
+        )
+        before = project_replicated_override_operations(
+            (
+                operation
+                for operation in self._operations.values()
+                if _same_field(operation, target)
+            ),
+            proposal.valid_from,
+        ).get(target.field_path, OverrideFrontier(target.field_path, "none", ()))
+        preview_operation = self._correction_operation(
+            proposal, target, overlaps, clock
+        )
+        after = project_replicated_override_operations(
+            [
+                *(
+                    operation
+                    for operation in self._operations.values()
+                    if _same_field(operation, target)
+                ),
+                preview_operation,
+            ],
+            proposal.valid_from,
+        )[target.field_path]
+        expires_at = clock + timedelta(minutes=5)
+        token = _token(proposal, overlaps, target.payload_hash, expires_at)
+        interval = ((proposal.valid_from, proposal.valid_to),)
+        gaps_introduced = (
+            interval if before.state != "none" and after.state == "none" else ()
+        )
+        gaps_removed = (
+            interval if before.state == "none" and after.state != "none" else ()
+        )
+        return CorrectionPreview(
+            interval,
+            overlaps,
+            gaps_introduced,
+            gaps_removed,
+            int(before.state != "conflict" and after.state == "conflict"),
+            int(before.state == "conflict" and after.state != "conflict"),
+            token,
+            expires_at,
+        )
+
+    def commit_correction(
+        self,
+        proposal: CorrectionProposal,
+        frontier_token: str,
+        *,
+        now: datetime | None = None,
+    ) -> ReplicatedOverrideOperation:
+        clock = now or datetime.now(timezone.utc)
+        preview = self.preview_correction(proposal, now=clock)
+        if not _valid_token(
+            frontier_token,
+            proposal,
+            preview.superseded_operation_ids,
+            self._require_operation(proposal.target_operation_id).payload_hash,
+            clock,
+        ):
+            raise ValueError("stale_frontier")
+        operation = self._correction_operation(
+            proposal,
+            self._require_operation(proposal.target_operation_id),
+            preview.superseded_operation_ids,
+            clock,
+        )
+        self.append(operation)
+        return self._operations[operation.operation_id]
+
+    def preview_purge(
+        self,
+        document_id: str,
+        operation_ids: Iterable[str],
+        *,
+        reason: str = "",
+        now: datetime | None = None,
+    ) -> PurgePreview:
+        clock = now or datetime.now(timezone.utc)
+        layer = next(
+            (item for item in self._layers.values() if item.document_id == document_id),
+            None,
+        )
+        if layer is None:
+            raise ValueError("document not found")
+        targets = tuple(sorted(set(operation_ids)))
+        if not targets or any(
+            self._require_operation(item).layer_id != layer.layer_id for item in targets
+        ):
+            raise ValueError("purge targets must belong to the document")
+        expires_at = clock + timedelta(minutes=5)
+        return PurgePreview(
+            document_id,
+            layer.generation,
+            len(targets),
+            _purge_token(document_id, layer.generation, targets, reason, expires_at),
+            expires_at,
+        )
+
+    def execute_purge(
+        self,
+        preview: PurgePreview,
+        operation_ids: Iterable[str],
+        *,
+        actor_id: str,
+        reason: str,
+        now: datetime | None = None,
+    ) -> PurgeResult:
+        clock = now or datetime.now(timezone.utc)
+        targets = tuple(sorted(set(operation_ids)))
+        if (
+            not reason.strip()
+            or preview.expires_at < clock
+            or preview.token
+            != _purge_token(
+                preview.document_id,
+                preview.generation,
+                targets,
+                reason,
+                preview.expires_at,
+            )
+        ):
+            raise ValueError("invalid or expired purge confirmation")
+        layer = next(
+            item
+            for item in self._layers.values()
+            if item.document_id == preview.document_id
+        )
+        if layer.generation != preview.generation:
+            raise ValueError("generation_changed")
+        old = [
+            operation
+            for operation in self._operations.values()
+            if operation.layer_id == layer.layer_id
+        ]
+        survivors = [
+            operation for operation in old if operation.operation_id not in targets
+        ]
+        remap = {operation.operation_id: str(uuid4()) for operation in survivors}
+        rebuilt = [
+            replace(
+                operation,
+                operation_id=remap[operation.operation_id],
+                supersedes_operation_ids=tuple(
+                    remap[item]
+                    for item in operation.supersedes_operation_ids
+                    if item in remap
+                ),
+                removes_operation_ids=tuple(
+                    remap[item]
+                    for item in operation.removes_operation_ids
+                    if item in remap
+                ),
+                metadata_json={
+                    **(operation.metadata_json or {}),
+                    "generation": layer.generation + 1,
+                },
+                payload_hash=None,
+            )
+            for operation in survivors
+        ]
+        tombstones = [
+            ReplicatedOverrideOperation(
+                1,
+                str(uuid4()),
+                str(uuid4()),
+                operation.layer_id,
+                "system",
+                operation.feed_id,
+                operation.entity_id,
+                operation.field_path,
+                "remove",
+                None,
+                (),
+                tuple(
+                    remap[item]
+                    for item in (
+                        operation.supersedes_operation_ids
+                        + operation.removes_operation_ids
+                    )
+                    if item in remap
+                ),
+                operation.valid_from,
+                None,
+                clock,
+                metadata_json={
+                    "generation": layer.generation + 1,
+                    "system_tombstone": True,
+                },
+            )
+            for operation in old
+            if operation.operation_id in targets
+            and any(
+                item in remap
+                for item in (
+                    operation.supersedes_operation_ids + operation.removes_operation_ids
+                )
+            )
+        ]
+        for operation in old:
+            self._operations.pop(operation.operation_id, None)
+        self._layers[layer.layer_id] = replace(layer, generation=layer.generation + 1)
+        for operation in [*rebuilt, *tombstones]:
+            self.append(operation)
+        self._purge_metadata.append(
+            {
+                "document_id": preview.document_id,
+                "actor_id": actor_id,
+                "reason": reason,
+                "erased_count": len(targets),
+                "completed_at": clock,
+            }
+        )
+        return PurgeResult(
+            preview.document_id,
+            layer.generation,
+            layer.generation + 1,
+            len(targets),
+            len(rebuilt),
+            len(tombstones),
+            clock,
+        )
+
+    def require_generation(self, document_id: str, generation: int) -> None:
+        layer = next(
+            (item for item in self._layers.values() if item.document_id == document_id),
+            None,
+        )
+        if layer is None or layer.generation != generation:
+            raise ValueError("generation_changed")
+
+    def operations_for_layer(
+        self, layer_id: str
+    ) -> tuple[ReplicatedOverrideOperation, ...]:
+        return tuple(
+            operation
+            for operation in self._operations.values()
+            if operation.layer_id == layer_id
+        )
+
+    def _composition_order(
+        self,
+        layer_id: str,
+        valid_at: datetime,
+        known_at: datetime,
+        revisions: list[CompositionRevision] | None = None,
+    ) -> tuple[str, ...]:
+        root = self._require_layer(layer_id)
+        items = self._compositions if revisions is None else revisions
+        items = list(_effective_compositions(items, known_at))
+        order: list[str] = []
+        visiting: set[str] = set()
+
+        def visit(current: str) -> None:
+            layer = self._require_layer(current)
+            if layer.owning_group != root.owning_group:
+                raise ValueError("composition layers must share one owning group")
+            if current in visiting:
+                raise ValueError("composition contains a cycle")
+            if current in order:
+                raise ValueError("composition contains a duplicate reachable layer")
+            visiting.add(current)
+            order.append(current)
+            active = next(
+                (
+                    revision
+                    for revision in reversed(items)
+                    if revision.layer_id == current
+                    and revision.recorded_at <= known_at
+                    and revision.valid_from <= valid_at
+                    and (revision.valid_to is None or valid_at < revision.valid_to)
+                ),
+                None,
+            )
+            if active:
+                for child in active.child_layer_ids:
+                    visit(child)
+            visiting.remove(current)
+
+        visit(layer_id)
+        return tuple(order)
+
+    def _matches(
+        self,
+        operation: ReplicatedOverrideOperation,
+        query: OperationQuery,
+        now: datetime,
+    ) -> bool:
+        if query.layer_id and operation.layer_id != query.layer_id:
+            return False
+        if query.entity_id and operation.entity_id != query.entity_id:
+            return False
+        if query.field_path and operation.field_path != query.field_path:
+            return False
+        if query.actor_id and operation.actor_id != query.actor_id:
+            return False
+        if (
+            query.operation_types
+            and operation.operation_type not in query.operation_types
+        ):
+            return False
+        if query.known_at and operation.recorded_at > query.known_at:
+            return False
+        if query.recorded_from and operation.recorded_at < query.recorded_from:
+            return False
+        if query.recorded_to and operation.recorded_at >= query.recorded_to:
+            return False
+        drift = bool((operation.metadata_json or {}).get("source_drift", False))
+        if query.source_drift is not None and drift != query.source_drift:
+            return False
+        active = operation.valid_from <= now and (
+            operation.valid_to is None or now < operation.valid_to
+        )
+        if query.view == "history":
+            return True
+        return active if query.view == "active" else operation.valid_from > now
+
+    def _correction_operation(
+        self,
+        proposal: CorrectionProposal,
+        target: ReplicatedOverrideOperation,
+        overlaps: tuple[str, ...],
+        recorded_at: datetime,
+    ) -> ReplicatedOverrideOperation:
+        remove = proposal.value is None
+        return ReplicatedOverrideOperation(
+            1,
+            str(uuid4()),
+            str(uuid4()),
+            target.layer_id,
+            proposal.actor_id,
+            target.feed_id,
+            target.entity_id,
+            target.field_path,
+            "remove" if remove else "set",
+            proposal.value,
+            () if remove else overlaps,
+            overlaps if remove else (),
+            proposal.valid_from,
+            None if remove else proposal.valid_to,
+            recorded_at,
+            target.observed_canonical_value_json,
+            proposal.comment,
+            {"generation": self._layers[target.layer_id].generation},
+        )
+
+    def _require_layer(self, layer_id: str) -> OverrideLayer:
+        try:
+            return self._layers[layer_id]
+        except KeyError as exc:
+            raise ValueError("layer not found") from exc
+
+    def _require_operation(self, operation_id: str) -> ReplicatedOverrideOperation:
+        try:
+            return self._operations[operation_id]
+        except KeyError as exc:
+            raise ValueError("operation not found") from exc
+
+
+def _same_field(
+    left: ReplicatedOverrideOperation, right: ReplicatedOverrideOperation
+) -> bool:
+    return (left.layer_id, left.feed_id, left.entity_id, left.field_path) == (
+        right.layer_id,
+        right.feed_id,
+        right.entity_id,
+        right.field_path,
+    )
+
+
+def _effective_compositions(
+    revisions: Iterable[CompositionRevision], known_at: datetime
+) -> tuple[CompositionRevision, ...]:
+    known = tuple(item for item in revisions if item.recorded_at <= known_at)
+    superseded = {
+        item.supersedes_revision_id
+        for item in known
+        if item.supersedes_revision_id is not None
+    }
+    return tuple(item for item in known if item.revision_id not in superseded)
+
+
+def _overlaps(
+    left_from: datetime,
+    left_to: datetime | None,
+    right_from: datetime,
+    right_to: datetime | None,
+) -> bool:
+    return (left_to is None or right_from < left_to) and (
+        right_to is None or left_from < right_to
+    )
+
+
+def _sort_key(operation: ReplicatedOverrideOperation) -> tuple[datetime, str]:
+    return operation.recorded_at, operation.operation_id
+
+
+def _encode_cursor(value: tuple[datetime, str]) -> str:
+    return json.dumps([value[0].isoformat(), value[1]], separators=(",", ":"))
+
+
+def _decode_cursor(value: str) -> tuple[datetime, str]:
+    try:
+        recorded_at, operation_id = json.loads(value)
+        return datetime.fromisoformat(recorded_at), str(operation_id)
+    except Exception as exc:
+        raise ValueError("invalid cursor") from exc
+
+
+def _token(
+    proposal: CorrectionProposal,
+    overlaps: tuple[str, ...],
+    payload_hash: str | None,
+    expires_at: datetime,
+) -> str:
+    payload = [
+        proposal.target_operation_id,
+        proposal.actor_id,
+        proposal.value.value_json if proposal.value else None,
+        proposal.valid_from.isoformat(),
+        proposal.valid_to.isoformat() if proposal.valid_to else None,
+        proposal.comment,
+        overlaps,
+        payload_hash,
+        expires_at.isoformat(),
+    ]
+    return f"{expires_at.isoformat()}:{sha256(json.dumps(payload, sort_keys=True, default=str).encode()).hexdigest()}"
+
+
+def _valid_token(
+    token: str,
+    proposal: CorrectionProposal,
+    overlaps: tuple[str, ...],
+    payload_hash: str | None,
+    now: datetime,
+) -> bool:
+    try:
+        expires_at = datetime.fromisoformat(token.rsplit(":", 1)[0])
+    except ValueError:
+        return False
+    return expires_at >= now and token == _token(
+        proposal, overlaps, payload_hash, expires_at
+    )
+
+
+def _purge_token(
+    document_id: str,
+    generation: int,
+    targets: tuple[str, ...],
+    reason: str,
+    expires_at: datetime,
+) -> str:
+    digest = sha256(
+        json.dumps(
+            [document_id, generation, targets, reason, expires_at.isoformat()]
+        ).encode()
+    ).hexdigest()
+    return f"{expires_at.isoformat()}:{digest}"
+
+
+def _require_aware(value: datetime, name: str) -> None:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{name} must be timezone-aware")

--- a/polars_hist_db/overrides/sql.py
+++ b/polars_hist_db/overrides/sql.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
-from dataclasses import asdict
+from dataclasses import asdict, replace
 from datetime import datetime, timezone
 from hashlib import sha256
 from typing import Any, Sequence
@@ -31,7 +31,9 @@ from .config import (
     build_crdt_update_table_config,
     build_document_access_table_configs,
     build_override_table_config,
+    build_layer_composition_table_config,
 )
+from .operations import CompositionRevision
 from .crdt import (
     AtomicInsert,
     AtomicUpdate,
@@ -47,7 +49,65 @@ from .types import (
     CrdtDocumentStoreConfig,
     DocumentAccessStoreConfig,
     OverrideLedgerConfig,
+    LayerCompositionStoreConfig,
 )
+
+
+class MariaDbLayerCompositionStore:
+    def __init__(
+        self, connection: Connection, config: LayerCompositionStoreConfig
+    ) -> None:
+        self.connection = connection
+        self.table = _table(connection, build_layer_composition_table_config(config))
+
+    def append(self, revision: CompositionRevision, actor_id: str) -> None:
+        self.connection.execute(
+            self.table.insert().values(
+                revision_id=revision.revision_id,
+                layer_id=revision.layer_id,
+                child_layer_ids_json=_json(list(revision.child_layer_ids)),
+                valid_from=revision.valid_from,
+                valid_to=revision.valid_to,
+                recorded_at=revision.recorded_at,
+                actor_id=actor_id,
+                supersedes_revision_id=revision.supersedes_revision_id,
+            )
+        )
+
+    def revisions(self, layer_id: str | None = None) -> tuple[CompositionRevision, ...]:
+        query = select(self.table)
+        if layer_id is not None:
+            query = query.where(self.table.c.layer_id == layer_id)
+        rows = self.connection.execute(
+            query.order_by(self.table.c.recorded_at, self.table.c.revision_id)
+        ).mappings()
+        return tuple(_composition_revision(row) for row in rows)
+
+
+def _composition_revision(row: Any) -> CompositionRevision:
+    children = row["child_layer_ids_json"]
+    if isinstance(children, str):
+        children = json.loads(children)
+    return CompositionRevision(
+        str(row["revision_id"]),
+        str(row["layer_id"]),
+        tuple(str(item) for item in children),
+        _aware_datetime(row["valid_from"]),
+        None if row.get("valid_to") is None else _aware_datetime(row["valid_to"]),
+        _aware_datetime(row["recorded_at"]),
+        row.get("supersedes_revision_id"),
+    )
+
+
+def _aware_datetime(value: object) -> datetime:
+    parsed = (
+        value if isinstance(value, datetime) else datetime.fromisoformat(str(value))
+    )
+    return (
+        parsed.replace(tzinfo=timezone.utc)
+        if parsed.tzinfo is None
+        else parsed.astimezone(timezone.utc)
+    )
 
 
 class MariaDbCrdtDocumentStore:
@@ -109,6 +169,19 @@ class MariaDbCrdtDocumentStore:
         current = _doc()
         current.apply_update(document.update)
         return current.get_update(state_vector)
+
+    def erase_document(self, document_id: str) -> None:
+        self.connection.execute(
+            self.projection.delete().where(
+                self.projection.c.crdt_document_id == document_id
+            )
+        )
+        self.connection.execute(
+            self.updates.delete().where(self.updates.c.document_id == document_id)
+        )
+        self.connection.execute(
+            self.documents.delete().where(self.documents.c.document_id == document_id)
+        )
 
     def commit(
         self,
@@ -174,6 +247,7 @@ class MariaDbCrdtDocumentStore:
                 self.documents.insert().values(
                     document_id=prepared.document_id,
                     revision=next_revision,
+                    generation=_generation(prepared),
                     head_state_vector_base64=_encode(prepared.state_vector),
                     updated_at=datetime.now(timezone.utc),
                 )
@@ -197,6 +271,7 @@ class MariaDbCrdtDocumentStore:
             self.updates.insert().values(
                 document_id=prepared.document_id,
                 revision=next_revision,
+                generation=_generation(prepared),
                 source_update_hash=prepared.source_update_hash,
                 accepted_update_hash=prepared.accepted_update_hash,
                 update_base64=_encode(prepared.accepted_update),
@@ -302,6 +377,9 @@ class MariaDbCrdtDocumentStore:
                     format_version=operation.format_version,
                     layer_id=operation.layer_id,
                     actor_id=operation.actor_id,
+                    actor_display_name=(operation.metadata_json or {}).get(
+                        "actor_display_name"
+                    ),
                     supersedes_operation_ids_json=_json(
                         list(operation.supersedes_operation_ids)
                     ),
@@ -312,8 +390,13 @@ class MariaDbCrdtDocumentStore:
                     payload_hash=operation.payload_hash,
                     crdt_document_id=prepared.document_id,
                     crdt_document_revision=revision,
+                    generation=_generation(prepared),
                 )
             )
+
+
+def _generation(prepared: PreparedCrdtCommit) -> int:
+    return prepared.generation
 
 
 class MariaDbDocumentAccessStore:
@@ -390,6 +473,23 @@ class MariaDbDocumentAccessStore:
             {"status": "active", "revision": expected_revision},
         )
 
+    def begin_purge(self, document_id: str, expected_generation: int) -> AccessDocument:
+        document = self.get(document_id)
+        if document is None:
+            raise DocumentNotFound("document not found")
+        if document.generation != expected_generation or document.status not in {
+            "active",
+            "purging",
+        }:
+            raise DocumentRevisionConflict("document generation changed")
+        self.connection.execute(
+            self.documents.update()
+            .where(self.documents.c.document_id == document_id)
+            .where(self.documents.c.generation == expected_generation)
+            .values(status="purging")
+        )
+        return replace(document, status="purging")
+
     def create(
         self,
         document_id: str,
@@ -400,9 +500,16 @@ class MariaDbDocumentAccessStore:
         *,
         initial_grants: Sequence[AccessGrantInput] = (),
         idempotency_key: str,
+        owning_group: str | None = None,
     ) -> AccessMutationResult:
         payload = _payload(
-            "create", document_id, name, description, actor_id, initial_grants
+            "create",
+            document_id,
+            name,
+            description,
+            actor_id,
+            initial_grants,
+            owning_group,
         )
         duplicate = self._duplicate(idempotency_key, payload)
         if duplicate:
@@ -417,6 +524,7 @@ class MariaDbDocumentAccessStore:
             1,
             actor_id,
             recorded_at,
+            owning_group=owning_group,
         )
         try:
             with self.connection.begin_nested():

--- a/polars_hist_db/overrides/types.py
+++ b/polars_hist_db/overrides/types.py
@@ -37,6 +37,10 @@ class OverrideOperation:
     reason: str | None = None
     comment: str | None = None
     metadata_json: dict[str, Any] = field(default_factory=dict)
+    recorded_at: datetime | None = None
+    actor_display_name: str | None = None
+    document_id: str | None = None
+    generation: int = 1
 
 
 @dataclass(frozen=True)
@@ -60,3 +64,15 @@ class DocumentAccessStoreConfig:
     documents_table: str = "document_access"
     grants_table: str = "document_access_grants"
     commands_table: str = "document_access_commands"
+
+
+@dataclass(frozen=True)
+class LayerCompositionStoreConfig:
+    schema: str = "overrides"
+    revisions_table: str = "layer_composition_revisions"
+
+
+@dataclass(frozen=True)
+class OverridePurgeStoreConfig:
+    schema: str = "overrides"
+    metadata_table: str = "override_purge_metadata"

--- a/polars_hist_db/overrides/xtdb.py
+++ b/polars_hist_db/overrides/xtdb.py
@@ -39,8 +39,10 @@ from .config import (
     build_crdt_document_table_config,
     build_crdt_update_table_config,
     build_document_access_table_configs,
+    build_layer_composition_table_config,
     build_override_table_config,
 )
+from .operations import CompositionRevision
 from .crdt import (
     AtomicInsert,
     AtomicUpdate,
@@ -55,8 +57,76 @@ from .crdt import (
 from .types import (
     CrdtDocumentStoreConfig,
     DocumentAccessStoreConfig,
+    LayerCompositionStoreConfig,
     OverrideLedgerConfig,
 )
+
+
+class XtdbLayerCompositionStore:
+    def __init__(self, connection: Any, config: LayerCompositionStoreConfig) -> None:
+        self.connection = connection
+        self.table = build_layer_composition_table_config(config)
+
+    def append(self, revision: CompositionRevision, actor_id: str) -> None:
+        _execute_xtdb_transaction(
+            self.connection,
+            [
+                _insert_statement(
+                    self.table,
+                    {
+                        "revision_id": revision.revision_id,
+                        "layer_id": revision.layer_id,
+                        "child_layer_ids_json": list(revision.child_layer_ids),
+                        "valid_from": revision.valid_from,
+                        "valid_to": revision.valid_to,
+                        "recorded_at": revision.recorded_at,
+                        "actor_id": actor_id,
+                        "supersedes_revision_id": revision.supersedes_revision_id,
+                    },
+                )
+            ],
+        )
+
+    def revisions(self, layer_id: str | None = None) -> tuple[CompositionRevision, ...]:
+        predicate = (
+            ""
+            if layer_id is None
+            else f" WHERE layer_id = {_literal(layer_id, 'VARCHAR(128)')}"
+        )
+        try:
+            rows = self.connection.execute(
+                text(
+                    "SELECT revision_id, layer_id, child_layer_ids_json, "
+                    f"valid_from, valid_to, recorded_at, supersedes_revision_id "
+                    f"FROM {_table_name(self.table)}"
+                    f"{predicate} ORDER BY recorded_at, revision_id"
+                )
+            ).mappings()
+            return tuple(_composition_revision(row) for row in rows)
+        except Exception as exc:
+            if not _is_xtdb_table_not_found_error(exc):
+                raise
+            _rollback_xtdb_connection(self.connection)
+            return ()
+
+
+def _composition_revision(row: Mapping[str, object]) -> CompositionRevision:
+    children = row["child_layer_ids_json"]
+    if isinstance(children, str):
+        children = json.loads(children)
+    if not isinstance(children, list):
+        raise ValueError("stored composition children are invalid")
+    return CompositionRevision(
+        str(row["revision_id"]),
+        str(row["layer_id"]),
+        tuple(str(item) for item in children),
+        _datetime(row["valid_from"]),
+        None if row.get("valid_to") is None else _datetime(row["valid_to"]),
+        _datetime(row["recorded_at"]),
+        None
+        if row.get("supersedes_revision_id") is None
+        else str(row["supersedes_revision_id"]),
+    )
 
 
 class XtdbCrdtDocumentStore:
@@ -108,6 +178,17 @@ class XtdbCrdtDocumentStore:
         current.apply_update(document.update)
         return current.get_update(state_vector)
 
+    def erase_document(self, document_id: str) -> None:
+        value = _literal(document_id, "VARCHAR(128)")
+        _execute_xtdb_transaction(
+            self.connection,
+            [
+                f"ERASE FROM {_table_name(self.projection)} WHERE crdt_document_id = {value}",
+                f"ERASE FROM {_table_name(self.updates)} WHERE document_id = {value}",
+                f"ERASE FROM {_table_name(self.documents)} WHERE _id = {value}",
+            ],
+        )
+
     def commit(
         self,
         prepared: PreparedCrdtCommit,
@@ -145,6 +226,7 @@ class XtdbCrdtDocumentStore:
                 {
                     "document_id": prepared.document_id,
                     "revision": prepared.base_revision + 1,
+                    "generation": _generation(prepared),
                     "head_state_vector_base64": _encode(prepared.state_vector),
                     "updated_at": _accepted_at(prepared),
                 },
@@ -154,6 +236,7 @@ class XtdbCrdtDocumentStore:
                 {
                     "document_id": prepared.document_id,
                     "revision": prepared.base_revision + 1,
+                    "generation": _generation(prepared),
                     "source_update_hash": prepared.source_update_hash,
                     "accepted_update_hash": prepared.accepted_update_hash,
                     "update_base64": _encode(prepared.accepted_update),
@@ -286,12 +369,16 @@ class XtdbCrdtDocumentStore:
             "format_version": operation.format_version,
             "layer_id": operation.layer_id,
             "actor_id": operation.actor_id,
+            "actor_display_name": (operation.metadata_json or {}).get(
+                "actor_display_name"
+            ),
             "supersedes_operation_ids_json": list(operation.supersedes_operation_ids),
             "removes_operation_ids_json": list(operation.removes_operation_ids),
             "recorded_at": operation.recorded_at,
             "payload_hash": operation.payload_hash,
             "crdt_document_id": prepared.document_id,
             "crdt_document_revision": prepared.base_revision + 1,
+            "generation": _generation(prepared),
         }
         return _insert_statement(
             self.projection,
@@ -394,6 +481,24 @@ class XtdbDocumentAccessStore:
             {"status": "active", "revision": expected_revision},
         )
 
+    def begin_purge(self, document_id: str, expected_generation: int) -> AccessDocument:
+        document = self.get(document_id)
+        if document is None:
+            raise DocumentNotFound("document not found")
+        if document.generation != expected_generation or document.status not in {
+            "active",
+            "purging",
+        }:
+            raise DocumentRevisionConflict("document generation changed")
+        _execute_xtdb_transaction(
+            self.connection,
+            [
+                f"ASSERT EXISTS (SELECT 1 FROM {_table_name(self.documents)} WHERE _id = {_literal(document_id, 'VARCHAR(128)')} AND generation = {expected_generation}::BIGINT), 'document generation changed'",
+                _access_update(self.documents, document_id, {"status": "purging"}),
+            ],
+        )
+        return replace(document, status="purging")
+
     def create(
         self,
         document_id: str,
@@ -404,9 +509,12 @@ class XtdbDocumentAccessStore:
         *,
         initial_grants: Sequence[AccessGrantInput] = (),
         idempotency_key: str,
+        owning_group: str | None = None,
     ) -> AccessMutationResult:
         grants = tuple(initial_grants)
-        payload = _payload("create", document_id, name, description, actor_id, grants)
+        payload = _payload(
+            "create", document_id, name, description, actor_id, grants, owning_group
+        )
         duplicate = self._duplicate(idempotency_key, payload)
         if duplicate:
             return duplicate
@@ -425,6 +533,7 @@ class XtdbDocumentAccessStore:
             1,
             actor_id,
             recorded_at,
+            owning_group=owning_group,
         )
         result = AccessMutationResult(
             document,
@@ -718,6 +827,8 @@ def _access_document_columns(prefix: str | None = None) -> str:
         "created_at",
         "archived_by",
         "archived_at",
+        "owning_group",
+        "generation",
     )
     return ", ".join(f"{prefix}.{name}" if prefix else name for name in names)
 
@@ -752,6 +863,10 @@ def _access_document_from_row(row: Mapping[str, object]) -> AccessDocument:
         archived_at=None
         if row["archived_at"] is None
         else _datetime(row["archived_at"]),
+        owning_group=(
+            None if row.get("owning_group") is None else str(row["owning_group"])
+        ),
+        generation=int(str(row.get("generation", 1))),
     )
 
 
@@ -785,6 +900,8 @@ def _document_row(document: AccessDocument) -> dict[str, object]:
         "created_at": document.created_at,
         "archived_by": document.archived_by,
         "archived_at": document.archived_at,
+        "owning_group": document.owning_group,
+        "generation": document.generation,
     }
 
 
@@ -968,6 +1085,10 @@ def _accepted_at(prepared: PreparedCrdtCommit) -> datetime:
     if prepared.operations:
         return prepared.operations[0].recorded_at
     return datetime.now(timezone.utc)
+
+
+def _generation(prepared: PreparedCrdtCommit) -> int:
+    return prepared.generation
 
 
 def _bootstrap_value(data_type: str) -> object:

--- a/tests/overrides/test_composition_store.py
+++ b/tests/overrides/test_composition_store.py
@@ -1,0 +1,47 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from polars_hist_db.overrides import (
+    CompositionRevision,
+    InMemoryLayerCompositionStore,
+    LayerCompositionStoreConfig,
+    OverridePurgeStoreConfig,
+    build_layer_composition_table_config,
+    build_override_purge_table_config,
+)
+
+
+def test_configurable_composition_and_purge_tables() -> None:
+    composition = build_layer_composition_table_config(
+        LayerCompositionStoreConfig("custom", "compositions")
+    )
+    purge = build_override_purge_table_config(
+        OverridePurgeStoreConfig("custom", "purges")
+    )
+
+    assert (composition.schema, composition.name) == ("custom", "compositions")
+    assert {column.name for column in composition.columns} >= {
+        "child_layer_ids_json",
+        "valid_from",
+        "valid_to",
+        "recorded_at",
+        "supersedes_revision_id",
+    }
+    assert (purge.schema, purge.name) == ("custom", "purges")
+    assert "value_json" not in {column.name for column in purge.columns}
+    assert "comment" not in {column.name for column in purge.columns}
+
+
+def test_in_memory_composition_store_preserves_revision_order() -> None:
+    store = InMemoryLayerCompositionStore()
+    first = CompositionRevision(
+        str(uuid4()),
+        "root",
+        ("left", "right"),
+        datetime(2026, 7, 13, tzinfo=timezone.utc),
+        None,
+        datetime(2026, 7, 12, tzinfo=timezone.utc),
+    )
+    store.append(first, "editor")
+
+    assert store.revisions("root") == (first,)

--- a/tests/overrides/test_crdt_document_store.py
+++ b/tests/overrides/test_crdt_document_store.py
@@ -130,6 +130,7 @@ def test_prepared_commit_finalizes_operations_and_rejects_later_mutation():
         source_update,
         actor_id="user-1",
         recorded_at=accepted_at,
+        authoritative_metadata={"actor_display_name": "Verified User"},
     )
     store = InMemoryCrdtDocumentStore()
     committed = store.commit(prepared)
@@ -138,6 +139,9 @@ def test_prepared_commit_finalizes_operations_and_rejects_later_mutation():
     assert committed.revision == 1
     assert prepared.source_update_hash != prepared.accepted_update_hash
     assert store.projected_operations("document-1")[0].actor_id == "user-1"
+    assert store.projected_operations("document-1")[0].metadata_json == {
+        "actor_display_name": "Verified User"
+    }
     assert store.projected_operations("document-1")[0].payload_hash is not None
 
     document: Any = Doc()

--- a/tests/overrides/test_crdt_table_config.py
+++ b/tests/overrides/test_crdt_table_config.py
@@ -19,6 +19,7 @@ def test_crdt_document_tables_use_portable_base64_payload_columns():
     assert {column.name for column in documents.columns} == {
         "document_id",
         "revision",
+        "generation",
         "head_state_vector_base64",
         "snapshot_update_base64",
         "snapshot_update_hash",
@@ -34,6 +35,7 @@ def test_crdt_document_tables_use_portable_base64_payload_columns():
         "snapshot_state_vector_base64",
     }
     assert updates.primary_keys == ("document_id", "revision")
+    assert "generation" in {column.name for column in updates.columns}
     source_hash_constraint = [
         column
         for column in updates.columns

--- a/tests/overrides/test_override_operations.py
+++ b/tests/overrides/test_override_operations.py
@@ -1,0 +1,197 @@
+from dataclasses import replace
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from polars_hist_db.overrides import (
+    CompositionRevision,
+    CorrectionProposal,
+    InMemoryOverrideOperationsStore,
+    OperationQuery,
+    OverrideTypedValue,
+    ReplicatedOverrideOperation,
+)
+
+
+def _utc(hour: int) -> datetime:
+    return datetime(2026, 7, 13, hour, tzinfo=timezone.utc)
+
+
+def _operation(
+    layer: str, value: str, *, hour: int = 10
+) -> ReplicatedOverrideOperation:
+    return ReplicatedOverrideOperation(
+        1,
+        str(uuid4()),
+        str(uuid4()),
+        layer,
+        "user-1",
+        "records",
+        "record-1",
+        "status",
+        "set",
+        OverrideTypedValue("enum", {"value": value}),
+        (),
+        (),
+        _utc(hour),
+        None,
+        _utc(hour + 1),
+        metadata_json={"generation": 1},
+    )
+
+
+def test_query_composition_correction_and_purge_contract() -> None:
+    store = InMemoryOverrideOperationsStore()
+    store.create_layer("root", "analysts", "document-root")
+    store.create_layer("child", "analysts")
+    child = _operation("child", "Loading")
+    root = _operation("root", "In Transit")
+    store.append(child)
+    store.append(root)
+    store.add_composition(
+        CompositionRevision(str(uuid4()), "root", ("child",), _utc(0), None, _utc(1))
+    )
+
+    page = store.query(OperationQuery(layer_id="root", view="history", limit=1))
+    projection = store.project("root", _utc(12), _utc(12))["status"]
+
+    assert [operation.operation_id for operation in page.operations] == [
+        root.operation_id
+    ]
+    assert projection.winning_layer_id == "root"
+    assert projection.shadowed[0][0] == "child"
+
+    proposal = CorrectionProposal(
+        root.operation_id,
+        "user-2",
+        OverrideTypedValue("enum", {"value": "Delivered"}),
+        _utc(10),
+        None,
+        "confirmed",
+    )
+    preview = store.preview_correction(proposal, now=_utc(12))
+    corrected = store.commit_correction(proposal, preview.frontier_token, now=_utc(12))
+    assert corrected.supersedes_operation_ids == (root.operation_id,)
+
+    purge = store.preview_purge(
+        "document-root", [root.operation_id], reason="privacy request", now=_utc(13)
+    )
+    result = store.execute_purge(
+        purge,
+        [root.operation_id],
+        actor_id="compliance-admin",
+        reason="privacy request",
+        now=_utc(13),
+    )
+    assert result.generation == 2
+    with pytest.raises(ValueError, match="generation_changed"):
+        store.require_generation("document-root", 1)
+
+
+def test_composition_rejects_cross_group_cycles_and_duplicate_reachability() -> None:
+    store = InMemoryOverrideOperationsStore()
+    for layer in ("a", "b", "c"):
+        store.create_layer(layer, "one")
+    store.create_layer("outside", "two")
+    store.add_composition(
+        CompositionRevision(str(uuid4()), "b", ("c",), _utc(0), None, _utc(1))
+    )
+
+    with pytest.raises(ValueError, match="owning group"):
+        store.add_composition(
+            CompositionRevision(str(uuid4()), "a", ("outside",), _utc(0), None, _utc(2))
+        )
+    with pytest.raises(ValueError, match="duplicate reachable"):
+        store.add_composition(
+            CompositionRevision(str(uuid4()), "a", ("b", "c"), _utc(0), None, _utc(2))
+        )
+
+    store.add_composition(
+        CompositionRevision(str(uuid4()), "a", ("b",), _utc(0), None, _utc(2))
+    )
+    with pytest.raises(ValueError, match="cycle"):
+        store.add_composition(
+            CompositionRevision(str(uuid4()), "c", ("a",), _utc(13), None, _utc(13))
+        )
+
+
+def test_composition_validates_ancestors_affected_by_a_child_revision() -> None:
+    store = InMemoryOverrideOperationsStore()
+    for layer in ("root", "left", "right"):
+        store.create_layer(layer, "one")
+    store.add_composition(
+        CompositionRevision(
+            str(uuid4()), "root", ("left", "right"), _utc(0), None, _utc(1)
+        )
+    )
+
+    with pytest.raises(ValueError, match="duplicate reachable"):
+        store.add_composition(
+            CompositionRevision(
+                str(uuid4()), "left", ("right",), _utc(0), None, _utc(2)
+            )
+        )
+
+
+def test_composition_revision_can_immutably_replace_an_open_schedule() -> None:
+    store = InMemoryOverrideOperationsStore()
+    for layer in ("root", "left", "right"):
+        store.create_layer(layer, "one")
+    original = CompositionRevision(
+        str(uuid4()), "root", ("left",), _utc(0), None, _utc(1)
+    )
+    store.add_composition(original)
+    revised = CompositionRevision(
+        str(uuid4()),
+        "root",
+        ("right",),
+        _utc(0),
+        None,
+        _utc(2),
+        original.revision_id,
+    )
+    store.add_composition(revised)
+
+    assert store.composition_order("root", _utc(12), _utc(1)) == ("root", "left")
+    assert store.composition_order("root", _utc(12), _utc(2)) == ("root", "right")
+
+
+def test_correction_token_rejects_a_changed_frontier() -> None:
+    store = InMemoryOverrideOperationsStore()
+    store.create_layer("root", "analysts")
+    original = _operation("root", "Loading")
+    store.append(original)
+    proposal = CorrectionProposal(
+        original.operation_id,
+        "user-2",
+        OverrideTypedValue("enum", {"value": "Delivered"}),
+        _utc(10),
+        None,
+    )
+    preview = store.preview_correction(proposal, now=_utc(12))
+    store.append(replace(_operation("root", "Scheduled"), valid_from=_utc(10)))
+
+    with pytest.raises(ValueError, match="stale_frontier"):
+        store.commit_correction(proposal, preview.frontier_token, now=_utc(12))
+
+
+def test_backdated_correction_reports_a_removed_canonical_gap() -> None:
+    store = InMemoryOverrideOperationsStore()
+    store.create_layer("root", "analysts")
+    original = _operation("root", "Loading", hour=10)
+    store.append(original)
+
+    preview = store.preview_correction(
+        CorrectionProposal(
+            original.operation_id,
+            "user-2",
+            OverrideTypedValue("enum", {"value": "Scheduled"}),
+            _utc(8),
+            None,
+        ),
+        now=_utc(12),
+    )
+
+    assert preview.canonical_gaps_introduced == ()
+    assert preview.canonical_gaps_removed == ((_utc(8), None),)

--- a/tests/overrides/test_override_table_config.py
+++ b/tests/overrides/test_override_table_config.py
@@ -51,12 +51,14 @@ def test_build_override_table_config_contains_required_columns():
         "format_version",
         "layer_id",
         "actor_id",
+        "actor_display_name",
         "supersedes_operation_ids_json",
         "removes_operation_ids_json",
         "recorded_at",
         "payload_hash",
         "crdt_document_id",
         "crdt_document_revision",
+        "generation",
     }
     assert (
         next(


### PR DESCRIPTION
## Summary
- add backend-neutral override operation queries, immutable corrections, layer composition, and purge-generation contracts
- provide in-memory, MariaDB, and XTDB implementations with configurable table names

## Verification
- full library tests, lint, and type checks pass

## Rollout
Release this before the API PR that consumes these contracts.