### PR TITLE
perf(xtdb): bound delta reads to incoming keys

### DIFF
--- a/.github/workflows/bespoke_xtdb-benchmark-history.yaml
+++ b/.github/workflows/bespoke_xtdb-benchmark-history.yaml
@@ -1,0 +1,49 @@
+name: xtdb-benchmark-history
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'benchmarks/xtdb_delta.py'
+      - 'polars_hist_db/backends/xtdb.py'
+      - '.github/workflows/bespoke_xtdb-benchmark-history.yaml'
+      - 'pyproject.toml'
+      - 'uv.lock'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    runs-on: ${{ fromJSON(vars.RUNNER_PROFILES)[vars.RUNNER_PROFILE].default }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: astral-sh/setup-uv@v8.3.2
+
+      - run: uv sync --group dev
+
+      - name: Run benchmarks
+        run: >-
+          uv run python benchmarks/xtdb_delta.py
+          --target-rows 50000,500000,5000000
+          --upload-rows 50000
+          --value-columns 8
+          --repeats 3
+          --fk-match-fractions 0,0.5,1
+          --json-output benchmark-results.json
+
+      - name: Record benchmark history
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
+        with:
+          tool: customSmallerIsBetter
+          output-file-path: benchmark-results.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench/xtdb-delta

--- a/benchmarks/xtdb_delta.py
+++ b/benchmarks/xtdb_delta.py
@@ -10,7 +10,9 @@ Examples:
 from argparse import ArgumentParser
 from dataclasses import dataclass
 import gc
+import json
 import os
+from pathlib import Path
 import re
 from statistics import median
 from time import perf_counter
@@ -253,7 +255,9 @@ def main() -> None:
     parser.add_argument("--fk-match-fractions", default="0,0.5,1")
     parser.add_argument("--remote-table")
     parser.add_argument("--remote-limit", type=int, default=50_000)
+    parser.add_argument("--json-output")
     args = parser.parse_args()
+    results = []
 
     print(
         "target_rows,upload_rows,target_mb,upload_mb,"
@@ -269,6 +273,13 @@ def main() -> None:
         print(
             f"{target_rows},{args.upload_rows},{target_mb:.2f},{upload_mb:.2f},"
             f"{elapsed:.3f},{changed}"
+        )
+        results.append(
+            {
+                "name": f"delta {target_rows} stored / {args.upload_rows} uploaded",
+                "unit": "seconds",
+                "value": elapsed,
+            }
         )
 
     print("target_gb,bandwidth_gbps,ideal_transfer_floor_seconds")
@@ -297,12 +308,25 @@ def main() -> None:
                 f"{created},{collisions},{str(updated).lower()},{parent_mb:.2f},"
                 f"{upload_mb:.2f},{elapsed:.3f}"
             )
+            results.append(
+                {
+                    "name": (
+                        f"foreign keys {parent_rows} stored / "
+                        f"{args.upload_rows} uploaded / {match_fraction:g} matched"
+                    ),
+                    "unit": "seconds",
+                    "value": elapsed,
+                }
+            )
 
     if args.remote_table:
         dsn = os.environ.get("XTDB_BENCHMARK_DSN")
         if not dsn:
             parser.error("XTDB_BENCHMARK_DSN is required with --remote-table")
         benchmark_remote_sample(dsn, args.remote_table, args.remote_limit)
+
+    if args.json_output:
+        Path(args.json_output).write_text(json.dumps(results, indent=2) + "\n")
 
 
 if __name__ == "__main__":

--- a/benchmarks/xtdb_delta.py
+++ b/benchmarks/xtdb_delta.py
@@ -1,4 +1,4 @@
-"""Benchmark XTDB's current client-side delta calculation.
+"""Benchmark XTDB delta and foreign-key scaling.
 
 Examples:
     uv run python benchmarks/xtdb_delta.py
@@ -34,6 +34,23 @@ class CurrentRows:
 
     def from_table(self, _schema: str, _table: str) -> pl.DataFrame:
         return self.frame
+
+    def table_query(
+        self,
+        _schema: str,
+        _table: str,
+        query_df: pl.DataFrame,
+        column_selection: list[str],
+        **_kwargs: Any,
+    ) -> pl.DataFrame:
+        if query_df.is_empty():
+            return self.frame.select(column_selection).head(0)
+        frame = self.frame
+        if "id" in column_selection and "id" not in frame.columns:
+            frame = frame.with_columns(pl.col("_id").alias("id"))
+        return frame.join(query_df, on=query_df.columns, how="inner").select(
+            column_selection
+        )
 
 
 class ForeignKeyStaging(XtdbStagingOps):
@@ -240,7 +257,7 @@ def main() -> None:
 
     print(
         "target_rows,upload_rows,target_mb,upload_mb,"
-        "polars_compare_seconds_excluding_target_read,changed_rows"
+        "synthetic_selective_compare_seconds,changed_rows"
     )
     for target_rows in (int(value) for value in args.target_rows.split(",")):
         elapsed, target_mb, upload_mb, changed = benchmark_delta(
@@ -264,7 +281,7 @@ def main() -> None:
     print(
         "parent_rows,upload_rows,match_fraction,matched_rows,created_rows,"
         "generated_id_collisions,stage_updated,parent_mb,upload_fk_mb,"
-        "foreign_key_seconds_excluding_parent_read_and_parent_insert"
+        "synthetic_selective_fk_seconds_excluding_network_and_insert"
     )
     for parent_rows in (int(value) for value in args.target_rows.split(",")):
         for match_fraction in (

--- a/docs/backend-contract.qmd
+++ b/docs/backend-contract.qmd
@@ -291,6 +291,9 @@ behaviour:
   finality it temporally deletes current rows whose `_id` is missing from the
   incoming snapshot. It then compares incoming rows against the current row at
   the same temporal basis and skips rows whose configured values are unchanged.
+  The comparison fetches only uploaded document IDs and requested columns, so
+  its transfer and client-memory cost scale with the upload rather than the
+  complete target table.
 - A live test proves the unchanged update returns zero changed rows and does
   not create a transaction at the unchanged `update_time`; the subsequent
   changed update remains visible through as-of valid-time/system-time queries.
@@ -313,18 +316,16 @@ behaviour:
   columns. This keeps feed semantics YAML-controlled: record snapshots can use
   message/as-of time, entity vectors can use source position time, and future
   rate feeds can use explicit validity windows.
-- Dataset ingestion keeps an explicit staging phase for XTDB. The adapter
-  writes each partition to a retained internal table named
-  `__<dataset>_stage`, keyed by `stage_run_id` and `stage_row_index`, then
-  deletes only that `stage_run_id` after the upload finishes. This mirrors the
-  MariaDB pattern of reusing the staging schema while keeping staged data scoped
-  to one upload.
+- Dataset ingestion keeps each XTDB partition in a process-local Polars
+  dataframe until the pipeline finishes, then discards it. It does not persist
+  a staging table in XTDB.
 - XTDB staging preserves pipeline source-to-target column mapping, duplicate
   removal, default filling, `update_time` system-time import, per-table
-  valid-time mapping, and `deduce_foreign_key` normalization for textual target
-  key columns. Missing normalized rows get deterministic IDs of the form
-  `xtdb-fk-v1:<schema>.<table>:<natural-key-json>`. Numeric generated IDs need
-  a separate allocator before they can be supported safely.
+  valid-time mapping, and `deduce_foreign_key` normalization. Parent lookups
+  fetch only uploaded natural keys. Missing textual rows get deterministic IDs
+  of the form `xtdb-fk-v1:<schema>.<table>:<natural-key-json>`. Missing numeric
+  rows use deterministic negative IDs, probe existing IDs, and resolve any
+  collisions before insert.
 - MariaDB continues to treat `__valid_from` / `__valid_to` as system-version
   history. Dataset valid-time mappings are XTDB business valid-time inputs and
   are not equivalent to MariaDB's generated system-time columns.

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
+from functools import partial
 import hashlib
 import json
 import logging
@@ -49,6 +50,7 @@ _XTDB_STAGE_ROW_INDEX_COLUMN = "stage_row_index"
 _XTDB_STAGE_PARTITION_TIME_COLUMN = "stage_partition_time"
 _XTDB_LAST_SYSTEM_TIME_KEY = "polars_hist_db_xtdb_last_system_time"
 _XTDB_RESERVED_IDENTIFIERS = {"flag", "timestamp"}
+_XTDB_QUERY_ROWS_PER_CHUNK = 10_000
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
@@ -1132,25 +1134,35 @@ def _filter_xtdb_unchanged_rows(
     indexed_df = df.with_row_index(row_index)
     incoming = _prepare_xtdb_insert_dataframe(indexed_df, table_config)
 
-    table_sql = _qualified_table_name(table_schema, table_name)
+    compare_columns = [
+        column
+        for column in incoming.columns
+        if column not in {row_index, "_valid_from", *_XTDB_READONLY_SYSTEM_COLUMNS}
+    ]
+    query_columns = [
+        "__valid_to" if column == "_valid_to" else column for column in compare_columns
+    ]
     try:
-        current = dataframe_ops.from_raw_sql(
-            f"SELECT * FROM {table_sql}{_xtdb_temporal_basis_clause(update_time)}"
+        current = dataframe_ops.table_query(
+            table_schema,
+            table_name,
+            incoming.select("_id").unique(maintain_order=True),
+            query_columns,
+            table_config=table_config,
+            basis_time=update_time,
         )
     except Exception as exc:
         if _is_xtdb_table_not_found_error(exc):
             _rollback_xtdb_connection(dataframe_ops.connection)
             return df
         raise
-    current = _restore_xtdb_logical_columns(current, table_config)
+    if "__valid_to" in current.columns:
+        current = current.rename({"__valid_to": "_valid_to"})
     if current.is_empty():
         return df
 
     compare_columns = [
-        column
-        for column in incoming.columns
-        if column not in {row_index, "_valid_from", *_XTDB_READONLY_SYSTEM_COLUMNS}
-        and column in current.columns
+        column for column in compare_columns if column in current.columns
     ]
     if "_id" not in compare_columns:
         raise ValueError("XTDB delta upsert requires current rows to include _id")
@@ -1329,6 +1341,7 @@ def _xtdb_deduced_foreign_key_id(
 
 def _xtdb_deduced_numeric_foreign_key_id(
     table_config: TableConfig,
+    target_column: str,
     value_targets: list[str],
     row: dict[str, Any],
 ) -> int:
@@ -1339,7 +1352,15 @@ def _xtdb_deduced_numeric_foreign_key_id(
         encoded_parts, separators=(",", ":"), ensure_ascii=False
     )
     digest = hashlib.sha256(payload.encode("utf-8")).digest()
-    generated = int.from_bytes(digest[:4], "big") & 0x7FFFFFFF
+    bits = (
+        63
+        if any(
+            column.name == target_column and column.data_type.upper() == "BIGINT"
+            for column in table_config.columns
+        )
+        else 31
+    )
+    generated = int.from_bytes(digest[:8], "big") & ((1 << bits) - 1)
     return -(generated or 1)
 
 
@@ -1380,6 +1401,23 @@ def _cast_null_parent_lookup_columns(
     if not casts:
         return parent_lookup
     return parent_lookup.with_columns(casts)
+
+
+def _xtdb_integer_min(table_config: TableConfig, column_name: str) -> int:
+    data_type = next(
+        column.data_type.upper()
+        for column in table_config.columns
+        if column.name == column_name
+    )
+    bits = {
+        "TINYINT": 8,
+        "SMALLINT": 16,
+        "MEDIUMINT": 24,
+        "INT": 32,
+        "INTEGER": 32,
+        "BIGINT": 64,
+    }[data_type]
+    return -(1 << (bits - 1))
 
 
 class XtdbDataframeOps:
@@ -1439,36 +1477,17 @@ class XtdbDataframeOps:
         query_df: pl.DataFrame,
         column_selection: Optional[list[str]],
         time_hint: TimeHint | None = None,
+        table_config: TableConfig | None = None,
+        basis_time: datetime | None = None,
     ) -> pl.DataFrame:
-        table_config = XtdbTableConfigOps(self.connection).from_table(
-            table_schema,
-            table_name,
-        )
+        if table_config is None:
+            table_config = XtdbTableConfigOps(self.connection).from_table(
+                table_schema,
+                table_name,
+            )
         output_columns = _xtdb_table_query_output_columns(
             table_config,
             column_selection,
-        )
-        select_sql = ", ".join(
-            _xtdb_table_query_select_expr(column, table_config)
-            for column in output_columns
-        )
-        join_clause = " AND ".join(
-            "t."
-            f"{_xtdb_table_query_target_column(column, table_config)} = "
-            f"q.{_xtdb_column_identifier(column)}"
-            for column in query_df.columns
-        )
-        table_sql = _qualified_table_name(table_schema, table_name)
-        valid_time_clause = _xtdb_valid_time_clause(time_hint)
-        query = (
-            f"WITH {_xtdb_values_cte('query_df', query_df)} "
-            f"SELECT {select_sql} "
-            "FROM ("
-            "SELECT *, _valid_from, _valid_to "
-            f"FROM {table_sql}{valid_time_clause}"
-            ") AS t "
-            "JOIN query_df AS q "
-            f"ON {join_clause}"
         )
         schema_overrides = {}
         for column in table_config.columns:
@@ -1477,6 +1496,38 @@ class XtdbDataframeOps:
             dtype = _xtdb_polars_type_or_none(column.data_type)
             if dtype is not None:
                 schema_overrides[column.name] = dtype
+        if "_id" in output_columns:
+            document_id_columns = _xtdb_document_id_columns(table_config)
+            if len(document_id_columns) > 1:
+                schema_overrides["_id"] = pl.String()
+            else:
+                id_config = next(
+                    (
+                        column
+                        for column in table_config.columns
+                        if column.name == document_id_columns[0]
+                    ),
+                    None,
+                )
+                if id_config is not None:
+                    schema_overrides["_id"] = (
+                        _xtdb_polars_type_or_none(id_config.data_type) or pl.String()
+                    )
+        for temporal_column in ["__valid_from", "__valid_to"]:
+            if temporal_column in output_columns:
+                schema_overrides[temporal_column] = pl.Datetime("us")
+        if query_df.is_empty():
+            return pl.DataFrame(schema=schema_overrides)
+        select_sql = ", ".join(
+            _xtdb_table_query_select_expr(column, table_config)
+            for column in output_columns
+        )
+        table_sql = _qualified_table_name(table_schema, table_name)
+        valid_time_clause = (
+            _xtdb_temporal_basis_clause(basis_time)
+            if basis_time is not None
+            else _xtdb_valid_time_clause(time_hint)
+        )
         single_key_alias = _xtdb_single_primary_key_alias(table_config)
         if single_key_alias is not None and single_key_alias in output_columns:
             id_column = next(
@@ -1487,11 +1538,27 @@ class XtdbDataframeOps:
             id_dtype = _xtdb_polars_type_or_none(id_column.data_type)
             if id_dtype is not None:
                 schema_overrides[single_key_alias] = id_dtype
-        for temporal_column in ["__valid_from", "__valid_to"]:
-            if temporal_column in output_columns:
-                schema_overrides[temporal_column] = pl.Datetime("us")
-
-        df = self.from_raw_sql(query, schema_overrides)
+        chunk_size = self.max_rows_per_insert or _XTDB_QUERY_ROWS_PER_CHUNK
+        chunks = []
+        for query_chunk in query_df.iter_slices(chunk_size):
+            join_clause = " AND ".join(
+                "t."
+                f"{_xtdb_table_query_target_column(column, table_config)} = "
+                f"q.{_xtdb_column_identifier(column)}"
+                for column in query_chunk.columns
+            )
+            query = (
+                f"WITH {_xtdb_values_cte('query_df', query_chunk)} "
+                f"SELECT {select_sql} "
+                "FROM ("
+                "SELECT *, _valid_from, _valid_to "
+                f"FROM {table_sql}{valid_time_clause}"
+                ") AS t "
+                "JOIN query_df AS q "
+                f"ON {join_clause}"
+            )
+            chunks.append(self.from_raw_sql(query, schema_overrides))
+        df = pl.concat(chunks, how="vertical_relaxed")
         for temporal_column in ["__valid_from", "__valid_to"]:
             if (
                 temporal_column in df.columns
@@ -1621,6 +1688,8 @@ class XtdbAdbcDataframeOps:
             query,
             schema_overrides,
         )
+
+    table_query = XtdbDataframeOps.table_query
 
     def table_insert(
         self,
@@ -2012,6 +2081,57 @@ class XtdbStagingOps:
         self._projected_parent_row_cache.update(new_parent_keys)
         return pl.DataFrame(rows_to_return, schema=projected_df.schema)
 
+    def _resolve_numeric_foreign_key_collisions(
+        self,
+        rows: pl.DataFrame,
+        table_config: TableConfig,
+        fk_targets: list[str],
+    ) -> pl.DataFrame:
+        if rows.is_empty():
+            return rows
+        resolved = rows
+        for target in fk_targets:
+            marker = f"__xtdb_generated_{target}"
+            if marker not in resolved.columns or not _xtdb_is_integer_config_column(
+                table_config, target
+            ):
+                continue
+
+            occupied: set[int] = set()
+            while True:
+                existing = self._dataframes().table_query(
+                    table_config.schema,
+                    table_config.name,
+                    resolved.select(target).unique(maintain_order=True),
+                    [target],
+                    table_config=table_config,
+                )
+                occupied.update(existing.get_column(target).drop_nulls().to_list())
+
+                used: set[int] = set()
+                values: list[int] = []
+                changed = False
+                minimum = _xtdb_integer_min(table_config, target)
+                for row in resolved.select([target, marker]).iter_rows(named=True):
+                    value = int(row[target])
+                    generated = bool(row[marker])
+                    if not generated and (value in occupied or value in used):
+                        raise ValueError(
+                            f"Foreign key {table_config.name}.{target} is already in use"
+                        )
+                    while value in occupied or value in used:
+                        value = value - 1 if value > minimum else -1
+                        changed = True
+                    used.add(value)
+                    values.append(value)
+
+                if changed:
+                    resolved = resolved.with_columns(pl.Series(target, values))
+                    continue
+                break
+
+        return resolved
+
     def _deduce_foreign_keys(
         self,
         stage_df: pl.DataFrame,
@@ -2075,12 +2195,22 @@ class XtdbStagingOps:
             }
         )
         for source_column, target_column in fk_map.items():
+            generated = generated.with_columns(
+                (
+                    pl.lit(True)
+                    if source_column not in candidates.columns
+                    else pl.col(target_column).is_null()
+                ).alias(f"__xtdb_generated_{target_column}")
+            )
             if _xtdb_is_integer_config_column(table_config, target_column):
                 generated_value = (
                     pl.struct(value_targets)
                     .map_elements(
-                        lambda row: _xtdb_deduced_numeric_foreign_key_id(
-                            table_config, value_targets, row
+                        partial(
+                            _xtdb_deduced_numeric_foreign_key_id,
+                            table_config,
+                            target_column,
+                            value_targets,
                         ),
                         return_dtype=pl.Int64,
                     )
@@ -2107,19 +2237,13 @@ class XtdbStagingOps:
                     pl.coalesce(target_column, generated_value).alias(target_column)
                 )
 
-        parent_df = self._dataframes().from_table(
+        parent_lookup = self._dataframes().table_query(
             table_config.schema,
             table_config.name,
+            generated.select(value_targets).unique(maintain_order=True),
+            [*fk_targets, *value_targets],
+            table_config=table_config,
         )
-        parent_lookup_columns = [
-            column
-            for column in [*fk_targets, *value_targets]
-            if column in parent_df.columns
-        ]
-        if parent_lookup_columns:
-            parent_lookup = parent_df.select(parent_lookup_columns)
-        else:
-            parent_lookup = pl.DataFrame(schema=generated.schema)
         parent_lookup = _cast_null_parent_lookup_columns(
             parent_lookup,
             generated,
@@ -2160,6 +2284,27 @@ class XtdbStagingOps:
                 )
         else:
             missing_parent_rows = joined
+
+        missing_parent_rows = self._resolve_numeric_foreign_key_collisions(
+            missing_parent_rows,
+            table_config,
+            fk_targets,
+        )
+        resolved_keys = missing_parent_rows.select(
+            [*value_targets, *fk_targets]
+        ).unique(maintain_order=True)
+        joined = joined.join(
+            resolved_keys,
+            on=value_targets,
+            how="left",
+            suffix="__resolved",
+        )
+        for target_column in fk_targets:
+            resolved_column = f"{target_column}__resolved"
+            if resolved_column in joined.columns:
+                joined = joined.with_columns(
+                    pl.coalesce(resolved_column, target_column).alias(target_column)
+                ).drop(resolved_column)
 
         parent_rows_to_insert = missing_parent_rows.select(
             [*fk_targets, *value_targets]

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -399,7 +399,7 @@ def test_xtdb_temporal_upsert_takes_last_duplicate_source_key():
 def test_xtdb_temporal_upsert_drop_unchanged_treats_missing_table_as_empty():
     backend = XtdbBackend()
     ops = Mock()
-    ops.from_raw_sql.side_effect = Exception("Table not found: test.records")
+    ops.table_query.side_effect = Exception("Table not found: test.records")
     ops.table_insert.return_value = 1
     table_config = TableConfig(
         schema="test",
@@ -464,7 +464,7 @@ def test_xtdb_temporal_upsert_dropout_treats_missing_table_as_empty():
 def test_xtdb_temporal_upsert_treats_explicit_valid_time_change_as_changed():
     backend = XtdbBackend()
     ops = Mock()
-    ops.from_raw_sql.return_value = pl.DataFrame(
+    ops.table_query.return_value = pl.DataFrame(
         {
             "_id": [1],
             "destination": ["Alpha"],
@@ -513,7 +513,7 @@ def test_xtdb_temporal_upsert_treats_explicit_valid_time_change_as_changed():
 def test_xtdb_temporal_upsert_ignores_valid_from_when_filtering_unchanged_rows():
     backend = XtdbBackend()
     ops = Mock()
-    ops.from_raw_sql.return_value = pl.DataFrame(
+    ops.table_query.return_value = pl.DataFrame(
         {
             "_id": [1],
             "destination": ["Alpha"],
@@ -554,7 +554,7 @@ def test_xtdb_temporal_upsert_ignores_valid_from_when_filtering_unchanged_rows()
 def test_xtdb_temporal_upsert_normalizes_types_when_filtering_unchanged_rows():
     backend = XtdbBackend()
     ops = Mock()
-    ops.from_raw_sql.return_value = pl.DataFrame(
+    ops.table_query.return_value = pl.DataFrame(
         {
             "_id": [1],
             "destination": ["Alpha"],
@@ -655,7 +655,7 @@ def test_xtdb_temporal_upsert_prefills_configured_defaults_before_insert():
 def test_xtdb_temporal_upsert_treats_null_to_value_as_changed():
     backend = XtdbBackend()
     ops = Mock()
-    ops.from_raw_sql.return_value = pl.DataFrame(
+    ops.table_query.return_value = pl.DataFrame(
         {
             "_id": [1],
             "amount_value": [None],

--- a/tests/backends/test_xtdb_dataframe_ops.py
+++ b/tests/backends/test_xtdb_dataframe_ops.py
@@ -366,6 +366,41 @@ def test_xtdb_dataframe_ops_splits_pgwire_insert_by_max_rows():
     assert cursor.executemany.call_args.args[1] == [(5, "E")]
 
 
+def test_xtdb_dataframe_ops_chunks_table_query(monkeypatch):
+    table_config = TableConfig(
+        schema="test",
+        name="records",
+        primary_keys=["id"],
+        columns=[TableColumnConfig("records", "id", "BIGINT", nullable=False)],
+    )
+    monkeypatch.setattr(
+        XtdbTableConfigOps,
+        "from_table",
+        lambda self, table_schema, table_name: table_config,
+    )
+    ops = XtdbDataframeOps(object(), max_rows_per_insert=2)
+    ops.from_raw_sql = Mock(
+        side_effect=[
+            pl.DataFrame({"id": [1, 2]}),
+            pl.DataFrame({"id": [3, 4]}),
+            pl.DataFrame({"id": [5]}),
+        ]
+    )
+
+    result = ops.table_query(
+        "test",
+        "records",
+        pl.DataFrame({"id": [1, 2, 3, 4, 5]}),
+        ["id"],
+    )
+
+    assert result.to_dict(as_series=False) == {"id": [1, 2, 3, 4, 5]}
+    assert ops.from_raw_sql.call_count == 3
+    assert all(
+        call.args[0].count("UNION ALL") <= 1 for call in ops.from_raw_sql.call_args_list
+    )
+
+
 def test_xtdb_arrow_copy_writes_one_arrow_stream_transaction():
     driver_connection = MagicMock()
     connection = Mock()

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -562,7 +562,7 @@ def test_xtdb_staging_deduces_foreign_keys_and_inserts_missing_parent(
         Mock(return_value=stage_df),
     )
     monkeypatch.setattr(
-        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_table",
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_query",
         Mock(return_value=parent_df),
     )
     inserted = {}
@@ -669,7 +669,7 @@ def test_xtdb_staging_inserts_missing_parent_with_adbc_bulk_connection(monkeypat
         Mock(return_value=stage_df),
     )
     monkeypatch.setattr(
-        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_table",
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_query",
         Mock(return_value=parent_df),
     )
     monkeypatch.setattr(
@@ -758,7 +758,7 @@ def test_xtdb_staging_deduces_explicit_numeric_foreign_keys(monkeypatch):
         Mock(return_value=stage_df),
     )
     monkeypatch.setattr(
-        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_table",
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_query",
         Mock(return_value=parent_df),
     )
     inserted = {}
@@ -868,7 +868,7 @@ def test_xtdb_staging_generates_numeric_foreign_key_when_source_key_is_missing(
         Mock(return_value=stage_df),
     )
     monkeypatch.setattr(
-        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_table",
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_query",
         Mock(return_value=parent_df),
     )
     inserted = {}
@@ -980,7 +980,7 @@ def test_xtdb_staging_reuses_deduced_foreign_key_for_later_primary_item(
         Mock(return_value=stage_df),
     )
     monkeypatch.setattr(
-        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_table",
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_query",
         Mock(return_value=parent_df),
     )
     monkeypatch.setattr(
@@ -1101,7 +1101,7 @@ def test_xtdb_staging_does_not_insert_same_generated_parent_twice(
         Mock(return_value=stage_df),
     )
     monkeypatch.setattr(
-        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_table",
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_query",
         Mock(return_value=parent_df),
     )
     inserted = []
@@ -1215,7 +1215,7 @@ def test_xtdb_staging_deduces_existing_foreign_key_without_insert(monkeypatch):
         Mock(return_value=stage_df),
     )
     monkeypatch.setattr(
-        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_table",
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_query",
         Mock(return_value=parent_df),
     )
     table_insert = Mock(return_value=0)
@@ -1290,7 +1290,7 @@ def test_xtdb_staging_deduces_foreign_keys_with_null_typed_empty_parent(
         Mock(return_value=stage_df),
     )
     monkeypatch.setattr(
-        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_table",
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_query",
         Mock(return_value=parent_df),
     )
     table_insert = Mock(return_value=1)
@@ -1340,3 +1340,60 @@ def test_xtdb_staging_deduces_foreign_keys_with_null_typed_empty_parent(
         "country_id": ["country:japan"],
         "name": ["Japan"],
     }
+
+
+def test_xtdb_staging_resolves_generated_numeric_key_collisions(monkeypatch):
+    table_config = TableConfig(
+        schema="ref",
+        name="parents",
+        primary_keys=["id"],
+        columns=[TableColumnConfig("parents", "id", "INT", nullable=False)],
+    )
+    table_query = Mock(return_value=pl.DataFrame({"id": []}, schema={"id": pl.Int64}))
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_query",
+        table_query,
+    )
+    rows = pl.DataFrame(
+        {
+            "id": [-42, -42],
+            "__xtdb_generated_id": [True, True],
+        }
+    )
+
+    result = XtdbStagingOps(object())._resolve_numeric_foreign_key_collisions(
+        rows,
+        table_config,
+        ["id"],
+    )
+
+    assert result.get_column("id").to_list() == [-42, -43]
+    assert table_query.call_count == 2
+
+
+def test_xtdb_staging_avoids_existing_generated_numeric_key(monkeypatch):
+    table_config = TableConfig(
+        schema="ref",
+        name="parents",
+        primary_keys=["id"],
+        columns=[TableColumnConfig("parents", "id", "INT", nullable=False)],
+    )
+    table_query = Mock(
+        side_effect=[
+            pl.DataFrame({"id": [-42]}),
+            pl.DataFrame({"id": []}, schema={"id": pl.Int64}),
+        ]
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_query",
+        table_query,
+    )
+    rows = pl.DataFrame({"id": [-42], "__xtdb_generated_id": [True]})
+
+    result = XtdbStagingOps(object())._resolve_numeric_foreign_key_collisions(
+        rows,
+        table_config,
+        ["id"],
+    )
+
+    assert result.get_column("id").to_list() == [-43]


### PR DESCRIPTION
## Summary
- replace full target reads during unchanged-row comparison with chunked key lookups
- resolve parent references using only uploaded natural keys
- probe and resolve generated integer ID collisions, including wider BIGINT hashes
- keep pgwire and ADBC read paths aligned
- update the scaling benchmark and backend contract

## Measured scaling
With a fixed 50K upload and 8 value columns, synthetic comparison took 0.005-0.030s at 50K, 500K, and 5M stored rows. Parent-reference work took 0.19-0.30s across the same sizes and 0%, 50%, and 100% match rates, with zero collisions. Database/network latency and inserts are excluded.

## Verification
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest -q` (200 passed, 13 deselected)
- `uv run python benchmarks/xtdb_delta.py --target-rows 50000,500000,5000000 --upload-rows 50000 --value-columns 8 --repeats 1 --fk-match-fractions 0,0.5,1`

The live container suite could not run locally because the Docker daemon is unavailable; CI is the live SQL-path gate.