### PR TITLE
fix(xtdb): store DATETIME precision columns as timestamps

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -401,6 +401,8 @@ def _xtdb_cast_type(data_type: str) -> str:
     normalized = data_type.upper()
     if normalized.startswith(("VARCHAR", "CHAR")) or "TEXT" in normalized:
         return "TEXT"
+    if normalized in {"JSON", "JSONB"}:
+        return "TEXT"
     if normalized in {"DOUBLE", "DOUBLE PRECISION"}:
         return "DOUBLE PRECISION"
     if normalized in {"FLOAT", "REAL"}:
@@ -413,13 +415,13 @@ def _xtdb_cast_type(data_type: str) -> str:
         return "INTEGER"
     if normalized in {"BIGINT", "DATE", "TIME"}:
         return normalized
-    if normalized == "DATETIME":
+    if normalized.startswith("DATETIME"):
         return "TIMESTAMP"
     if normalized.startswith(("DECIMAL", "NUMERIC")):
         return normalized
     if normalized.startswith("TIMESTAMP"):
         return normalized
-    return "TEXT"
+    raise ValueError(f"Unsupported XTDB column type: {data_type}")
 
 
 def _xtdb_cast_type_from_polars(dtype: pl.DataType) -> str:

--- a/polars_hist_db/types.py
+++ b/polars_hist_db/types.py
@@ -267,13 +267,15 @@ class SQLAlchemyType:
     @staticmethod
     def from_sql(sql_type: str) -> TypeEngine:
         t = sql_type.upper()
+        type_name, params, param_dict = _TypeConversionUtils._parse_parameterised_type(
+            t
+        )
+        if type_name == "DATETIME" and params and params[0]:
+            return mysql.DATETIME(fsp=int(params[0]))
         idx = _TypeConversionUtils._rowidx_from_sql_type(t)
         if idx >= 0:
             return TYPE_PRIORITY_MAP[idx][2]
 
-        type_name, params, param_dict = _TypeConversionUtils._parse_parameterised_type(
-            t
-        )
         if type_name == "VARCHAR":
             length = int(param_dict.get("length") or param_dict.get("a") or params[0])
             return sqlalchemy.types.VARCHAR(length=length)

--- a/tests/backends/test_override_table_contract.py
+++ b/tests/backends/test_override_table_contract.py
@@ -3,6 +3,8 @@ from polars_hist_db.overrides import (
     build_override_table_config,
     build_override_valid_time_config,
 )
+from polars_hist_db.types import SQLAlchemyType
+from sqlalchemy.dialects import mysql
 
 
 def test_override_table_config_builds_sqlalchemy_columns_for_mariadb_path():
@@ -27,6 +29,15 @@ def test_override_table_config_builds_sqlalchemy_columns_for_mariadb_path():
     }
     operation_id = next(column for column in columns if column.name == "operation_id")
     assert operation_id.primary_key is True
+    assert {
+        column.name: column.type.fsp
+        for column in columns
+        if isinstance(column.type, mysql.DATETIME)
+    } == {"valid_from": 6, "valid_to": 6, "recorded_at": 6}
+
+
+def test_mariadb_datetime_without_precision_remains_supported():
+    assert repr(SQLAlchemyType.from_sql("DATETIME()")) == "DATETIME()"
 
 
 def test_override_valid_time_config_targets_business_window_for_xtdb_path():

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -32,6 +32,11 @@ def test_xtdb_casts_mediumtext_as_text():
     assert _xtdb_cast_type("MEDIUMTEXT") == "TEXT"
 
 
+def test_xtdb_rejects_unknown_configured_column_type():
+    with pytest.raises(ValueError, match="Unsupported XTDB column type: UUID"):
+        _xtdb_cast_type("UUID")
+
+
 def test_xtdb_backend_builds_crdt_document_store(monkeypatch):
     class Store:
         def __init__(self, connection, document_store, projection):

--- a/tests/backends/test_xtdb_dataframe_ops.py
+++ b/tests/backends/test_xtdb_dataframe_ops.py
@@ -516,6 +516,39 @@ def test_xtdb_dataframe_ops_normalizes_bound_timestamp_parameters_to_naive_utc()
     assert insert_call.args[1] == [(1, 1, datetime(2030, 1, 1, 12, 30))]
 
 
+def test_xtdb_dataframe_ops_casts_datetime_precision_to_timestamp():
+    driver_connection = Mock()
+    connection = Mock()
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+    ops = XtdbDataframeOps(connection)
+    table_config = TableConfig(
+        schema="test",
+        name="records",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "seen_at", "DATETIME(6)"),
+        ],
+    )
+
+    ops.table_insert(
+        pl.DataFrame(
+            {
+                "id": [1],
+                "seen_at": [datetime(2030, 1, 1, 12, 30, tzinfo=timezone.utc)],
+            }
+        ),
+        "test",
+        "records",
+        table_config=table_config,
+    )
+
+    insert_call = _single_executemany_call(driver_connection)
+    assert "%s::TIMESTAMP" in insert_call.args[0]
+    assert insert_call.args[1] == [(1, 1, datetime(2030, 1, 1, 12, 30))]
+
+
 def test_xtdb_dataframe_ops_uses_native_casts_for_mysql_compatibility_types():
     driver_connection = Mock()
     connection = Mock()


### PR DESCRIPTION
Fixes timestamp handling across both backends.\n\n- XTDB: `DATETIME(6)` now maps to `TIMESTAMP`; unsupported configured types fail closed rather than silently becoming text.\n- MariaDB: parameterised `DATETIME(6)` now compiles to `DATETIME(6)`, retaining microseconds, while reflected plain `DATETIME()` remains supported.\n\nIncludes focused regression tests for both paths.