### PR TITLE
perf(xtdb): clear serialized staging table directly

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -2226,16 +2226,11 @@ class XtdbStagingOps:
         if stage_df is not None:
             if stage_df.is_empty():
                 return
-            stage_config = self.stage_table_config(delta_table_config)
-            ids = _prepare_xtdb_insert_dataframe(stage_df, stage_config).get_column(
-                "_id"
-            )
-            ids_sql = ", ".join(
-                _xtdb_sql_literal(value, "TEXT") for value in ids.to_list()
-            )
+            # ponytail: ingest runs are serialized per dataset; restore a
+            # run-scoped erase if concurrent runs are introduced.
             _execute_xtdb_dml(
                 self.connection,
-                f"ERASE FROM {table_name} WHERE _id IN ({ids_sql})",
+                f"ERASE FROM {table_name} WHERE TRUE",
             )
             return
 

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -672,7 +672,7 @@ def test_xtdb_staging_cleanup_erases_only_batch_run():
     ) in [call.args for call in driver_connection.execute.call_args_list]
 
 
-def test_xtdb_staging_cleanup_uses_cached_document_ids():
+def test_xtdb_staging_cleanup_clears_serialized_stage_table():
     driver_connection = Mock()
     connection = Mock()
     connection.connection.driver_connection = driver_connection
@@ -702,10 +702,7 @@ def test_xtdb_staging_cleanup_uses_cached_document_ids():
         for call in driver_connection.execute.call_args_list
         if call.args[0].startswith("ERASE")
     )
-    assert "WHERE _id IN (" in sql
-    assert 'xtdb-pk-v1:[["stage_run_id","stage-1"],["stage_row_index",0]]' in sql
-    assert 'xtdb-pk-v1:[["stage_run_id","stage-1"],["stage_row_index",1]]' in sql
-    assert "WHERE stage_run_id" not in sql
+    assert sql == "ERASE FROM fakedata.__record_stream_stage WHERE TRUE"
 
 
 def test_xtdb_staging_deduces_foreign_keys_and_inserts_missing_parent(


### PR DESCRIPTION
## What changed
- clear the serialized staging table with `ERASE ... WHERE TRUE`
- remove the 903-id cleanup predicate and document-id construction
- retain the run-scoped fallback for uncached recovery

## Why
The cached cleanup path scanned the accumulated staging table for 903 document IDs. Live traces measured that single cleanup transaction at 14-17 seconds. A direct whole-table ERASE avoids the semi-join scan; ingestion is already serialized per dataset.

## Verification
- focused staging suite: 21 passed
- ruff passed
- mypy passed