### PR TITLE
perf(xtdb): bulk ingest pgwire writes with Arrow COPY

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy (uv run)
-        entry: uv run --group dev mypy --config-file=pyproject.toml
+        entry: uv run --group dev mypy .
         language: system
         types: [python]
         require_serial: true

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -836,6 +836,60 @@ def _execute_xtdb_dml(
     return row_count
 
 
+def _execute_xtdb_arrow_copy(
+    connection: Any,
+    table_sql: str,
+    df: pl.DataFrame,
+    *,
+    system_time: Optional[datetime] = None,
+) -> None:
+    driver_connection = _driver_connection(connection)
+    if driver_connection is None:
+        raise ValueError("XTDB Arrow COPY requires a live DBAPI connection")
+
+    _rollback_xtdb_connection(connection)
+    autocommit = getattr(driver_connection, "autocommit", None)
+    if autocommit is not None:
+        driver_connection.autocommit = True
+
+    begin_sql = "BEGIN READ WRITE"
+    if system_time is not None:
+        system_time = _next_xtdb_system_time(connection, system_time)
+        begin_sql = (
+            "BEGIN READ WRITE WITH "
+            f"(SYSTEM_TIME = {_xtdb_timestamp_literal(system_time)})"
+        )
+
+    arrow_table = _normalize_xtdb_ingest_arrow(df.to_arrow())
+    sink = pa.BufferOutputStream()
+    with pa.ipc.new_stream(sink, arrow_table.schema) as writer:
+        writer.write_table(arrow_table)
+
+    driver_connection.execute(begin_sql)
+    try:
+        cursor = driver_connection.cursor()
+        try:
+            with cursor.copy(
+                f"COPY {table_sql} FROM STDIN WITH (FORMAT 'arrow-stream')"
+            ) as copy:
+                copy.write(sink.getvalue().to_pybytes())
+        finally:
+            close = getattr(cursor, "close", None)
+            if callable(close):
+                close()
+        driver_connection.execute("COMMIT")
+    except Exception as exc:
+        driver_connection.execute("ROLLBACK")
+        driver_connection.rollback()
+        if system_time is not None and _is_xtdb_invalid_system_time_error(exc):
+            _execute_xtdb_arrow_copy(connection, table_sql, df, system_time=None)
+            return
+        raise
+    finally:
+        if autocommit is not None:
+            driver_connection.autocommit = autocommit
+
+
 def _execute_xtdb_transaction(connection: Any, statements: Iterable[str]) -> None:
     """Submit one serialized XTDB DML transaction."""
 
@@ -1472,6 +1526,22 @@ class XtdbDataframeOps:
         if driver_connection is not None:
             inserted_count = 0
             for chunk in _iter_xtdb_insert_chunks(df, self.max_rows_per_insert):
+                table_sql = _qualified_table_name(table_schema, table_name)
+                if chunk.height > 1:
+                    physical_columns = {
+                        column: _xtdb_physical_column_name(column)
+                        for column in chunk.columns
+                        if column != _xtdb_physical_column_name(column)
+                    }
+                    _execute_xtdb_arrow_copy(
+                        self.connection,
+                        table_sql,
+                        chunk.rename(physical_columns),
+                        system_time=update_time,
+                    )
+                    inserted_count += chunk.height
+                    continue
+
                 columns = [_xtdb_column_identifier(column) for column in chunk.columns]
                 column_sql = ", ".join(columns)
                 casts = _xtdb_insert_casts(chunk, table_config)
@@ -1483,7 +1553,6 @@ class XtdbDataframeOps:
                     for row in chunk.rows()
                 ]
                 values_sql = "(" + ", ".join(f"%s::{cast}" for cast in casts) + ")"
-                table_sql = _qualified_table_name(table_schema, table_name)
                 insert_sql = (
                     f"INSERT INTO {table_sql} ({column_sql}) VALUES {values_sql}"
                 )
@@ -1789,6 +1858,7 @@ class XtdbStagingOps:
         except Exception as exc:
             if not _is_xtdb_adbc_ingest_unavailable(exc):
                 raise
