### PR TITLE
fix(overrides): preserve deterministic replacement order

### DIFF
--- a/polars_hist_db/overrides/__init__.py
+++ b/polars_hist_db/overrides/__init__.py
@@ -24,6 +24,11 @@ from .crdt import (
     prepare_crdt_generation,
 )
 from .ledger import InMemoryOverrideLedgerStore, OverrideLedger
+from .ordering import (
+    override_recorded_order_sql,
+    override_recorded_time_sql,
+    project_personal_override_operations,
+)
 from .access import (
     AccessDocument,
     AccessGrant,
@@ -97,6 +102,9 @@ __all__ = [
     "AtomicUpdate",
     "InMemoryReplicatedOverrideLedger",
     "OverrideLedger",
+    "override_recorded_order_sql",
+    "override_recorded_time_sql",
+    "project_personal_override_operations",
     "OverrideLedgerConfig",
     "OverrideOperation",
     "OverrideOperationType",

--- a/polars_hist_db/overrides/ordering.py
+++ b/polars_hist_db/overrides/ordering.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Iterable
+
+from .types import OverrideOperation
+
+
+def override_recorded_time_sql(db_backend: str) -> str:
+    return (
+        "_system_from" if db_backend == "xtdb" else "COALESCE(recorded_at, valid_from)"
+    )
+
+
+def override_recorded_order_sql(db_backend: str) -> str:
+    recorded = override_recorded_time_sql(db_backend)
+    payload_order = (
+        ", COALESCE(recorded_at, valid_from)" if db_backend == "xtdb" else ""
+    )
+    return (
+        f"{recorded}{payload_order}, "
+        "CASE WHEN operation_type IN ('close', 'system_close') THEN 0 ELSE 1 END, "
+        "operation_id"
+    )
+
+
+def project_personal_override_operations(
+    operations: Iterable[OverrideOperation],
+) -> list[OverrideOperation]:
+    projected: list[OverrideOperation] = []
+    open_sets: dict[tuple[str, str, str], int] = {}
+    for operation in operations:
+        key = (operation.feed_id, operation.entity_id, operation.field_path)
+        if operation.operation_type == "set":
+            open_sets[key] = len(projected)
+        elif operation.operation_type in {"close", "system_close"}:
+            index = open_sets.pop(key, None)
+            if index is not None:
+                projected[index] = replace(
+                    projected[index],
+                    valid_to=max(operation.valid_from, projected[index].valid_from),
+                )
+        projected.append(operation)
+    return projected

--- a/tests/overrides/test_ordering.py
+++ b/tests/overrides/test_ordering.py
@@ -1,0 +1,56 @@
+from datetime import datetime, timezone
+
+from polars_hist_db.overrides import (
+    OverrideOperation,
+    OverrideTypedValue,
+    override_recorded_order_sql,
+    project_personal_override_operations,
+)
+
+
+def test_xtdb_order_preserves_close_before_set_within_one_transaction() -> None:
+    sql = override_recorded_order_sql("xtdb")
+
+    assert sql.startswith("_system_from, COALESCE(recorded_at, valid_from)")
+    assert "THEN 0 ELSE 1 END, operation_id" in sql
+
+
+def test_personal_projection_preserves_authoritative_store_order() -> None:
+    at = datetime(2026, 7, 17, tzinfo=timezone.utc)
+    close = OverrideOperation(
+        operation_id="op-z-close",
+        change_set_id="change-1",
+        owner_user_id="user-1",
+        actor_user_id="user-1",
+        feed_id="feed-1",
+        entity_id="entity-1",
+        field_path="classification",
+        observed_canonical_value_json=None,
+        created_against_stale_source=False,
+        valid_from=at,
+        recorded_at=at,
+        operation_type="close",
+        value=None,
+        valid_to=at,
+    )
+    replacement = OverrideOperation(
+        operation_id="op-a-set",
+        change_set_id="change-1",
+        owner_user_id="user-1",
+        actor_user_id="user-1",
+        feed_id="feed-1",
+        entity_id="entity-1",
+        field_path="classification",
+        operation_type="set",
+        value=OverrideTypedValue("enum", {"value": "Possible"}),
+        observed_canonical_value_json=None,
+        created_against_stale_source=False,
+        valid_from=at,
+        valid_to=None,
+        recorded_at=at,
+    )
+
+    projected = project_personal_override_operations([close, replacement])
+
+    assert projected[-1].operation_id == replacement.operation_id
+    assert projected[-1].valid_to is None


### PR DESCRIPTION
## Summary
- define backend-neutral override ordering in polars-hist-db
- keep XTDB system time authoritative while preserving intra-transaction operation order
- deterministically apply close before replacement set when timestamps tie
- project operations in the order supplied by the durable store

## Root cause
XTDB assigns one system timestamp to all operations in a transaction. Replacement close/set pairs were then ordered by random operation IDs, intermittently closing the new value.

## Verification
- pre-commit hooks (ruff, formatting, mypy)
- focused override ordering and ledger tests