### PR TITLE
perf(xtdb): erase staging rows by document id

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -2149,10 +2149,26 @@ class XtdbStagingOps:
         ).join(resolver, on=value_sources, how="left")
 
     def cleanup_run(self, stage_run_id: str, delta_table_config: TableConfig) -> None:
-        self._stage_run_cache.pop(stage_run_id, None)
+        stage_df = self._stage_run_cache.pop(stage_run_id, None)
         table_name = _qualified_table_name(
             delta_table_config.schema, _xtdb_stage_table_name(delta_table_config.name)
         )
+        if stage_df is not None:
+            if stage_df.is_empty():
+                return
+            stage_config = self.stage_table_config(delta_table_config)
+            ids = _prepare_xtdb_insert_dataframe(stage_df, stage_config).get_column(
+                "_id"
+            )
+            ids_sql = ", ".join(
+                _xtdb_sql_literal(value, "TEXT") for value in ids.to_list()
+            )
+            _execute_xtdb_dml(
+                self.connection,
+                f"ERASE FROM {table_name} WHERE _id IN ({ids_sql})",
+            )
+            return
+
         stage_run_literal = _xtdb_sql_literal(stage_run_id, "TEXT")
         _execute_xtdb_dml(
             self.connection,

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -671,6 +671,42 @@ def test_xtdb_staging_cleanup_erases_only_batch_run():
     ) in [call.args for call in driver_connection.execute.call_args_list]
 
 
+def test_xtdb_staging_cleanup_uses_cached_document_ids():
+    driver_connection = Mock()
+    connection = Mock()
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+    delta_table_config = TableConfig(
+        schema="fakedata",
+        name="record_stream",
+        columns=[TableColumnConfig("record_stream", "record_id", "INT")],
+    )
+    staging = XtdbStagingOps(connection)
+    staging._stage_run_cache["stage-1"] = pl.DataFrame(
+        {
+            "stage_run_id": ["stage-1", "stage-1"],
+            "stage_row_index": [0, 1],
+            "record_id": [10, 20],
+            "stage_partition_time": [
+                datetime(2030, 1, 1),
+                datetime(2030, 1, 1),
+            ],
+        }
+    )
+
+    staging.cleanup_run("stage-1", delta_table_config)
+
+    sql = next(
+        call.args[0]
+        for call in driver_connection.execute.call_args_list
+        if call.args[0].startswith("ERASE")
+    )
+    assert "WHERE _id IN (" in sql
+    assert 'xtdb-pk-v1:[["stage_run_id","stage-1"],["stage_row_index",0]]' in sql
+    assert 'xtdb-pk-v1:[["stage_run_id","stage-1"],["stage_row_index",1]]' in sql
+    assert "WHERE stage_run_id" not in sql
+
+
 def test_xtdb_staging_deduces_foreign_keys_and_inserts_missing_parent(
     monkeypatch,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -1483,7 +1483,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1529,7 +1529,7 @@ sqlalchemy = [
 
 [[package]]
 name = "polars-hist-db"
-version = "0.12.41"
+version = "0.12.42"
 source = { editable = "." }
 dependencies = [
     { name = "nats-py" },


### PR DESCRIPTION
## Root cause
A production XTDB trace showed staging cleanup spending 61.5 seconds on a stage_run_id-filtered ERASE, scanning 882 fragmented pages for 903 rows. Interactive writes queued behind that transaction.

## Fix
- erase normal staged batches by their cached composite _id values, using XTDB document-key lookup
- preserve the stage_run_id scan only as a cache-miss recovery fallback
- retain the existing durable staging and hard-erasure behavior

## Verification
- 196 tests passed, 1 skipped
- 21 focused XTDB staging tests passed
- ruff and strict mypy passed