### PR TITLE
perf(xtdb): benchmark ingest lookup scaling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ check:
 	uv run ruff format
 	uv run mypy .
 
+benchmark-xtdb-delta:
+	uv run python benchmarks/xtdb_delta.py
+
 run-tests:
 	NATS_PORT=$(NATS_PORT) MARIADB_PORT=$(MARIADB_PORT) uv run python -m pytest tests/
 

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Runnable performance benchmarks."""

--- a/benchmarks/xtdb_delta.py
+++ b/benchmarks/xtdb_delta.py
@@ -14,11 +14,15 @@ import os
 import re
 from statistics import median
 from time import perf_counter
+from typing import Any
 
 import polars as pl
 
-from polars_hist_db.backends.xtdb import _filter_xtdb_unchanged_rows
-from polars_hist_db.config import TableColumnConfig, TableConfig
+from polars_hist_db.backends.xtdb import (
+    XtdbStagingOps,
+    _filter_xtdb_unchanged_rows,
+)
+from polars_hist_db.config import DatasetConfig, TableColumnConfig, TableConfig
 
 
 @dataclass
@@ -27,6 +31,21 @@ class CurrentRows:
 
     def from_raw_sql(self, _sql: str) -> pl.DataFrame:
         return self.frame
+
+    def from_table(self, _schema: str, _table: str) -> pl.DataFrame:
+        return self.frame
+
+
+class ForeignKeyStaging(XtdbStagingOps):
+    def __init__(self, parent: pl.DataFrame):
+        super().__init__(object())
+        self.rows = CurrentRows(parent)
+
+    def _dataframes(self) -> Any:
+        return self.rows
+
+    def _bulk_table_insert(self, *args, **kwargs) -> int:
+        raise AssertionError("benchmark rows should already exist in the parent table")
 
 
 def network_floor_seconds(data_gb: float, bandwidth_gbps: float) -> float:
@@ -70,6 +89,39 @@ def table_config(value_columns: int) -> TableConfig:
     )
 
 
+def foreign_key_config() -> tuple[DatasetConfig, TableConfig]:
+    dataset = DatasetConfig(
+        name="records",
+        delta_table_schema="benchmark",
+        input_config={"type": "dsv", "search_paths": []},  # type: ignore[arg-type]
+        pipeline=[  # type: ignore[arg-type]
+            {
+                "schema": "benchmark",
+                "table": "parents",
+                "type": "primary",
+                "columns": [
+                    {
+                        "source": "parent_id",
+                        "target": "id",
+                        "deduce_foreign_key": True,
+                    },
+                    {"source": "parent_key", "target": "natural_key"},
+                ],
+            }
+        ],
+    )
+    config = TableConfig(
+        schema="benchmark",
+        name="parents",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("parents", "id", "BIGINT", nullable=False),
+            TableColumnConfig("parents", "natural_key", "BIGINT"),
+        ],
+    )
+    return dataset, config
+
+
 def benchmark_delta(
     target_rows: int,
     upload_rows: int,
@@ -95,6 +147,32 @@ def benchmark_delta(
         incoming.estimated_size("mb"),
         changed_rows,
     )
+
+
+def benchmark_foreign_keys(
+    parent_rows: int, upload_rows: int, repeats: int
+) -> tuple[float, float, float]:
+    if upload_rows > parent_rows:
+        raise ValueError("upload rows cannot exceed parent rows")
+    parent = pl.DataFrame(
+        {"id": range(parent_rows), "natural_key": range(parent_rows)}
+    ).sample(fraction=1, shuffle=True, seed=42)
+    incoming = pl.DataFrame(
+        {"parent_id": range(upload_rows), "parent_key": range(upload_rows)}
+    )
+    dataset, config = foreign_key_config()
+    timings = []
+    for _ in range(repeats):
+        gc.collect()
+        staging = ForeignKeyStaging(parent)
+        staging._stage_run_cache["benchmark"] = incoming
+        started = perf_counter()
+        result = staging.prepare_pipeline_item_dataframe(
+            "benchmark", dataset, 0, config, valid_time=None
+        )
+        timings.append(perf_counter() - started)
+        assert len(result) == upload_rows
+    return median(timings), parent.estimated_size("mb"), incoming.estimated_size("mb")
 
 
 def benchmark_remote_sample(dsn: str, table: str, limit: int) -> None:
@@ -147,6 +225,19 @@ def main() -> None:
         print(
             f"{args.target_gb:g},{bandwidth:g},"
             f"{network_floor_seconds(args.target_gb, bandwidth):.1f}"
+        )
+
+    print(
+        "parent_rows,upload_rows,parent_mb,upload_fk_mb,"
+        "foreign_key_seconds_excluding_parent_read"
+    )
+    for parent_rows in (int(value) for value in args.target_rows.split(",")):
+        elapsed, parent_mb, upload_mb = benchmark_foreign_keys(
+            parent_rows, args.upload_rows, args.repeats
+        )
+        print(
+            f"{parent_rows},{args.upload_rows},{parent_mb:.2f},{upload_mb:.2f},"
+            f"{elapsed:.3f}"
         )
 
     if args.remote_table:

--- a/benchmarks/xtdb_delta.py
+++ b/benchmarks/xtdb_delta.py
@@ -1,0 +1,160 @@
+"""Benchmark XTDB's current client-side delta calculation.
+
+Examples:
+    uv run python benchmarks/xtdb_delta.py
+    uv run python benchmarks/xtdb_delta.py --target-rows 50000,5000000
+    XTDB_BENCHMARK_DSN=postgresql://... uv run python benchmarks/xtdb_delta.py \
+        --remote-table spire.vessel_info --remote-limit 50000
+"""
+
+from argparse import ArgumentParser
+from dataclasses import dataclass
+import gc
+import os
+import re
+from statistics import median
+from time import perf_counter
+
+import polars as pl
+
+from polars_hist_db.backends.xtdb import _filter_xtdb_unchanged_rows
+from polars_hist_db.config import TableColumnConfig, TableConfig
+
+
+@dataclass
+class CurrentRows:
+    frame: pl.DataFrame
+
+    def from_raw_sql(self, _sql: str) -> pl.DataFrame:
+        return self.frame
+
+
+def network_floor_seconds(data_gb: float, bandwidth_gbps: float) -> float:
+    return data_gb * 8 / bandwidth_gbps
+
+
+def synthetic_frames(
+    target_rows: int, upload_rows: int, value_columns: int
+) -> tuple[pl.DataFrame, pl.DataFrame]:
+    if upload_rows > target_rows:
+        raise ValueError("upload rows cannot exceed target rows")
+    current = pl.DataFrame({"_id": range(target_rows)})
+    incoming = pl.DataFrame({"id": range(upload_rows)})
+    for column in range(value_columns):
+        name = f"value_{column}"
+        current = current.with_columns((pl.col("_id") + column).alias(name))
+        incoming = incoming.with_columns((pl.col("id") + column).alias(name))
+    current = current.sample(fraction=1, shuffle=True, seed=42)
+    if upload_rows:
+        incoming = incoming.with_columns(
+            pl.when(pl.col("id") == upload_rows - 1)
+            .then(pl.col("value_0") + 1)
+            .otherwise(pl.col("value_0"))
+            .alias("value_0")
+        )
+    return current, incoming
+
+
+def table_config(value_columns: int) -> TableConfig:
+    return TableConfig(
+        schema="benchmark",
+        name="records",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            *[
+                TableColumnConfig("records", f"value_{column}", "BIGINT")
+                for column in range(value_columns)
+            ],
+        ],
+    )
+
+
+def benchmark_delta(
+    target_rows: int,
+    upload_rows: int,
+    value_columns: int,
+    repeats: int,
+) -> tuple[float, float, float, int]:
+    current, incoming = synthetic_frames(target_rows, upload_rows, value_columns)
+    ops = CurrentRows(current)
+    config = table_config(value_columns)
+    timings = []
+    changed_rows = 0
+    for _ in range(repeats):
+        gc.collect()
+        started = perf_counter()
+        changed = _filter_xtdb_unchanged_rows(
+            incoming, "benchmark", "records", config, ops, None
+        )
+        timings.append(perf_counter() - started)
+        changed_rows = len(changed)
+    return (
+        median(timings),
+        current.estimated_size("mb"),
+        incoming.estimated_size("mb"),
+        changed_rows,
+    )
+
+
+def benchmark_remote_sample(dsn: str, table: str, limit: int) -> None:
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*", table):
+        raise ValueError("remote table must be an unquoted schema.table identifier")
+    import psycopg
+
+    with psycopg.connect(dsn) as connection:
+        started = perf_counter()
+        frame = pl.read_database(f"SELECT * FROM {table} LIMIT {limit}", connection)
+        elapsed = perf_counter() - started
+    print("remote_table,rows,decoded_mb,seconds,rows_per_second,decoded_mb_per_second")
+    decoded_mb = frame.estimated_size("mb")
+    print(
+        f"{table},{len(frame)},{decoded_mb:.2f},{elapsed:.3f},"
+        f"{len(frame) / elapsed:.0f},{decoded_mb / elapsed:.2f}"
+    )
+
+
+def main() -> None:
+    parser = ArgumentParser()
+    parser.add_argument("--target-rows", default="50000,500000,5000000,10000000")
+    parser.add_argument("--upload-rows", type=int, default=50_000)
+    parser.add_argument("--value-columns", type=int, default=8)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--target-gb", type=float, default=100)
+    parser.add_argument("--bandwidth-gbps", default="1,10,100")
+    parser.add_argument("--remote-table")
+    parser.add_argument("--remote-limit", type=int, default=50_000)
+    args = parser.parse_args()
+
+    print(
+        "target_rows,upload_rows,target_mb,upload_mb,"
+        "polars_compare_seconds_excluding_target_read,changed_rows"
+    )
+    for target_rows in (int(value) for value in args.target_rows.split(",")):
+        elapsed, target_mb, upload_mb, changed = benchmark_delta(
+            target_rows,
+            args.upload_rows,
+            args.value_columns,
+            args.repeats,
+        )
+        print(
+            f"{target_rows},{args.upload_rows},{target_mb:.2f},{upload_mb:.2f},"
+            f"{elapsed:.3f},{changed}"
+        )
+
+    print("target_gb,bandwidth_gbps,ideal_transfer_floor_seconds")
+    for bandwidth in (float(value) for value in args.bandwidth_gbps.split(",")):
+        print(
+            f"{args.target_gb:g},{bandwidth:g},"
+            f"{network_floor_seconds(args.target_gb, bandwidth):.1f}"
+        )
+
+    if args.remote_table:
+        dsn = os.environ.get("XTDB_BENCHMARK_DSN")
+        if not dsn:
+            parser.error("XTDB_BENCHMARK_DSN is required with --remote-table")
+        benchmark_remote_sample(dsn, args.remote_table, args.remote_limit)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/xtdb_delta.py
+++ b/benchmarks/xtdb_delta.py
@@ -40,12 +40,14 @@ class ForeignKeyStaging(XtdbStagingOps):
     def __init__(self, parent: pl.DataFrame):
         super().__init__(object())
         self.rows = CurrentRows(parent)
+        self.inserted_rows = 0
 
     def _dataframes(self) -> Any:
         return self.rows
 
-    def _bulk_table_insert(self, *args, **kwargs) -> int:
-        raise AssertionError("benchmark rows should already exist in the parent table")
+    def _bulk_table_insert(self, df: pl.DataFrame, *args, **kwargs) -> int:
+        self.inserted_rows += len(df)
+        return len(df)
 
 
 def network_floor_seconds(data_gb: float, bandwidth_gbps: float) -> float:
@@ -150,18 +152,32 @@ def benchmark_delta(
 
 
 def benchmark_foreign_keys(
-    parent_rows: int, upload_rows: int, repeats: int
-) -> tuple[float, float, float]:
+    parent_rows: int, upload_rows: int, match_fraction: float, repeats: int
+) -> tuple[float, float, float, int, int, int, bool]:
     if upload_rows > parent_rows:
         raise ValueError("upload rows cannot exceed parent rows")
+    if not 0 <= match_fraction <= 1:
+        raise ValueError("match fraction must be between zero and one")
+    matched_rows = round(upload_rows * match_fraction)
+    unmatched_rows = upload_rows - matched_rows
     parent = pl.DataFrame(
         {"id": range(parent_rows), "natural_key": range(parent_rows)}
     ).sample(fraction=1, shuffle=True, seed=42)
+    incoming_keys = [
+        *range(matched_rows),
+        *range(parent_rows, parent_rows + unmatched_rows),
+    ]
     incoming = pl.DataFrame(
-        {"parent_id": range(upload_rows), "parent_key": range(upload_rows)}
+        {
+            "parent_id": pl.Series([None] * upload_rows, dtype=pl.Int64),
+            "parent_key": incoming_keys,
+        }
     )
     dataset, config = foreign_key_config()
     timings = []
+    inserted_rows = 0
+    generated_id_collisions = 0
+    stage_updated = False
     for _ in range(repeats):
         gc.collect()
         staging = ForeignKeyStaging(parent)
@@ -172,7 +188,24 @@ def benchmark_foreign_keys(
         )
         timings.append(perf_counter() - started)
         assert len(result) == upload_rows
-    return median(timings), parent.estimated_size("mb"), incoming.estimated_size("mb")
+        inserted_rows = staging.inserted_rows
+        staged = staging._stage_run_cache["benchmark"]
+        stage_updated = staged["parent_id"].null_count() == 0
+        generated_ids = staged.filter(pl.col("parent_key") >= parent_rows).get_column(
+            "parent_id"
+        )
+        generated_id_collisions = len(generated_ids) - generated_ids.n_unique()
+        assert inserted_rows == unmatched_rows
+        assert stage_updated
+    return (
+        median(timings),
+        parent.estimated_size("mb"),
+        incoming.estimated_size("mb"),
+        matched_rows,
+        inserted_rows,
+        generated_id_collisions,
+        stage_updated,
+    )
 
 
 def benchmark_remote_sample(dsn: str, table: str, limit: int) -> None:
@@ -200,6 +233,7 @@ def main() -> None:
     parser.add_argument("--repeats", type=int, default=3)
     parser.add_argument("--target-gb", type=float, default=100)
     parser.add_argument("--bandwidth-gbps", default="1,10,100")
+    parser.add_argument("--fk-match-fractions", default="0,0.5,1")
     parser.add_argument("--remote-table")
     parser.add_argument("--remote-limit", type=int, default=50_000)
     args = parser.parse_args()
@@ -228,17 +262,24 @@ def main() -> None:
         )
 
     print(
-        "parent_rows,upload_rows,parent_mb,upload_fk_mb,"
-        "foreign_key_seconds_excluding_parent_read"
+        "parent_rows,upload_rows,match_fraction,matched_rows,created_rows,"
+        "generated_id_collisions,stage_updated,parent_mb,upload_fk_mb,"
+        "foreign_key_seconds_excluding_parent_read_and_parent_insert"
     )
     for parent_rows in (int(value) for value in args.target_rows.split(",")):
-        elapsed, parent_mb, upload_mb = benchmark_foreign_keys(
-            parent_rows, args.upload_rows, args.repeats
-        )
-        print(
-            f"{parent_rows},{args.upload_rows},{parent_mb:.2f},{upload_mb:.2f},"
-            f"{elapsed:.3f}"
-        )
+        for match_fraction in (
+            float(value) for value in args.fk_match_fractions.split(",")
+        ):
+            elapsed, parent_mb, upload_mb, matched, created, collisions, updated = (
+                benchmark_foreign_keys(
+                    parent_rows, args.upload_rows, match_fraction, args.repeats
+                )
+            )
+            print(
+                f"{parent_rows},{args.upload_rows},{match_fraction:g},{matched},"
+                f"{created},{collisions},{str(updated).lower()},{parent_mb:.2f},"
+                f"{upload_mb:.2f},{elapsed:.3f}"
+            )
 
     if args.remote_table:
         dsn = os.environ.get("XTDB_BENCHMARK_DSN")

--- a/tests/benchmarks/test_xtdb_delta_benchmark.py
+++ b/tests/benchmarks/test_xtdb_delta_benchmark.py
@@ -12,5 +12,8 @@ def test_xtdb_delta_benchmark_models_target_and_upload_independently():
     assert incoming.shape == (10, 3)
     assert network_floor_seconds(100, 10) == 80
 
-    _, parent_mb, upload_mb = benchmark_foreign_keys(100, 10, 1)
+    _, parent_mb, upload_mb, matched, created, collisions, updated = (
+        benchmark_foreign_keys(100, 10, 0.5, 1)
+    )
     assert parent_mb > upload_mb
+    assert (matched, created, collisions, updated) == (5, 5, 0, True)

--- a/tests/benchmarks/test_xtdb_delta_benchmark.py
+++ b/tests/benchmarks/test_xtdb_delta_benchmark.py
@@ -1,0 +1,9 @@
+from benchmarks.xtdb_delta import network_floor_seconds, synthetic_frames
+
+
+def test_xtdb_delta_benchmark_models_target_and_upload_independently():
+    current, incoming = synthetic_frames(100, 10, 2)
+
+    assert current.shape == (100, 3)
+    assert incoming.shape == (10, 3)
+    assert network_floor_seconds(100, 10) == 80

--- a/tests/benchmarks/test_xtdb_delta_benchmark.py
+++ b/tests/benchmarks/test_xtdb_delta_benchmark.py
@@ -1,4 +1,8 @@
-from benchmarks.xtdb_delta import network_floor_seconds, synthetic_frames
+from benchmarks.xtdb_delta import (
+    benchmark_foreign_keys,
+    network_floor_seconds,
+    synthetic_frames,
+)
 
 
 def test_xtdb_delta_benchmark_models_target_and_upload_independently():
@@ -7,3 +11,6 @@ def test_xtdb_delta_benchmark_models_target_and_upload_independently():
     assert current.shape == (100, 3)
     assert incoming.shape == (10, 3)
     assert network_floor_seconds(100, 10) == 80
+
+    _, parent_mb, upload_mb = benchmark_foreign_keys(100, 10, 1)
+    assert parent_mb > upload_mb


### PR DESCRIPTION
## What changed
- benchmark unchanged-row comparison independently from target size
- benchmark foreign-key inference by parent size, upload size, and 0/50/100% match rates
- verify unmatched parents are created and their IDs update the in-memory staged dataframe
- report generated numeric-ID collisions
- report remote-transfer floors and provide opt-in remote sampling

## Scaling breakdown
Fixed 50,000-row upload; times exclude the full parent read and actual parent insert:

| Parent rows | Matched | Created | FK processing |
|---:|---:|---:|---:|
| 50,000 | 50,000 | 0 | 179 ms |
| 50,000 | 25,000 | 25,000 | 227 ms |
| 50,000 | 0 | 50,000 | 265 ms |
| 10,000,000 | 50,000 | 0 | 507 ms |
| 10,000,000 | 25,000 | 25,000 | 558 ms |
| 10,000,000 | 0 | 50,000 | 595 ms |

At 5 million parents, increasing upload size from 1,000 to 10,000 to 50,000 raises FK processing from roughly 0.21-0.24s to 0.20-0.32s to 0.33-0.43s depending on match rate. Parent transfer remains the dominant unmeasured cost.

Current FK inference reads the complete parent once per FK-bearing pipeline item. Unchanged detection reads the complete target. Dropout detection reads every current `_id`. A 100 GB read has an ideal transfer floor of 80 seconds at 10 Gbps.

## Correctness finding
Generated numeric foreign keys use a 31-bit negative hash. The deterministic benchmark observed 0 collisions at 50,000 unmatched keys, 1 at 100,000, and 10 at 200,000. The staged dataframe was populated, but colliding natural keys can receive the same generated ID.

## Conclusion
Full-parent reads must be replaced by selective natural-key lookup using the existing `table_query()` path. Numeric generated IDs also need a collision-safe strategy. This PR benchmarks current behavior without changing either algorithm.

## Verification
- benchmarks through 10 million parents and 200,000 unmatched keys
- 197 unit tests passed
- Ruff, formatting, and mypy passed