### PR TITLE
fix(xtdb): order composition history by system time

### DIFF
--- a/polars_hist_db/overrides/xtdb.py
+++ b/polars_hist_db/overrides/xtdb.py
@@ -97,9 +97,10 @@ class XtdbLayerCompositionStore:
             rows = self.connection.execute(
                 text(
                     "SELECT revision_id, layer_id, child_layer_ids_json, "
-                    f"valid_from, valid_to, recorded_at, supersedes_revision_id "
+                    f"valid_from, valid_to, recorded_at, _system_from AS system_from, "
+                    f"supersedes_revision_id "
                     f"FROM {_table_name(self.table)}"
-                    f"{predicate} ORDER BY recorded_at, revision_id"
+                    f"{predicate} ORDER BY _system_from, revision_id"
                 )
             ).mappings()
             return tuple(_composition_revision(row) for row in rows)
@@ -122,7 +123,7 @@ def _composition_revision(row: Mapping[str, object]) -> CompositionRevision:
         tuple(str(item) for item in children),
         _datetime(row["valid_from"]),
         None if row.get("valid_to") is None else _datetime(row["valid_to"]),
-        _datetime(row["recorded_at"]),
+        _datetime(row.get("system_from") or row["recorded_at"]),
         None
         if row.get("supersedes_revision_id") is None
         else str(row["supersedes_revision_id"]),

--- a/tests/overrides/test_composition_store.py
+++ b/tests/overrides/test_composition_store.py
@@ -9,6 +9,7 @@ from polars_hist_db.overrides import (
     build_layer_composition_table_config,
     build_override_purge_table_config,
 )
+from polars_hist_db.overrides.xtdb import XtdbLayerCompositionStore
 
 
 def test_configurable_composition_and_purge_tables() -> None:
@@ -45,3 +46,22 @@ def test_in_memory_composition_store_preserves_revision_order() -> None:
     store.append(first, "editor")
 
     assert store.revisions("root") == (first,)
+
+
+def test_xtdb_composition_history_orders_by_system_time() -> None:
+    class Connection:
+        statement = ""
+
+        def execute(self, statement):
+            self.statement = str(statement)
+            return self
+
+        def mappings(self):
+            return []
+
+    connection = Connection()
+    store = XtdbLayerCompositionStore(connection, LayerCompositionStoreConfig())
+
+    assert store.revisions() == ()
+    assert "_system_from AS system_from" in connection.statement
+    assert "ORDER BY _system_from, revision_id" in connection.statement


### PR DESCRIPTION
Avoids mixing legacy text `recorded_at` values with new timestamps in XTDB composition history. Uses `_system_from` as authoritative recorded time and retains a focused regression test.