### PR TITLE
feat: add backend-neutral table health probes

### DIFF
--- a/polars_hist_db/backends/__init__.py
+++ b/polars_hist_db/backends/__init__.py
@@ -1,10 +1,11 @@
-from .base import HistoricalDbBackend
+from .base import HistoricalDbBackend, TableHealthResult
 from .config import BackendName, DbEngineConfig
 
 __all__ = [
     "BackendName",
     "DbEngineConfig",
     "HistoricalDbBackend",
+    "TableHealthResult",
     "MariaDbBackend",
     "XtdbBackend",
     "backend_from_config",

--- a/polars_hist_db/backends/base.py
+++ b/polars_hist_db/backends/base.py
@@ -1,19 +1,90 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+import re
 from typing import TYPE_CHECKING, Any, Protocol
+
+from sqlalchemy import text
 
 if TYPE_CHECKING:
     from ..config import TableConfig
+    from .config import DbEngineConfig
+
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class TableHealthResult:
+    ready: bool
+    minimum_rows: int
+    sampled_rows: int
+
+    @property
+    def detail(self) -> str:
+        if self.minimum_rows == 0:
+            return "readable"
+        rows = "row" if self.minimum_rows == 1 else "rows"
+        if self.ready:
+            return f"at least {self.minimum_rows} {rows}"
+        return f"need ≥{self.minimum_rows} {rows}, found {self.sampled_rows}"
+
+
+def bounded_table_health_query(
+    table_schema: str,
+    table_name: str,
+    minimum_rows: int,
+    *,
+    quote: str,
+) -> str:
+    if (
+        not isinstance(minimum_rows, int)
+        or isinstance(minimum_rows, bool)
+        or minimum_rows < 0
+    ):
+        raise ValueError("minimum_rows must be a non-negative integer")
+    for identifier in (table_schema, table_name):
+        if not _IDENTIFIER_RE.fullmatch(identifier):
+            raise ValueError(f"Invalid SQL identifier {identifier!r}")
+    qualified_table = f"{quote}{table_schema}{quote}.{quote}{table_name}{quote}"
+    return f"SELECT 1 FROM {qualified_table} LIMIT {minimum_rows}"
+
+
+def execute_table_health_query(
+    connection: Any,
+    query: str,
+    minimum_rows: int,
+) -> TableHealthResult:
+    sampled_rows = len(connection.execute(text(query)).fetchall())
+    return TableHealthResult(
+        ready=minimum_rows == 0 or sampled_rows >= minimum_rows,
+        minimum_rows=minimum_rows,
+        sampled_rows=sampled_rows,
+    )
 
 
 class HistoricalDbBackend(Protocol):
     name: str
+
+    def create_engine(self, config: DbEngineConfig) -> Any: ...
 
     def dataframes(self, connection: Any) -> Any: ...
 
     def table_configs(self, connection: Any) -> Any: ...
 
     def tables(self, table_schema: str, table_name: str, connection: Any) -> Any: ...
+
+    def table_health_query(
+        self, table_schema: str, table_name: str, minimum_rows: int = 0
+    ) -> str: ...
+
+    def check_table_resource(
+        self,
+        connection: Any,
+        table_schema: str,
+        table_name: str,
+        minimum_rows: int = 0,
+    ) -> TableHealthResult: ...
 
     def finalize_ingest_run(
         self, connection: Any, delta_table_config: TableConfig

--- a/polars_hist_db/backends/mariadb.py
+++ b/polars_hist_db/backends/mariadb.py
@@ -8,6 +8,11 @@ from sqlalchemy.engine import Engine
 
 from ..core import DataframeOps, TableConfigOps, TableOps
 from ..core import TimeHint
+from .base import (
+    TableHealthResult,
+    bounded_table_health_query,
+    execute_table_health_query,
+)
 from .config import DbEngineConfig
 from .temporal import system_time_hint_clause
 
@@ -75,6 +80,26 @@ class MariaDbBackend:
 
     def tables(self, table_schema: str, table_name: str, connection: Any) -> TableOps:
         return TableOps(table_schema, table_name, connection)
+
+    def table_health_query(
+        self, table_schema: str, table_name: str, minimum_rows: int = 0
+    ) -> str:
+        return bounded_table_health_query(
+            table_schema, table_name, minimum_rows, quote="`"
+        )
+
+    def check_table_resource(
+        self,
+        connection: Any,
+        table_schema: str,
+        table_name: str,
+        minimum_rows: int = 0,
+    ) -> TableHealthResult:
+        return execute_table_health_query(
+            connection,
+            self.table_health_query(table_schema, table_name, minimum_rows),
+            minimum_rows,
+        )
 
     def time_hint_clause(self, time_hint: TimeHint) -> str | None:
         return system_time_hint_clause(time_hint)

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -27,6 +27,11 @@ from ..core import TimeHint
 from ..pipeline_projection import project_staged_pipeline_item_dataframe
 from ..types import PolarsType
 from .config import DbEngineConfig
+from .base import (
+    TableHealthResult,
+    bounded_table_health_query,
+    execute_table_health_query,
+)
 from .temporal import system_time_hint_clause
 
 if TYPE_CHECKING:
@@ -2403,6 +2408,26 @@ class XtdbBackend:
 
     def table_configs(self, connection: Any) -> XtdbTableConfigOps:
         return XtdbTableConfigOps(connection)
+
+    def table_health_query(
+        self, table_schema: str, table_name: str, minimum_rows: int = 0
+    ) -> str:
+        return bounded_table_health_query(
+            table_schema, table_name, minimum_rows, quote='"'
+        )
+
+    def check_table_resource(
+        self,
+        connection: Any,
+        table_schema: str,
+        table_name: str,
+        minimum_rows: int = 0,
+    ) -> TableHealthResult:
+        return execute_table_health_query(
+            connection,
+            self.table_health_query(table_schema, table_name, minimum_rows),
+            minimum_rows,
+        )
 
     def crdt_documents(
         self,

--- a/tests/backends/test_health.py
+++ b/tests/backends/test_health.py
@@ -1,0 +1,68 @@
+from unittest.mock import Mock
+
+import pytest
+
+from polars_hist_db.backends import MariaDbBackend, XtdbBackend
+
+
+@pytest.mark.parametrize(
+    ("backend", "expected_table"),
+    [
+        (MariaDbBackend(), "`app`.`events`"),
+        (XtdbBackend(), '"app"."events"'),
+    ],
+)
+def test_backend_health_query_is_dialect_correct_and_bounded(backend, expected_table):
+    query = backend.table_health_query("app", "events", minimum_rows=3)
+
+    assert query == f"SELECT 1 FROM {expected_table} LIMIT 3"
+    assert "COUNT" not in query
+
+
+@pytest.mark.parametrize("backend", [MariaDbBackend(), XtdbBackend()])
+def test_backend_health_check_enforces_minimum_rows(backend):
+    connection = Mock()
+    connection.execute.return_value.fetchall.return_value = [(1,), (1,)]
+
+    result = backend.check_table_resource(connection, "app", "events", minimum_rows=3)
+
+    assert result.ready is False
+    assert result.sampled_rows == 2
+    assert result.detail == "need ≥3 rows, found 2"
+    assert connection.execute.call_args.args[0].text.endswith("LIMIT 3")
+
+
+@pytest.mark.parametrize("backend", [MariaDbBackend(), XtdbBackend()])
+def test_backend_health_check_accepts_empty_table_when_no_minimum_is_configured(
+    backend,
+):
+    connection = Mock()
+    connection.execute.return_value.fetchall.return_value = []
+
+    result = backend.check_table_resource(connection, "app", "events")
+
+    assert result.ready is True
+    assert result.detail == "readable"
+    assert connection.execute.call_args.args[0].text.endswith("LIMIT 0")
+
+
+@pytest.mark.parametrize("backend", [MariaDbBackend(), XtdbBackend()])
+def test_backend_health_check_reports_singular_minimum(backend):
+    connection = Mock()
+    connection.execute.return_value.fetchall.return_value = [(1,)]
+
+    result = backend.check_table_resource(connection, "app", "events", minimum_rows=1)
+
+    assert result.detail == "at least 1 row"
+
+
+@pytest.mark.parametrize("backend", [MariaDbBackend(), XtdbBackend()])
+@pytest.mark.parametrize(
+    ("schema", "table", "minimum_rows"),
+    [("bad-schema", "events", 0), ("app", "bad.table", 0), ("app", "events", -1)],
+)
+def test_backend_health_query_rejects_invalid_input(
+    backend, schema, table, minimum_rows
+):
+    with pytest.raises(ValueError):
+        backend.table_health_query(schema, table, minimum_rows)


### PR DESCRIPTION
Summary:
- add a typed table health contract to HistoricalDbBackend
- implement bounded, dialect-correct probes for MariaDB and XTDB
- reject unsafe identifiers and invalid row thresholds without a generic fallback
- cover backend parity, bounded reads, row thresholds, and public result details

Why:
Periodic service health checks currently use full-table row counts, which caused a 13-second XTDB scan and starved the API event loop. Backends should own their efficient health semantics; consumers should not invent backend-specific SQL.

Verification:
- make check
- uv run pytest -q (218 passed, 13 deselected)

Follow-up: pyapi-service-kit will consume this contract off the asyncio event loop after this release.