### PR TITLE
feat(overrides): add typed columnar projection

### DIFF
--- a/polars_hist_db/overrides/__init__.py
+++ b/polars_hist_db/overrides/__init__.py
@@ -29,6 +29,7 @@ from .ordering import (
     override_recorded_time_sql,
     project_personal_override_operations,
 )
+from .projection import ColumnOverride, apply_columnar_overrides
 from .access import (
     AccessDocument,
     AccessGrant,
@@ -105,6 +106,8 @@ __all__ = [
     "override_recorded_order_sql",
     "override_recorded_time_sql",
     "project_personal_override_operations",
+    "ColumnOverride",
+    "apply_columnar_overrides",
     "OverrideLedgerConfig",
     "OverrideOperation",
     "OverrideOperationType",

--- a/polars_hist_db/overrides/projection.py
+++ b/polars_hist_db/overrides/projection.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+import polars as pl
+
+
+@dataclass(frozen=True)
+class ColumnOverride:
+    entity_id: str
+    column: str
+    value: Any
+    dtype: pl.DataType | None = None
+
+
+def apply_columnar_overrides(
+    frame: pl.DataFrame,
+    *,
+    entity_column: str,
+    overrides: Iterable[ColumnOverride],
+) -> pl.DataFrame:
+    if entity_column not in frame.columns:
+        raise ValueError(f"entity column {entity_column!r} does not exist")
+
+    latest = {(override.entity_id, override.column): override for override in overrides}
+    if not latest:
+        return frame
+
+    by_column: dict[str, list[ColumnOverride]] = {}
+    for override in latest.values():
+        by_column.setdefault(override.column, []).append(override)
+
+    missing = [
+        pl.lit(None, _override_dtype(values)).alias(column)
+        for column, values in by_column.items()
+        if column not in frame.columns
+    ]
+    if missing:
+        frame = frame.with_columns(missing)
+
+    entity_id = pl.col(entity_column).cast(pl.String)
+    return frame.with_columns(
+        [
+            entity_id.replace_strict(
+                [override.entity_id for override in values],
+                [override.value for override in values],
+                default=pl.col(column),
+                return_dtype=frame.schema[column],
+            ).alias(column)
+            for column, values in by_column.items()
+        ]
+    )
+
+
+def _override_dtype(overrides: list[ColumnOverride]) -> pl.DataType:
+    declared = [override.dtype for override in overrides if override.dtype is not None]
+    if declared:
+        if any(dtype != declared[0] for dtype in declared[1:]):
+            raise ValueError("conflicting dtypes for override column")
+        return declared[0]
+
+    inferred = pl.Series([override.value for override in overrides]).dtype
+    if inferred == pl.Null:
+        raise ValueError("dtype is required for an all-null override-only column")
+    return inferred

--- a/tests/overrides/test_columnar_projection.py
+++ b/tests/overrides/test_columnar_projection.py
@@ -1,0 +1,53 @@
+from datetime import datetime, timezone
+
+import polars as pl
+import pytest
+
+from polars_hist_db.overrides import ColumnOverride, apply_columnar_overrides
+
+
+def test_applies_overrides_columnarly_and_preserves_schema() -> None:
+    frame = pl.DataFrame(
+        {
+            "trade_id": range(150),
+            "status": ["Expected"] * 150,
+            "amount": [1.0] * 150,
+            "aware_at": [datetime(2026, 7, 1, tzinfo=timezone.utc)] * 150,
+            "naive_at": [datetime(2026, 7, 1)] * 150,
+        }
+    )
+    original_schema = frame.schema
+
+    result = apply_columnar_overrides(
+        frame,
+        entity_column="trade_id",
+        overrides=[
+            ColumnOverride("149", "status", "Possible"),
+            ColumnOverride("149", "status", "Actual"),
+            ColumnOverride("149", "amount", 3.5),
+            ColumnOverride(
+                "149", "aware_at", datetime(2026, 7, 2, tzinfo=timezone.utc)
+            ),
+            ColumnOverride("149", "naive_at", datetime(2026, 7, 2)),
+            ColumnOverride("149", "classification", "Actual", pl.String()),
+            ColumnOverride("0", "amount", None),
+        ],
+    )
+
+    assert result.select(original_schema.names()).schema == original_schema
+    assert result["status"][149] == "Actual"
+    assert result["amount"][0] is None
+    assert result["amount"][149] == 3.5
+    assert result["aware_at"][149] == datetime(2026, 7, 2, tzinfo=timezone.utc)
+    assert result["naive_at"][149] == datetime(2026, 7, 2)
+    assert result["classification"][0] is None
+    assert result["classification"][149] == "Actual"
+
+
+def test_requires_type_for_all_null_override_only_column() -> None:
+    with pytest.raises(ValueError, match="dtype is required"):
+        apply_columnar_overrides(
+            pl.DataFrame({"trade_id": [1]}),
+            entity_column="trade_id",
+            overrides=[ColumnOverride("1", "comment", None)],
+        )


### PR DESCRIPTION
## Summary
- add a backend-neutral Polars override projection primitive
- apply typed values without materializing canonical rows as Python objects
- retain existing schemas and create explicitly typed override-only columns
- use the last replacement for each entity and column

## Verification
- make check
- uv run pytest