+            self.adbc_connection = None
 
         return self._dataframes().table_insert(
             df,

--- a/tests/backends/test_xtdb_dataframe_ops.py
+++ b/tests/backends/test_xtdb_dataframe_ops.py
@@ -2,15 +2,17 @@ import builtins
 from datetime import datetime, timezone
 from decimal import Decimal
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import polars as pl
+import pyarrow as pa
 import pytest
 
 from polars_hist_db.backends.xtdb import (
     XtdbDataframeOps,
     XtdbTableConfigOps,
     _execute_xtdb_dml,
+    _execute_xtdb_arrow_copy,
 )
 from polars_hist_db.config import TableColumnConfig, TableConfig
 from polars_hist_db.core import TimeHint
@@ -344,7 +346,7 @@ def test_xtdb_dataframe_ops_uses_system_time_transaction_for_update_time():
 
 
 def test_xtdb_dataframe_ops_splits_pgwire_insert_by_max_rows():
-    driver_connection = Mock()
+    driver_connection = MagicMock()
     cursor = driver_connection.cursor.return_value
     connection = Mock()
     connection.connection.driver_connection = driver_connection
@@ -360,17 +362,37 @@ def test_xtdb_dataframe_ops_splits_pgwire_insert_by_max_rows():
     )
 
     assert result == 5
-    insert_sql = [call.args[0] for call in cursor.executemany.call_args_list]
-    assert insert_sql == [
-        "INSERT INTO test.records (_id, destination) VALUES (%s::BIGINT, %s::TEXT)",
-        "INSERT INTO test.records (_id, destination) VALUES (%s::BIGINT, %s::TEXT)",
-        "INSERT INTO test.records (_id, destination) VALUES (%s::BIGINT, %s::TEXT)",
+    assert cursor.copy.call_count == 2
+    assert cursor.executemany.call_args.args[1] == [(5, "E")]
+
+
+def test_xtdb_arrow_copy_writes_one_arrow_stream_transaction():
+    driver_connection = MagicMock()
+    connection = Mock()
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+
+    _execute_xtdb_arrow_copy(
+        connection,
+        "test.records",
+        pl.DataFrame({"_id": [1, 2, 3], "destination": ["A", "B", "C"]}),
+    )
+
+    assert [call.args[0] for call in driver_connection.execute.call_args_list] == [
+        "BEGIN READ WRITE",
+        "COMMIT",
     ]
-    assert [call.args[1] for call in cursor.executemany.call_args_list] == [
-        [(1, "A"), (2, "B")],
-        [(3, "C"), (4, "D")],
-        [(5, "E")],
+    driver_connection.cursor.return_value.copy.assert_called_once_with(
+        "COPY test.records FROM STDIN WITH (FORMAT 'arrow-stream')"
+    )
+    payload = driver_connection.cursor.return_value.copy.return_value.__enter__.return_value.write.call_args.args[
+        0
     ]
+    table = pa.ipc.open_stream(payload).read_all()
+    assert table.to_pydict() == {
+        "_id": [1, 2, 3],
+        "destination": ["A", "B", "C"],
+    }
 
 
 def test_xtdb_dml_advances_reused_system_time_on_same_connection():

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -228,6 +228,7 @@ def test_xtdb_staging_insert_partition_falls_back_when_adbc_ingest_unavailable(
     assert inserted["table_schema"] == "fakedata"
     assert inserted["table_name"] == "__record_stream_stage"
     assert inserted["table_config"].name == "__record_stream_stage"
+    assert staging.adbc_connection is None
 
 
 def test_xtdb_staging_projects_from_insert_cache_after_partition_insert(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -1529,7 +1529,7 @@ sqlalchemy = [
 
 [[package]]
 name = "polars-hist-db"
-version = "0.12.42"
+version = "0.12.43"
 source = { editable = "." }
 dependencies = [
     { name = "nats-py" },


### PR DESCRIPTION
## What changed
- use XTDB pgwire `COPY ... FORMAT arrow-stream` for multi-row dataframe writes
- preserve explicit SYSTEM_TIME transactions and retry semantics
- retain parameterized INSERT for single-row writes
- stop retrying unsupported ADBC ingest within the same staging cycle

## Why
A live 903-row snapshot generated 903 statements for staging, 903 for the metadata table, and 903 for the temporal table. Those transactions took 6.58s, 2.17s, and 2.71s and serialized later writes behind them.

A live Arrow COPY probe handled 903 rows in 108-203ms when not queued behind an existing row-by-row transaction.

## Verification
- 198 non-integration tests passed
- focused XTDB backend/staging/dataframe suites passed
- ruff passed
- mypy passed
- live XTDB Arrow COPY probe passed, including explicit transaction use and cleanup