### PR TITLE
fix: harden ingestion transaction semantics

### DIFF
--- a/docs/api.qmd
+++ b/docs/api.qmd
@@ -172,6 +172,9 @@ Input configuration is polymorphic via `InputConfig.from_dict(config)`.
 - `payload_ingest: JetstreamIngestConfig`
 - `run_until: Literal["empty", "forever"]`
 
+`JetStreamFetchConfig.heartbeat_interval` controls `in_progress()` heartbeats in
+seconds (default `30`; set to `0` to disable).
+
 ## Core Operations (`polars_hist_db.core`)
 
 ### DbOps

--- a/polars_hist_db/config/input/jetstream_config.py
+++ b/polars_hist_db/config/input/jetstream_config.py
@@ -28,6 +28,13 @@ class JetStreamFetchConfig:
     # timeout for a single fetch call in seconds
     batch_timeout: float = 5.0
 
+    # interval between in-progress heartbeats; 0 disables them
+    heartbeat_interval: float = 30.0
+
+    def __post_init__(self):
+        if self.heartbeat_interval < 0:
+            raise ValueError("heartbeat_interval cannot be negative")
+
 
 @dataclass
 class JetStreamConfig:

--- a/polars_hist_db/core/audit.py
+++ b/polars_hist_db/core/audit.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Literal, Optional
 
 import polars as pl
-from sqlalchemy import and_, Connection, delete, select, Table
+from sqlalchemy import and_, Connection, delete, func, Index, select, Table
 
 from ..config.input.types import InputDataSourceType
 from ..config.table import TableColumnConfig, TableConfig
@@ -143,6 +143,11 @@ class AuditOps:
         table_config = self._table_config()
         tbl = TableConfigOps(connection).create(table_config)
         assert tbl is not None
+        Index(
+            f"ix_{self._table_name}_table_ts",
+            tbl.c["table_name"],
+            tbl.c["data_source_ts"],
+        ).create(connection)
         return tbl
 
     def reset_dataset(self, target_table_name: str, connection: Connection) -> None:
@@ -251,14 +256,12 @@ class AuditOps:
                 return
 
             latest_log = _xtdb_dataframe_ops(connection).from_raw_sql(
-                "SELECT data_source_ts "
+                "SELECT MAX(data_source_ts) AS data_source_ts "
                 f"FROM {self._table_sql()} "
-                f"WHERE table_name = {_sql_literal(target_table_name)} "
-                "ORDER BY data_source_ts "
-                "LIMIT 1",
+                f"WHERE table_name = {_sql_literal(target_table_name)} ",
                 schema_overrides={"data_source_ts": pl.Datetime("us", "UTC")},
             )
-            if latest_log.is_empty():
+            if latest_log.is_empty() or latest_log[0, "data_source_ts"] is None:
                 return
 
             xtdb_latest_log_ts: datetime = latest_log[0, "data_source_ts"]
@@ -281,15 +284,12 @@ class AuditOps:
         self.create(connection)
         tbo = TableOps(self.schema, self._table_name, connection)
         tbl = tbo.get_table_metadata()
-        latest_log_sql = (
-            select(tbl)
-            .where(tbl.c["table_name"] == target_table_name)
-            .order_by("data_source_ts")
-            .limit(1)
-        )
+        latest_log_sql = select(
+            func.max(tbl.c["data_source_ts"]).label("data_source_ts")
+        ).where(tbl.c["table_name"] == target_table_name)
 
         latest_log = DataframeOps(connection).from_selectable(latest_log_sql)
-        if latest_log.is_empty():
+        if latest_log.is_empty() or latest_log[0, "data_source_ts"] is None:
             return
 
         latest_log_ts: datetime = latest_log[0, "data_source_ts"]
@@ -321,10 +321,10 @@ class AuditOps:
             existing_tbl_entries = (
                 _xtdb_dataframe_ops(connection)
                 .from_raw_sql(
-                    "SELECT data_source, data_source_ts "
+                    "SELECT data_source, MAX(data_source_ts) AS data_source_ts "
                     f"FROM {self._table_sql()} "
                     f"WHERE table_name = {_sql_literal(target_table_name)} "
-                    "ORDER BY data_source_ts",
+                    "GROUP BY data_source",
                     schema_overrides={"data_source_ts": pl.Datetime("us", "UTC")},
                 )
                 .with_columns(pl.col("data_source").cast(pl.Utf8))
@@ -345,9 +345,12 @@ class AuditOps:
 
         # get the set of datasource items already processed
         target_table_logs_sql = (
-            select(audit_tbl.c["data_source"], audit_tbl.c["data_source_ts"])
+            select(
+                audit_tbl.c["data_source"],
+                func.max(audit_tbl.c["data_source_ts"]).label("data_source_ts"),
+            )
             .where(audit_tbl.c["table_name"] == target_table_name)
-            .order_by(audit_tbl.c["data_source_ts"])
+            .group_by(audit_tbl.c["data_source"])
         )
 
         existing_tbl_entries = (
@@ -493,23 +496,19 @@ class AuditOps:
 
             where_clause = f"WHERE {' AND '.join(xtdb_filters)}" if xtdb_filters else ""
             latest_log = _xtdb_dataframe_ops(connection).from_raw_sql(
-                "SELECT * "
-                f"FROM {self._table_sql()} "
-                f"{where_clause} "
-                "ORDER BY data_source_ts DESC",
+                "SELECT audit_id, table_name, data_source_type, data_source, "
+                "data_source_ts, upload_ts FROM ("
+                "SELECT *, ROW_NUMBER() OVER ("
+                "PARTITION BY table_name ORDER BY data_source_ts DESC"
+                ") AS _rn "
+                f"FROM {self._table_sql()} {where_clause}"
+                ") AS ranked WHERE _rn = 1",
                 schema_overrides={
                     "data_source_ts": pl.Datetime("us", "UTC"),
                     "upload_ts": pl.Datetime("us", "UTC"),
                 },
             )
-            if latest_log.is_empty():
-                return latest_log
-            return (
-                latest_log.group_by("table_name")
-                .first()
-                .with_columns(pl.col("data_source_ts").cast(pl.Datetime("us", "UTC")))
-                .with_columns(pl.col("upload_ts").cast(pl.Datetime("us", "UTC")))
-            )
+            return latest_log
 
         tbl = self.create(connection)
         assert isinstance(tbl, Table)
@@ -524,19 +523,23 @@ class AuditOps:
                 raise ValueError("asof_timestamp must be timezone aware")
             filters.append(tbl.c["data_source_ts"] <= asof_timestamp)
 
-        latest_log_sql = (
+        ranked = (
             select(tbl)
+            .add_columns(
+                func.row_number()
+                .over(
+                    partition_by=tbl.c["table_name"],
+                    order_by=tbl.c["data_source_ts"].desc(),
+                )
+                .label("_rn")
+            )
             .where(and_(True, *filters))
-            .order_by(tbl.c["data_source_ts"].desc())
+            .subquery()
         )
+        latest_log_sql = select(
+            *(ranked.c[column.name] for column in tbl.columns)
+        ).where(ranked.c["_rn"] == 1)
 
-        latest_log = (
-            DataframeOps(connection)
-            .from_selectable(latest_log_sql)
-            .group_by("table_name")
-            .first()
-            .with_columns(pl.col("data_source_ts").cast(pl.Datetime("us", "UTC")))
-            .with_columns(pl.col("upload_ts").cast(pl.Datetime("us", "UTC")))
-        )
+        latest_log = DataframeOps(connection).from_selectable(latest_log_sql)
 
         return latest_log

--- a/polars_hist_db/core/audit.py
+++ b/polars_hist_db/core/audit.py
@@ -508,7 +508,10 @@ class AuditOps:
                     "upload_ts": pl.Datetime("us", "UTC"),
                 },
             )
-            return latest_log
+            return latest_log.with_columns(
+                pl.col("data_source_ts").cast(pl.Datetime("us", "UTC")),
+                pl.col("upload_ts").cast(pl.Datetime("us", "UTC")),
+            )
 
         tbl = self.create(connection)
         assert isinstance(tbl, Table)
@@ -540,6 +543,13 @@ class AuditOps:
             *(ranked.c[column.name] for column in tbl.columns)
         ).where(ranked.c["_rn"] == 1)
 
-        latest_log = DataframeOps(connection).from_selectable(latest_log_sql)
+        latest_log = (
+            DataframeOps(connection)
+            .from_selectable(latest_log_sql)
+            .with_columns(
+                pl.col("data_source_ts").cast(pl.Datetime("us", "UTC")),
+                pl.col("upload_ts").cast(pl.Datetime("us", "UTC")),
+            )
+        )
 
         return latest_log

--- a/polars_hist_db/core/dataframe.py
+++ b/polars_hist_db/core/dataframe.py
@@ -1,4 +1,5 @@
 from datetime import datetime, time
+from itertools import batched
 import logging
 from types import MappingProxyType
 from typing import Dict, Iterable, List, Literal, Mapping, Optional, Union
@@ -105,8 +106,8 @@ class DataframeOps:
             if col in default_values.keys():
                 col_polars_dtype = df[col].dtype
                 if col_polars_dtype == pl.Boolean:
-                    default_value = pl.lit(bool(default_values[col])).cast(
-                        col_polars_dtype
+                    default_value = PolarsType.convert_str_value(
+                        default_values[col], col_polars_dtype
                     )
                 elif col_polars_dtype == pl.Time:
                     default_value = pl.lit(
@@ -251,22 +252,13 @@ class DataframeOps:
             "inserting dataframe %s into %s.%s", df.shape, table_schema, table_name
         )
 
-        cols_to_upload = {c.name for c in tbl.columns}.intersection(df.columns)
-        num_rows_changed: int = (
-            df.select(cols_to_upload)
-            .to_pandas()
-            .to_sql(
-                name=table_name,
-                con=self.connection,
-                schema=table_schema,
-                if_exists="append",
-                index=False,
-                chunksize=1000,
+        cols_to_upload = [c.name for c in tbl.columns if c.name in df.columns]
+        num_rows_changed = 0
+        for rows in batched(df.select(cols_to_upload).iter_rows(named=True), 1000):
+            result = DbOps(self.connection).execute_sqlalchemy(
+                f"sql.dataframe.insert.{len(rows)}", tbl.insert(), list(rows)
             )
-        )
-
-        if num_rows_changed is None:
-            num_rows_changed = 0
+            num_rows_changed += max(result.rowcount, 0)
 
         LOGGER.debug("insert dataframe affected %d/%d rows", num_rows_changed, len(df))
 
@@ -307,11 +299,10 @@ class DataframeOps:
             .where(and_(*[tbl.c[k] == bindparam(f"_{k}") for k in primary_keys]))
         )
 
-        update_data = (
-            df.rename({col: f"_{col}" for col in common_cols})
-            .to_pandas()
-            .to_dict(orient="records")
-        )
+        update_data = [
+            {f"_{col}": value for col, value in row.items()}
+            for row in df.select(common_cols).iter_rows(named=True)
+        ]
 
         result = DbOps(self.connection).execute_sqlalchemy(
             f"sql.dataframe.update.{len(update_data)}",
@@ -383,14 +374,14 @@ class DataframeOps:
         update_time: Optional[datetime] = None,
     ) -> int:
         DbOps(self.connection).set_system_versioning_time(update_time)
-
-        num_deletions = 0
-        if not df.is_empty():
-            num_deletions = self.table_delete_rows(df, table_schema, table_name)
-
-        DbOps(self.connection).set_system_versioning_time(None)
-
-        return num_deletions
+        try:
+            return (
+                self.table_delete_rows(df, table_schema, table_name)
+                if not df.is_empty()
+                else 0
+            )
+        finally:
+            DbOps(self.connection).set_system_versioning_time(None)
 
     def table_delete_rows(
         self, df: pl.DataFrame, table_schema: str, table_name: str
@@ -409,34 +400,29 @@ class DataframeOps:
         tbl = tbo.get_table_metadata()
 
         primary_keys = [c.name for c in tbl.primary_key]
-        if len(set(df.columns).difference(primary_keys)) > 0:
-            raise ValueError("missing primary keys in dataframe: %s", primary_keys)
+        missing_primary_keys = set(primary_keys).difference(df.columns)
+        if missing_primary_keys:
+            raise ValueError(
+                f"missing primary keys in dataframe: {missing_primary_keys}"
+            )
 
         delete_sql = delete(tbl).where(
-            and_(*[tbl.c[col] == bindparam(f"_{col}") for col in df.columns])
+            and_(*[tbl.c[col] == bindparam(f"_{col}") for col in primary_keys])
         )
 
-        delete_data = (
-            df.rename({col: f"_{col}" for col in df.columns})
-            .to_pandas()
-            .to_dict(orient="records")
-        )
-
-        count_before = tbo.row_count()
-        _result = DbOps(self.connection).execute_sqlalchemy(
+        delete_data = [
+            {f"_{col}": value for col, value in zip(primary_keys, row, strict=True)}
+            for row in df.select(primary_keys).iter_rows()
+        ]
+        result = DbOps(self.connection).execute_sqlalchemy(
             f"sql.dataframe.delete.{len(delete_data)}",
             delete_sql,
             delete_data,
         )
-
-        count_after = tbo.row_count()
-
-        num_deleted_rows = count_after - count_before
         LOGGER.debug(
-            "deleted %d rows from %s.%s", num_deleted_rows, table_schema, table_name
+            "deleted %d rows from %s.%s", result.rowcount, table_schema, table_name
         )
-
-        return num_deleted_rows
+        return result.rowcount
 
 
 def _remove_duplicate_rows(
@@ -469,29 +455,14 @@ def _prevalidate_insert_from_dataframe(
         if col not in df.columns:
             continue
 
-        if is_text_col(str(col.type)):
-            df_col = df.select(col.name).drop_nulls()
-            if df_col.is_empty():
-                continue
-
-        try:
-            max_col_len = col.type.length  # type: ignore[attr-defined]
-            truncated_data = (
-                df_col.select(
-                    col.name,
-                    length=(
-                        pl.col(col.name)
-                        .cast(pl.Utf8)
-                        .map_elements(len, skip_nulls=True)
-                    ),
-                )
-                .sort(pl.col("length"), descending=True)
-                .filter(pl.col("length") >= pl.lit(max_col_len))
-            )
-
-            if not truncated_data.is_empty():
-                LOGGER.error("data truncation in column %s", col.name)
-                LOGGER.error(truncated_data)
-
-        except Exception as e:
-            LOGGER.error("failed to check column %s", col, exc_info=e)
+        if not is_text_col(str(col.type)):
+            continue
+        max_col_len = col.type.length  # type: ignore[attr-defined]
+        if max_col_len is None:
+            continue
+        truncated_data = df.filter(
+            pl.col(col.name).str.len_chars() > pl.lit(max_col_len)
+        )
+        if not truncated_data.is_empty():
+            LOGGER.error("data truncation in column %s", col.name)
+            LOGGER.error(truncated_data)

--- a/polars_hist_db/core/delta_table.py
+++ b/polars_hist_db/core/delta_table.py
@@ -53,44 +53,43 @@ class DeltaTableOps:
         src_tgt_colname_map: Mapping[str, str] = MappingProxyType({}),
     ) -> Tuple[int, int, int]:
         DbOps(self.connection).set_system_versioning_time(update_time)
+        try:
+            tgt_to_src_map = {v: k for k, v in src_tgt_colname_map.items()}
 
-        tgt_to_src_map = {v: k for k, v in src_tgt_colname_map.items()}
+            if self.delta_config.row_finality == "dropout":
+                deleted_keys = self._drop_missing_rows(
+                    self.table_schema, target_table, self.table_name, tgt_to_src_map
+                )
+                num_deletions = len(deleted_keys)
+            else:
+                num_deletions = 0
 
-        if self.delta_config.row_finality == "dropout":
-            deleted_keys = self._drop_missing_rows(
-                self.table_schema, target_table, self.table_name, tgt_to_src_map
-            )
-            num_deletions = len(deleted_keys)
-        else:
-            num_deletions = 0
+            tbo = TableOps(self.table_schema, self.table_name, self.connection)
+            if source_columns is None:
+                source_tbl = tbo.get_table_metadata()
+                source_columns = [c.name for c in source_tbl.columns]
 
-        tbo = TableOps(self.table_schema, self.table_name, self.connection)
-        if source_columns is None:
-            source_tbl = tbo.get_table_metadata()
-            source_columns = [c.name for c in source_tbl.columns]
+            if is_main_table and self.delta_config.drop_unchanged_rows:
+                ref_columns = [src_tgt_colname_map.get(c, c) for c in source_columns]
+                num_deletions += self._drop_unchanged_rows(
+                    self.table_schema,
+                    target_table=self.table_name,
+                    ref_table=target_table,
+                    ref_cmp_columns=ref_columns,
+                    ref_tgt_colname_map=tgt_to_src_map,
+                )
 
-        if is_main_table and self.delta_config.drop_unchanged_rows:
-            ref_columns = [src_tgt_colname_map.get(c, c) for c in source_columns]
-            num_deletions += self._drop_unchanged_rows(
+            num_inserts, num_updates = self._table_upsert_nontemporal(
                 self.table_schema,
-                target_table=self.table_name,
-                ref_table=target_table,
-                ref_cmp_columns=ref_columns,
-                ref_tgt_colname_map=tgt_to_src_map,
+                self.table_name,
+                target_table,
+                source_columns,
+                src_tgt_colname_map,
+                on_duplicate_key=self.delta_config.on_duplicate_key,
             )
-
-        num_inserts, num_updates = self._table_upsert_nontemporal(
-            self.table_schema,
-            self.table_name,
-            target_table,
-            source_columns,
-            src_tgt_colname_map,
-            on_duplicate_key=self.delta_config.on_duplicate_key,
-        )
-
-        DbOps(self.connection).set_system_versioning_time(None)
-
-        return num_inserts, num_updates, num_deletions
+            return num_inserts, num_updates, num_deletions
+        finally:
+            DbOps(self.connection).set_system_versioning_time(None)
 
     def _table_upsert_nontemporal(
         self,
@@ -445,5 +444,5 @@ def _prevalidate_upsert_from_table(
                 check_failed = True
                 continue
 
-        if check_failed:
-            raise ValueError("column type mismatches. check logs")
+    if check_failed:
+        raise ValueError("column type mismatches. check logs")

--- a/polars_hist_db/core/table.py
+++ b/polars_hist_db/core/table.py
@@ -69,13 +69,11 @@ class TableOps:
     def row_count(self) -> int:
         tbl = self.get_table_metadata()
         count_sql = select(func.count().label("nrow")).select_from(tbl)
-        row_count = DbOps(self.connection).execute_sqlalchemy(
-            "sql.op.row_count", count_sql
+        return (
+            DbOps(self.connection)
+            .execute_sqlalchemy("sql.op.row_count", count_sql)
+            .scalar_one()
         )
-        assert isinstance(row_count, int), (
-            f"expected row count to be int, got {type(row_count)}"
-        )
-        return row_count
 
     def get_column_intersection(
         self,

--- a/polars_hist_db/dataset/__init__.py
+++ b/polars_hist_db/dataset/__init__.py
@@ -1,3 +1,3 @@
-from .entrypoint import run_datasets
+from .entrypoint import RunResult, run_datasets
 
-__all__ = ["run_datasets"]
+__all__ = ["RunResult", "run_datasets"]

--- a/polars_hist_db/dataset/entrypoint.py
+++ b/polars_hist_db/dataset/entrypoint.py
@@ -1,6 +1,8 @@
+from dataclasses import dataclass
 from datetime import datetime
 import logging
 import time
+import warnings
 from typing import List, Optional, Tuple
 
 from nats.js.client import JetStreamContext
@@ -18,6 +20,13 @@ from .scrape import try_run_pipeline_as_transaction
 LOGGER = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class RunResult:
+    datasets_processed: int
+    datasets_failed: int
+    errors: tuple[Exception, ...]
+
+
 async def run_datasets(
     config: PolarsHistDbConfig,
     engine: Optional[Engine] = None,
@@ -26,37 +35,57 @@ async def run_datasets(
     js: Optional[JetStreamContext] = None,
     raise_on_error: bool = False,
 ):
+    if not raise_on_error:
+        warnings.warn(
+            "raise_on_error=False is deprecated; inspect the returned RunResult",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     backend = backend_from_config(config.db_config)
+    owns_engine = engine is None
     if engine is None:
         engine = backend.create_engine(config.db_config)
 
     num_datasets_processed = 0
+    errors: list[Exception] = []
     adbc_connection = None
     try:
-        for dataset in config.datasets.datasets:
-            if dataset_name is None or dataset.name == dataset_name:
-                if getattr(backend, "name", None) == "xtdb" and adbc_connection is None:
-                    adbc_connection = backend.create_adbc_connection(config.db_config)
+        selected_datasets = [
+            dataset
+            for dataset in config.datasets.datasets
+            if dataset_name is None or dataset.name == dataset_name
+        ]
+        if selected_datasets:
+            _create_config_tables(engine, config.tables, backend)
+        for dataset in selected_datasets:
+            if getattr(backend, "name", None) == "xtdb" and adbc_connection is None:
+                adbc_connection = backend.create_adbc_connection(config.db_config)
 
-                num_datasets_processed += 1
-                LOGGER.info("scraping dataset %s", dataset.name)
-                await _run_dataset(
-                    dataset.input_config,
-                    dataset,
-                    config.tables,
-                    engine,
-                    debug_capture_output,
-                    backend,
-                    adbc_connection=adbc_connection,
-                    js=js,
-                    raise_on_error=raise_on_error,
-                )
+            num_datasets_processed += 1
+            LOGGER.info("scraping dataset %s", dataset.name)
+            error = await _run_dataset(
+                dataset.input_config,
+                dataset,
+                config.tables,
+                engine,
+                debug_capture_output,
+                backend,
+                adbc_connection=adbc_connection,
+                js=js,
+                raise_on_error=raise_on_error,
+            )
+            if error is not None:
+                errors.append(error)
     finally:
         if adbc_connection is not None:
             adbc_connection.close()
+        if owns_engine:
+            engine.dispose()
 
     if num_datasets_processed == 0:
         LOGGER.error("no datasets processed for %s", dataset_name)
+
+    return RunResult(num_datasets_processed, len(errors), tuple(errors))
 
 
 def _create_config_tables(engine: Engine, tables: TableConfigs, backend):
@@ -98,7 +127,6 @@ async def _run_dataset(
 ):
     LOGGER.info("starting %s ingest for %s", input_config.type, dataset.name)
 
-    _create_config_tables(engine, tables, backend)
     delta_table_config = _build_delta_table_config(tables, dataset)
 
     start_time = time.perf_counter()
@@ -106,8 +134,9 @@ async def _run_dataset(
     input_source = InputSourceFactory.create_input_source(
         tables, dataset, input_config, js=js
     )
+    error = None
     try:
-        async for partitions, commit_fn in await input_source.next_df(engine):
+        async for partitions, finalizer in await input_source.next_df(engine):
             if debug_capture_output is not None:
                 debug_capture_output.extend(partitions)
 
@@ -116,7 +145,7 @@ async def _run_dataset(
                 dataset,
                 tables,
                 engine,
-                commit_fn,
+                finalizer,
                 delta_table_config=delta_table_config,
                 backend=backend,
                 adbc_connection=adbc_connection,
@@ -126,9 +155,11 @@ async def _run_dataset(
         LOGGER.error("error while processing InputSource: %s", e, exc_info=e)
         if raise_on_error:
             raise
+        error = e
     finally:
         await input_source.cleanup()
 
     Clock().add_timing("dataset", time.perf_counter() - start_time)
 
     LOGGER.info("stopped scrape - %s", dataset.name)
+    return error

--- a/polars_hist_db/dataset/scrape.py
+++ b/polars_hist_db/dataset/scrape.py
@@ -1,8 +1,9 @@
+import asyncio
 from datetime import datetime
 from contextlib import nullcontext
 import logging
-from time import sleep
-from typing import Any, Awaitable, Callable, List, Optional, Set, Tuple
+from random import uniform
+from typing import Any, List, Optional, Set, Tuple
 from uuid import uuid4
 
 import polars as pl
@@ -11,6 +12,7 @@ from sqlalchemy import Connection, Engine
 from ..config import TableConfig, TableConfigs, DatasetConfig
 from ..core import DataframeOps, TableConfigOps
 from ..utils import NonRetryableException
+from ..loaders.input_source import BatchFinalizer
 
 from .extract_item import scrape_extract_item
 from .primary_item import scrape_primary_item
@@ -84,14 +86,12 @@ def _ensure_delta_table(
     )
 
 
-async def try_run_pipeline_as_transaction(
+def _run_pipeline_as_transaction(
     partitions: List[Tuple[datetime, pl.DataFrame]],
     dataset: DatasetConfig,
     tables: TableConfigs,
     engine: Engine,
-    commit_fn: Callable[[Connection, List[Tuple[str, str]]], Awaitable[bool]],
-    num_retries: int = 3,
-    seconds_between_retries: float = 60,
+    finalizer: BatchFinalizer,
     delta_table_config: Optional[TableConfig] = None,
     backend: Any = None,
     adbc_connection: Any = None,
@@ -101,113 +101,135 @@ async def try_run_pipeline_as_transaction(
     header_keys = [tbl_to_header_map.get(k, k) for k in main_table_config.primary_keys]
     is_xtdb = getattr(backend, "name", None) == "xtdb"
 
-    while num_retries > 0:
-        with engine.connect() as connection:
-            try:
-                with _pipeline_transaction_context(connection, is_xtdb):
-                    staging = (
-                        backend.staging(
-                            connection,
-                            adbc_connection=adbc_connection,
-                        )
-                        if is_xtdb
-                        else None
+    with engine.connect() as connection:
+        with _pipeline_transaction_context(connection, is_xtdb):
+            staging = (
+                backend.staging(
+                    connection,
+                    adbc_connection=adbc_connection,
+                )
+                if is_xtdb
+                else None
+            )
+            if delta_table_config is not None and not is_xtdb:
+                _ensure_delta_table(
+                    connection,
+                    delta_table_config,
+                    dataset.delta_config.is_temporary_table,
+                )
+            modified_tables: Set[Tuple[str, str]] = set()
+            for i, (ts, partition_df) in enumerate(partitions):
+                stage_run_id = None
+                assert isinstance(ts, datetime), (
+                    f"timestamp is not a datetime [{type(ts)}]"
+                )
+                LOGGER.info(
+                    "-- (%d/%d) time_partition[%s] %d rows",
+                    i + 1,
+                    len(partitions),
+                    ts.isoformat(),
+                    len(partition_df),
+                )
+
+                if not is_xtdb:
+                    DataframeOps(connection).table_insert(
+                        partition_df,
+                        dataset.delta_table_schema,
+                        dataset.name,
+                        uniqueness_col_set=header_keys,
+                        prefill_nulls_with_default=True,
+                        clear_table_first=True,
                     )
-                    if delta_table_config is not None and not is_xtdb:
-                        _ensure_delta_table(
+                else:
+                    if delta_table_config is None:
+                        raise ValueError("XTDB ingest requires delta table config")
+                    if staging is None:
+                        raise ValueError("XTDB ingest requires staging ops")
+                    stage_run_id = f"{dataset.name}:{uuid4()}"
+                    staging.insert_partition(
+                        partition_df,
+                        delta_table_config,
+                        stage_run_id,
+                        ts,
+                        uniqueness_col_set=header_keys,
+                        prefill_nulls_with_default=True,
+                    )
+
+                try:
+                    for pipeline_id, (
+                        target_schema,
+                        target_table,
+                    ) in dataset.pipeline.get_pipeline_items().items():
+                        did_modify = _scrape_pipeline_item(
+                            pipeline_id,
+                            dataset,
+                            target_schema,
+                            target_table,
+                            tables,
+                            ts,
                             connection,
-                            delta_table_config,
-                            dataset.delta_config.is_temporary_table,
-                        )
-                    modified_tables: Set[Tuple[str, str]] = set()
-                    for i, (ts, partition_df) in enumerate(partitions):
-                        stage_run_id = None
-                        assert isinstance(ts, datetime), (
-                            f"timestamp is not a datetime [{type(ts)}]"
-                        )
-                        LOGGER.info(
-                            "-- (%d/%d) time_partition[%s] %d rows",
-                            i + 1,
-                            len(partitions),
-                            ts.isoformat(),
-                            len(partition_df),
+                            partition_df=partition_df,
+                            stage_run_id=stage_run_id,
+                            staging=staging,
+                            backend=backend,
                         )
 
-                        if not is_xtdb:
-                            DataframeOps(connection).table_insert(
-                                partition_df,
-                                dataset.delta_table_schema,
-                                dataset.name,
-                                uniqueness_col_set=header_keys,
-                                prefill_nulls_with_default=True,
-                                clear_table_first=True,
-                            )
-                        else:
-                            if delta_table_config is None:
-                                raise ValueError(
-                                    "XTDB ingest requires delta table config"
-                                )
-                            if staging is None:
-                                raise ValueError("XTDB ingest requires staging ops")
-                            stage_run_id = f"{dataset.name}:{uuid4()}"
-                            staging.insert_partition(
-                                partition_df,
-                                delta_table_config,
-                                stage_run_id,
-                                ts,
-                                uniqueness_col_set=header_keys,
-                                prefill_nulls_with_default=True,
-                            )
+                        if did_modify:
+                            modified_item = (target_schema, target_table)
+                            modified_tables.add(modified_item)
+                finally:
+                    if is_xtdb and stage_run_id is not None and staging is not None:
+                        staging.cleanup_run(stage_run_id)
 
-                        try:
-                            for pipeline_id, (
-                                target_schema,
-                                target_table,
-                            ) in dataset.pipeline.get_pipeline_items().items():
-                                did_modify = _scrape_pipeline_item(
-                                    pipeline_id,
-                                    dataset,
-                                    target_schema,
-                                    target_table,
-                                    tables,
-                                    ts,
-                                    connection,
-                                    partition_df=partition_df,
-                                    stage_run_id=stage_run_id,
-                                    staging=staging,
-                                    backend=backend,
-                                )
+            if delta_table_config is not None:
+                backend.finalize_ingest_run(connection, delta_table_config)
 
-                                if did_modify:
-                                    modified_item = (target_schema, target_table)
-                                    modified_tables.add(modified_item)
-                        finally:
-                            if (
-                                is_xtdb
-                                and stage_run_id is not None
-                                and staging is not None
-                            ):
-                                staging.cleanup_run(stage_run_id)
+            if not finalizer.write_audit_before_commit(
+                connection, sorted(modified_tables)
+            ):
+                raise NonRetryableException("Failed to update audit log")
 
-                    if delta_table_config is not None:
-                        backend.finalize_ingest_run(connection, delta_table_config)
 
-                    success = await commit_fn(connection, sorted(modified_tables))
-                    if success:
-                        return
-
-            except NonRetryableException as e:
-                LOGGER.error("non-retryable exception %s", e)
-                connection.rollback()
+async def try_run_pipeline_as_transaction(
+    partitions: List[Tuple[datetime, pl.DataFrame]],
+    dataset: DatasetConfig,
+    tables: TableConfigs,
+    engine: Engine,
+    finalizer: BatchFinalizer,
+    num_retries: int = 3,
+    seconds_between_retries: float = 60,
+    max_retry_delay: float = 300,
+    retry_jitter: float = 0.1,
+    delta_table_config: Optional[TableConfig] = None,
+    backend: Any = None,
+    adbc_connection: Any = None,
+):
+    if num_retries < 1:
+        raise ValueError("num_retries must be at least 1")
+    if not 0 <= retry_jitter <= 1:
+        raise ValueError("retry_jitter must be between 0 and 1")
+    for attempt in range(num_retries):
+        try:
+            await asyncio.to_thread(
+                _run_pipeline_as_transaction,
+                partitions,
+                dataset,
+                tables,
+                engine,
+                finalizer,
+                delta_table_config,
+                backend,
+                adbc_connection,
+            )
+            break
+        except NonRetryableException:
+            raise
+        except Exception as e:
+            LOGGER.error("error in scrape_pipeline_as_transaction", exc_info=e)
+            if attempt + 1 == num_retries:
                 raise
-
-            except Exception as e:
-                LOGGER.error("error in scrape_pipeline_as_transaction", exc_info=e)
-
-                connection.rollback()
-                if num_retries == 0:
-                    raise
-
-                sleep(seconds_between_retries)
-                LOGGER.info("retries remaining: %d", num_retries)
-                num_retries -= 1
+            delay = min(seconds_between_retries * 2**attempt, max_retry_delay)
+            delay *= uniform(1 - retry_jitter, 1 + retry_jitter)
+            LOGGER.info("retries remaining: %d", num_retries - attempt - 1)
+            await asyncio.sleep(delay)
+    await finalizer.ack_after_commit()

--- a/polars_hist_db/loaders/dsv/dsv_loader.py
+++ b/polars_hist_db/loaders/dsv/dsv_loader.py
@@ -133,11 +133,6 @@ def _validate_expected_columns(
         .difference(schema_overrides.keys())
     )
 
-    if len(headers_no_config) > 0:
-        headers_no_config_str = "],[".join(headers_no_config)
-        LOGGER.warning("dsv-headers skipped/unknown [%s]", headers_no_config_str)
-        dsv_df = dsv_df.drop(headers_no_config)
-
     defined_but_missing_headers = list(set(expected_headers).difference(dsv_df.columns))
 
     if len(defined_but_missing_headers) > 0:
@@ -148,14 +143,16 @@ def _validate_expected_columns(
             ",".join(defined_but_missing_headers),
         )
 
-        missing_columns_df = pl.DataFrame()
-        missing_columns_df = missing_columns_df.with_columns(
+        dsv_df = dsv_df.with_columns(
             [
                 pl.lit(None).cast(_get_column_target_dtype(h, header_cfgs)).alias(h)
                 for h in defined_but_missing_headers
             ]
-        ).clear()
+        )
 
-        LOGGER.debug(missing_columns_df)
+    if len(headers_no_config) > 0:
+        headers_no_config_str = "],[".join(headers_no_config)
+        LOGGER.warning("dsv-headers skipped/unknown [%s]", headers_no_config_str)
+        dsv_df = dsv_df.drop(headers_no_config)
 
     return dsv_df

--- a/polars_hist_db/loaders/dsv/file_search.py
+++ b/polars_hist_db/loaders/dsv/file_search.py
@@ -85,60 +85,29 @@ def _find_files_with_timestamps(
         max_depth=max_depth,
     )
 
-    entries = list(sd)
-
-    df = pl.DataFrame({"root_path": root_path, "entry": entries}).filter(
-        pl.col("entry").map_elements(
-            lambda x: x.is_file, skip_nulls=True, return_dtype=pl.Boolean
-        )
-    )
-
-    if df.is_empty():
-        return pl.DataFrame(schema=return_schema)
-
-    df = df.with_columns(
-        __path=pl.concat_str(
-            [
-                pl.lit(root_path),
-                pl.col("entry").map_elements(lambda x: x.path, return_dtype=pl.Utf8),
-            ],
-            separator=os.sep,
-        ),
-        mtime=pl.col("entry").map_elements(
-            lambda x: (
-                x.st_mtime
-                if isinstance(x.st_mtime, datetime)
-                else source_tz.localize(datetime.fromtimestamp(x.st_mtime))
-            ).astimezone(target_tz),
-            skip_nulls=True,
-            return_dtype=pl.Datetime("us", "UTC"),
-        ),
-    ).with_columns(
-        __path=pl.col("__path").map_elements(
-            lambda x: os.path.normpath(str(x)), skip_nulls=True, return_dtype=pl.Utf8
-        )
-    )
-
-    if tz_method == "regex":
-        datetime_regex = timestamp["datetime_regex"]
-        df = df.with_columns(
-            __created_at=pl.col("__path").map_elements(
-                lambda x: _parse_time(x, datetime_regex, source_tz, target_tz),
-                skip_nulls=True,
-                return_dtype=pl.Datetime("us", "UTC"),
-            )
-        )
-
-    elif tz_method == "manual":
-        dt_value = source_tz.localize(timestamp["datetime"]).astimezone(target_tz)
-        df = df.with_columns(__created_at=pl.lit(dt_value))
-
-    elif tz_method == "mtime":
-        df = df.with_columns(__created_at=pl.col("mtime"))
-
-    else:
+    if tz_method not in {"regex", "manual", "mtime"}:
         raise ValueError(f"unknown tz_method: '{tz_method}'")
 
-    df = df.select(return_schema.keys()).sort("__created_at")
+    manual_time = (
+        source_tz.localize(timestamp["datetime"]).astimezone(target_tz)
+        if tz_method == "manual"
+        else None
+    )
+    rows = []
+    for entry in sd:
+        if not entry.is_file:
+            continue
+        path = os.path.normpath(os.path.join(root_path, entry.path))
+        mtime = (
+            entry.st_mtime
+            if isinstance(entry.st_mtime, datetime)
+            else source_tz.localize(datetime.fromtimestamp(entry.st_mtime))
+        ).astimezone(target_tz)
+        created_at = (
+            _parse_time(path, timestamp["datetime_regex"], source_tz, target_tz)
+            if tz_method == "regex"
+            else manual_time or mtime
+        )
+        rows.append({"__path": path, "__created_at": created_at})
 
-    return df
+    return pl.DataFrame(rows, schema=return_schema).sort("__created_at")

--- a/polars_hist_db/loaders/dsv_input_source.py
+++ b/polars_hist_db/loaders/dsv_input_source.py
@@ -1,8 +1,9 @@
+from hashlib import sha256
 from datetime import datetime
 import logging
 from pathlib import Path
 import time
-from typing import Any, AsyncGenerator, Awaitable, Callable, List, Tuple, Union
+from typing import Any, AsyncGenerator, List, Tuple, Union
 
 import polars as pl
 from sqlalchemy import Connection, Engine
@@ -17,27 +18,26 @@ from ..config.table import TableConfigs
 from ..core.audit import AuditOps
 from .dsv.dsv_loader import load_typed_dsv
 from .dsv.file_search import find_files
-from .input_source import InputSource
+from .input_source import BatchFinalizer, InputSource
 from ..utils.clock import Clock
 
 LOGGER = logging.getLogger(__name__)
 
 
-def _make_dsv_file_commit_fn(
-    bound_csv_file: str,
+def _make_dsv_finalizer(
+    data_source: str,
     bound_file_time: Any,
-) -> Callable[[Connection, List[Tuple[str, str]]], Awaitable[bool]]:
-    async def commit_fn(
+) -> BatchFinalizer:
+    def write_audit_before_commit(
         connection: Connection,
         modified_tables: List[Tuple[str, str]],
     ) -> bool:
         result = True
         for modified_schema, modified_table in modified_tables:
             aops = AuditOps(modified_schema)
-            path = Path(bound_csv_file).absolute()
             result = aops.add_entry(
                 "dsv",
-                path.as_posix(),
+                data_source,
                 modified_table,
                 connection,
                 bound_file_time,
@@ -48,13 +48,17 @@ def _make_dsv_file_commit_fn(
                     "audit for [%s.%s - %s]: FAILED",
                     modified_schema,
                     modified_table,
-                    path.name,
+                    data_source,
                 )
                 raise NonRetryableException("Failed to update audit log")
 
         return result
 
-    return commit_fn
+    return BatchFinalizer(write_audit_before_commit)
+
+
+def _make_dsv_file_finalizer(csv_file: str, file_time: Any) -> BatchFinalizer:
+    return _make_dsv_finalizer(Path(csv_file).absolute().as_posix(), file_time)
 
 
 class DsvCrawlerInputSource(InputSource[DsvCrawlerInputConfig]):
@@ -92,14 +96,14 @@ class DsvCrawlerInputSource(InputSource[DsvCrawlerInputConfig]):
     ) -> AsyncGenerator[
         Tuple[
             List[Tuple[datetime, pl.DataFrame]],
-            Callable[[Connection, List[Tuple[str, str]]], Awaitable[bool]],
+            BatchFinalizer,
         ],
         None,
     ]:
         async def _generator() -> AsyncGenerator[
             Tuple[
                 List[Tuple[datetime, pl.DataFrame]],
-                Callable[[Connection, List[Tuple[str, str]]], Awaitable[bool]],
+                BatchFinalizer,
             ],
             None,
         ]:
@@ -109,20 +113,22 @@ class DsvCrawlerInputSource(InputSource[DsvCrawlerInputConfig]):
                 assert isinstance(self.config.payload, str)
                 assert self.config.payload_time is not None
 
-                partitions = self._process_payload(
-                    bytes(self.config.payload, "UTF8"), self.config.payload_time
+                payload = bytes(self.config.payload, "UTF8")
+                data_source = f"payload:{sha256(payload).hexdigest()}"
+                candidates = pl.DataFrame(
+                    {
+                        "__path": [data_source],
+                        "__created_at": [self.config.payload_time],
+                    }
                 )
-
-                async def commit_fn(
-                    connection: Connection, modified_tables: List[Tuple[str, str]]
-                ) -> bool:
-                    # payload was send directly to the pipeline, rather than a filepath
-                    # difficult generate an audit id in this case
-                    # for now, these messages are not audited - but might need to require
-                    # an audit_id field to be provided
-                    return True
-
-                yield partitions, commit_fn
+                if self._search_and_filter_files(
+                    candidates, table_schema, table_name, engine
+                ).is_empty():
+                    return
+                yield (
+                    self._process_payload(payload, self.config.payload_time),
+                    (_make_dsv_finalizer(data_source, self.config.payload_time)),
+                )
                 return
 
             # Handle file-based case
@@ -147,7 +153,7 @@ class DsvCrawlerInputSource(InputSource[DsvCrawlerInputConfig]):
 
                 partitions = self._process_payload(Path(csv_file), file_time)
 
-                yield partitions, _make_dsv_file_commit_fn(csv_file, file_time)
+                yield partitions, _make_dsv_file_finalizer(csv_file, file_time)
 
                 pipeline_time = time.perf_counter() - start_time
                 timings.add_timing("pipeline", pipeline_time)

--- a/polars_hist_db/loaders/input_source.py
+++ b/polars_hist_db/loaders/input_source.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import AsyncGenerator, Awaitable, Callable, List, Tuple, TypeVar, Generic
 from datetime import datetime
 import logging
@@ -15,6 +16,18 @@ from ..config.input.input_source import InputConfig
 LOGGER = logging.getLogger(__name__)
 
 TConfig = TypeVar("TConfig", bound=InputConfig)
+
+
+async def _noop_after_commit() -> None:
+    pass
+
+
+@dataclass
+class BatchFinalizer:
+    write_audit_before_commit: Callable[[Connection, List[Tuple[str, str]]], bool] = (
+        lambda connection, modified_tables: True
+    )
+    ack_after_commit: Callable[[], Awaitable[None]] = _noop_after_commit
 
 
 def _file_filter_connection_context(engine: Engine):
@@ -45,7 +58,7 @@ class InputSource(ABC, Generic[TConfig]):
     ) -> AsyncGenerator[
         Tuple[
             List[Tuple[datetime, pl.DataFrame]],
-            Callable[[Connection, List[Tuple[str, str]]], Awaitable[bool]],
+            BatchFinalizer,
         ],
         None,
     ]:

--- a/polars_hist_db/loaders/jetstream_input_source.py
+++ b/polars_hist_db/loaders/jetstream_input_source.py
@@ -1,13 +1,7 @@
 import asyncio
 from datetime import datetime
 import logging
-from typing import (
-    AsyncGenerator,
-    Awaitable,
-    Callable,
-    List,
-    Tuple,
-)
+from typing import AsyncGenerator, List, Tuple
 
 from nats.js.api import ConsumerConfig
 from nats.js.client import JetStreamContext
@@ -25,7 +19,7 @@ from .ingest_payload import load_df_from_msg
 from ..config.dataset import DatasetConfig
 from ..config.input.jetstream_config import JetStreamInputConfig
 from ..config.table import TableConfigs
-from .input_source import InputSource
+from .input_source import BatchFinalizer, InputSource
 from .transform import apply_transformations
 
 
@@ -52,14 +46,14 @@ class JetStreamInputSource(InputSource[JetStreamInputConfig]):
     ) -> AsyncGenerator[
         Tuple[
             List[Tuple[datetime, pl.DataFrame]],
-            Callable[[Connection, List[Tuple[str, str]]], Awaitable[bool]],
+            BatchFinalizer,
         ],
         None,
     ]:
         async def _generator() -> AsyncGenerator[
             Tuple[
                 List[Tuple[datetime, pl.DataFrame]],
-                Callable[[Connection, List[Tuple[str, str]]], Awaitable[bool]],
+                BatchFinalizer,
             ],
             None,
         ]:
@@ -108,8 +102,11 @@ class JetStreamInputSource(InputSource[JetStreamInputConfig]):
                 run_until == "forever"
             ):
                 try:
+                    fetch_size = self.config.jetstream.fetch.batch_size
+                    if remaining_msgs > 0:
+                        fetch_size = min(fetch_size, remaining_msgs)
                     msgs = await sub.fetch(
-                        self.config.jetstream.fetch.batch_size,
+                        fetch_size,
                         self.config.jetstream.fetch.batch_timeout,
                     )
 
@@ -117,6 +114,8 @@ class JetStreamInputSource(InputSource[JetStreamInputConfig]):
                         continue
 
                     total_msgs += len(msgs)
+                    if remaining_msgs > 0:
+                        remaining_msgs -= len(msgs)
                     msg_ts: datetime = msgs[-1].metadata.timestamp
 
                     all_dfs = []
@@ -172,18 +171,16 @@ class JetStreamInputSource(InputSource[JetStreamInputConfig]):
 
                     partitions = self._apply_time_partitioning(df, msg_ts)
 
-                    def _make_commit_fn(
+                    def _make_finalizer(
                         bound_msgs: list,
                         bound_msg_audits: list,
                         bound_audit_entries: List[str],
-                    ) -> Callable[[Connection, List[Tuple[str, str]]], Awaitable[bool]]:
-                        async def commit_fn(
+                    ) -> BatchFinalizer:
+                        def write_audit_before_commit(
                             connection: Connection,
                             modified_tables: List[Tuple[str, str]],
                         ) -> bool:
-                            for msg, (audit_log_id, created_at) in zip(
-                                bound_msgs, bound_msg_audits, strict=True
-                            ):
+                            for audit_log_id, created_at in bound_msg_audits:
                                 result = True
                                 if audit_log_id in bound_audit_entries:
                                     for (
@@ -199,10 +196,7 @@ class JetStreamInputSource(InputSource[JetStreamInputConfig]):
                                             created_at,
                                         )
 
-                                if result:
-                                    await msg.ack()
-                                else:
-                                    await msg.nak()
+                                if not result:
                                     LOGGER.error(
                                         "audit for [%s.%s - %s]: FAILED",
                                         table_schema,
@@ -215,12 +209,37 @@ class JetStreamInputSource(InputSource[JetStreamInputConfig]):
 
                             return True
 
-                        return commit_fn
+                        async def ack_after_commit() -> None:
+                            for msg in bound_msgs:
+                                await msg.ack()
 
-                    yield (
-                        partitions,
-                        _make_commit_fn(msgs, msg_audits, audit_entries),
+                        return BatchFinalizer(
+                            write_audit_before_commit, ack_after_commit
+                        )
+
+                    async def heartbeat(bound_msgs: list) -> None:
+                        while True:
+                            await asyncio.sleep(
+                                self.config.jetstream.fetch.heartbeat_interval
+                            )
+                            await asyncio.gather(
+                                *(msg.in_progress() for msg in bound_msgs)
+                            )
+
+                    heartbeat_task = (
+                        asyncio.create_task(heartbeat(msgs))
+                        if self.config.jetstream.fetch.heartbeat_interval > 0
+                        else None
                     )
+                    try:
+                        yield (
+                            partitions,
+                            _make_finalizer(msgs, msg_audits, audit_entries),
+                        )
+                    finally:
+                        if heartbeat_task is not None:
+                            heartbeat_task.cancel()
+                            await asyncio.gather(heartbeat_task, return_exceptions=True)
 
                 except TimeoutError:
                     if run_until == "empty":

--- a/polars_hist_db/utils/clock.py
+++ b/polars_hist_db/utils/clock.py
@@ -1,36 +1,19 @@
+from collections import defaultdict, deque
 from datetime import timedelta
-from typing import Any, Dict
-import polars as pl
+from typing import ClassVar
 
 
 class Clock:
-    _borg: Dict[str, Any] = {"_df": None}
-
-    def __init__(self) -> None:
-        self.__dict__ = self._borg
-        self._df: pl.DataFrame = self._getdf()
-
-    def _getdf(self) -> pl.DataFrame:
-        if self._df is None:
-            self._df = pl.DataFrame(schema={"name": pl.Utf8, "time": pl.Float64})
-
-        return self._df
+    _timings: ClassVar[dict[str, deque[float]]] = defaultdict(
+        lambda: deque(maxlen=1000)
+    )
 
     def add_timing(self, name: str, timing: float) -> None:
-        self._df = pl.concat(
-            [self._getdf(), pl.from_dict({"name": [name], "time": [timing]})]
-        )
+        self._timings[name].append(timing)
 
     def get_avg(self, name: str, window_size: int = 5) -> float:
-        avg_seconds: float = (
-            self._getdf()
-            .filter(pl.col("name") == name)
-            .get_column("time")
-            .rolling_mean(window_size=window_size, min_samples=1)
-            .tail(1)[0]
-        )
-
-        return avg_seconds
+        values = list(self._timings[name])[-window_size:]
+        return sum(values) / len(values)
 
     def eta(self, name: str, count_remaining: int, window_size: int = 5) -> timedelta:
         avg_seconds = self.get_avg(name, window_size)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,7 @@ requires-python = ">=3.12,<4.0"
 
 dependencies = [
     "nats-py>=2.15.0",
-    "pandas>=3.0.3",
-    "polars[sqlalchemy]>=1.42.1",
+    "polars>=1.42.1",
     "pyarrow>=25.0.0",
     "pymysql>=1.2.0",
     "pytz>=2026.2",
@@ -20,7 +19,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-sqlalchemy = ["polars[sqlalchemy]"]
+sqlalchemy = ["polars"]
 nats = ["nats-py"]
 xtdb = ["adbc-driver-flightsql>=1.11.0", "psycopg[binary]>=3.3.4"]
 crdt = [

--- a/tests/_data/config/foodprices.yaml
+++ b/tests/_data/config/foodprices.yaml
@@ -70,6 +70,7 @@ datasets:
         fetch:
           batch_size: 1000
           batch_timeout: 1
+          heartbeat_interval: 30
 
     time_partition:
       column: time

--- a/tests/config/test_jetstream_config.py
+++ b/tests/config/test_jetstream_config.py
@@ -1,0 +1,12 @@
+import pytest
+
+from polars_hist_db.config.input.jetstream_config import JetStreamFetchConfig
+
+
+def test_jetstream_heartbeat_interval_is_configurable():
+    assert JetStreamFetchConfig().heartbeat_interval == 30.0
+    assert JetStreamFetchConfig(heartbeat_interval=5).heartbeat_interval == 5
+    assert JetStreamFetchConfig(heartbeat_interval=0).heartbeat_interval == 0
+
+    with pytest.raises(ValueError, match="cannot be negative"):
+        JetStreamFetchConfig(heartbeat_interval=-1)

--- a/tests/core/test_correctness_regressions.py
+++ b/tests/core/test_correctness_regressions.py
@@ -2,11 +2,12 @@ from datetime import datetime, timezone
 
 import polars as pl
 import pytest
-from sqlalchemy import Column, Integer, MetaData, String, Table
+from sqlalchemy import Column, DateTime, Integer, MetaData, String, Table
 
 from polars_hist_db.config import DeltaConfig
 from polars_hist_db.config.parser_config import IngestionColumnConfig
 from polars_hist_db.core.dataframe import DataframeOps
+from polars_hist_db.core.audit import AuditOps
 from polars_hist_db.core.delta_table import (
     DeltaTableOps,
     _prevalidate_upsert_from_table,
@@ -87,3 +88,36 @@ def test_temporal_upsert_resets_session_timestamp_after_error(monkeypatch):
         ops.upsert("items", update_time)
 
     assert timestamps == [update_time, None]
+
+
+def test_latest_audit_entry_keeps_utc_schema_when_empty(monkeypatch):
+    metadata = MetaData()
+    audit_table = Table(
+        "__audit_log",
+        metadata,
+        Column("audit_id", Integer),
+        Column("table_name", String),
+        Column("data_source_type", String),
+        Column("data_source", String),
+        Column("data_source_ts", DateTime),
+        Column("upload_ts", DateTime),
+    )
+    empty = pl.DataFrame(
+        schema={
+            "audit_id": pl.Int32,
+            "table_name": pl.String,
+            "data_source_type": pl.String,
+            "data_source": pl.String,
+            "data_source_ts": pl.Datetime("us"),
+            "upload_ts": pl.Datetime("us"),
+        }
+    )
+    monkeypatch.setattr(AuditOps, "create", lambda self, connection: audit_table)
+    monkeypatch.setattr(
+        DataframeOps, "from_selectable", lambda self, query: empty.clone()
+    )
+
+    result = AuditOps("sample").get_latest_entry(object())
+
+    assert result.schema["data_source_ts"] == pl.Datetime("us", "UTC")
+    assert result.schema["upload_ts"] == pl.Datetime("us", "UTC")

--- a/tests/core/test_correctness_regressions.py
+++ b/tests/core/test_correctness_regressions.py
@@ -1,0 +1,89 @@
+from datetime import datetime, timezone
+
+import polars as pl
+import pytest
+from sqlalchemy import Column, Integer, MetaData, String, Table
+
+from polars_hist_db.config import DeltaConfig
+from polars_hist_db.config.parser_config import IngestionColumnConfig
+from polars_hist_db.core.dataframe import DataframeOps
+from polars_hist_db.core.delta_table import (
+    DeltaTableOps,
+    _prevalidate_upsert_from_table,
+)
+from polars_hist_db.loaders.dsv.dsv_loader import _validate_expected_columns
+
+
+def test_boolean_string_defaults_are_parsed():
+    df = pl.DataFrame({"enabled": [None]}, schema={"enabled": pl.Boolean})
+
+    result = DataframeOps.fill_nulls_with_defaults(df, {"enabled": "false"})
+
+    assert result["enabled"].to_list() == [False]
+
+
+def test_missing_dsv_columns_are_added_to_rows():
+    config = IngestionColumnConfig(
+        column_type="data",
+        schema="sample",
+        table="items",
+        ingestion_data_type="VARCHAR(10)",
+        target_data_type="VARCHAR(10)",
+        source="missing",
+        target="missing",
+    )
+
+    result = _validate_expected_columns(pl.DataFrame({"present": [1, 2]}), [config])
+
+    assert result.schema == {"missing": pl.String}
+    assert result["missing"].to_list() == [None, None]
+
+
+def test_last_delta_column_type_mismatch_raises():
+    metadata = MetaData()
+    source = Table("source", metadata, Column("id", String(10)))
+    target = Table("target", metadata, Column("id", Integer))
+
+    with pytest.raises(ValueError, match="column type mismatches"):
+        _prevalidate_upsert_from_table(source, target, ["id"], {}, False)
+
+
+def test_temporal_delete_resets_session_timestamp_after_error(monkeypatch):
+    timestamps = []
+    ops = DataframeOps(object())
+    monkeypatch.setattr(
+        "polars_hist_db.core.dataframe.DbOps.set_system_versioning_time",
+        lambda self, value: timestamps.append(value),
+    )
+    monkeypatch.setattr(
+        ops,
+        "table_delete_rows",
+        lambda *args: (_ for _ in ()).throw(RuntimeError("delete failed")),
+    )
+    update_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    with pytest.raises(RuntimeError, match="delete failed"):
+        ops.table_delete_rows_temporal(
+            pl.DataFrame({"id": [1]}), "sample", "items", update_time
+        )
+
+    assert timestamps == [update_time, None]
+
+
+def test_temporal_upsert_resets_session_timestamp_after_error(monkeypatch):
+    timestamps = []
+    ops = DeltaTableOps("sample", "delta", DeltaConfig(), object())
+    monkeypatch.setattr(
+        "polars_hist_db.core.delta_table.DbOps.set_system_versioning_time",
+        lambda self, value: timestamps.append(value),
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.core.delta_table.TableOps.get_table_metadata",
+        lambda self: (_ for _ in ()).throw(RuntimeError("upsert failed")),
+    )
+    update_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    with pytest.raises(RuntimeError, match="upsert failed"):
+        ops.upsert("items", update_time)
+
+    assert timestamps == [update_time, None]

--- a/tests/dataset/test_backend_entrypoint.py
+++ b/tests/dataset/test_backend_entrypoint.py
@@ -10,10 +10,11 @@ from polars_hist_db.dataset.entrypoint import _create_config_tables
 class _FakeBackend:
     def __init__(self):
         self.created_with = None
+        self.engine = SimpleNamespace(dispose=lambda: None)
 
     def create_engine(self, config):
         self.created_with = config
-        return object()
+        return self.engine
 
 
 class _FakeAdbcConnection:
@@ -31,10 +32,11 @@ class _FakeXtdbBackend:
         self.created_engine_with = None
         self.created_adbc_with = None
         self.adbc_connection = _FakeAdbcConnection()
+        self.engine = SimpleNamespace(dispose=lambda: None)
 
     def create_engine(self, config):
         self.created_engine_with = config
-        return object()
+        return self.engine
 
     def create_adbc_connection(self, config):
         self.created_adbc_with = config
@@ -160,6 +162,10 @@ async def test_run_datasets_creates_xtdb_adbc_connection(monkeypatch):
     monkeypatch.setattr(
         "polars_hist_db.dataset.entrypoint._run_dataset", fake_run_dataset
     )
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.entrypoint._create_config_tables",
+        lambda *args: None,
+    )
 
     await run_datasets(config)
 
@@ -201,6 +207,38 @@ async def test_run_datasets_can_raise_input_source_errors(monkeypatch):
         await run_datasets(config, engine, raise_on_error=True)
 
     assert _FailingInputSource.cleaned is True
+
+
+@pytest.mark.asyncio
+async def test_run_datasets_reports_swallowed_input_source_errors(monkeypatch):
+    backend = _FakeBackendWithTableConfigOps()
+    engine = _FakeEngine()
+    dataset = SimpleNamespace(
+        name="bad_dataset",
+        input_config=SimpleNamespace(type="dsv"),
+    )
+    config = SimpleNamespace(
+        db_config=DbEngineConfig(backend="mariadb"),
+        datasets=SimpleNamespace(datasets=[dataset]),
+        tables=object(),
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.entrypoint.backend_from_config", lambda config: backend
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.entrypoint._build_delta_table_config",
+        lambda tables, dataset: object(),
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.entrypoint.InputSourceFactory.create_input_source",
+        lambda *args, **kwargs: _FailingInputSource(),
+    )
+
+    result = await run_datasets(config, engine)
+
+    assert result.datasets_processed == 1
+    assert result.datasets_failed == 1
+    assert isinstance(result.errors[0], RuntimeError)
 
 
 def test_create_config_tables_uses_selected_backend_table_config_ops():

--- a/tests/dataset/test_scrape_transactions.py
+++ b/tests/dataset/test_scrape_transactions.py
@@ -1,4 +1,10 @@
+from types import SimpleNamespace
+
+import pytest
+
+from polars_hist_db.loaders.input_source import BatchFinalizer
 from polars_hist_db.dataset.scrape import _pipeline_transaction_context
+from polars_hist_db.dataset.scrape import try_run_pipeline_as_transaction
 
 
 class _FakeTransaction:
@@ -45,3 +51,54 @@ def test_pipeline_transaction_context_uses_plain_context_for_xtdb():
     assert connection.begin_called is False
     assert connection.transaction.entered is False
     assert connection.transaction.exited is False
+
+
+@pytest.mark.asyncio
+async def test_pipeline_acks_only_after_transaction_finishes(monkeypatch):
+    events = []
+
+    def run_batch(*args):
+        events.append("committed")
+
+    async def ack():
+        events.append("acked")
+
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.scrape._run_pipeline_as_transaction", run_batch
+    )
+
+    await try_run_pipeline_as_transaction(
+        [], object(), object(), object(), BatchFinalizer(ack_after_commit=ack)
+    )
+
+    assert events == ["committed", "acked"]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_raises_final_retry_error(monkeypatch):
+    attempts = 0
+
+    def fail(*args):
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("still broken")
+
+    async def no_wait(delay):
+        pass
+
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.scrape._run_pipeline_as_transaction", fail
+    )
+    monkeypatch.setattr("polars_hist_db.dataset.scrape.asyncio.sleep", no_wait)
+
+    with pytest.raises(RuntimeError, match="still broken"):
+        await try_run_pipeline_as_transaction(
+            [],
+            SimpleNamespace(),
+            object(),
+            object(),
+            BatchFinalizer(),
+            num_retries=3,
+        )
+
+    assert attempts == 3

--- a/tests/loaders/test_dsv_input_source.py
+++ b/tests/loaders/test_dsv_input_source.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-from polars_hist_db.loaders.dsv_input_source import _make_dsv_file_commit_fn
+from polars_hist_db.loaders.dsv_input_source import _make_dsv_file_finalizer
 
 
 @pytest.mark.asyncio
@@ -14,9 +14,9 @@ async def test_dsv_file_commit_succeeds_when_no_tables_changed(monkeypatch):
         "polars_hist_db.loaders.dsv_input_source.AuditOps", fail_audit_ops
     )
 
-    commit_fn = _make_dsv_file_commit_fn(
+    finalizer = _make_dsv_file_finalizer(
         "/tmp/source.csv",
         datetime(2026, 1, 1, tzinfo=timezone.utc),
     )
 
-    assert await commit_fn(object(), []) is True
+    assert finalizer.write_audit_before_commit(object(), []) is True

--- a/uv.lock
+++ b/uv.lock
@@ -1330,125 +1330,12 @@ wheels = [
 ]
 
 [[package]]
-name = "numpy"
-version = "2.4.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573, upload-time = "2026-03-29T13:18:52.629Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782, upload-time = "2026-03-29T13:18:55.579Z" },
-    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038, upload-time = "2026-03-29T13:18:57.769Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666, upload-time = "2026-03-29T13:19:00.341Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480, upload-time = "2026-03-29T13:19:03.63Z" },
-    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036, upload-time = "2026-03-29T13:19:07.428Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643, upload-time = "2026-03-29T13:19:10.775Z" },
-    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117, upload-time = "2026-03-29T13:19:13.464Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584, upload-time = "2026-03-29T13:19:16.155Z" },
-    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450, upload-time = "2026-03-29T13:19:18.994Z" },
-    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50", size = 16684933, upload-time = "2026-03-29T13:19:22.47Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115", size = 14694532, upload-time = "2026-03-29T13:19:25.581Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af", size = 5199661, upload-time = "2026-03-29T13:19:28.31Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c", size = 6547539, upload-time = "2026-03-29T13:19:30.97Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103", size = 15668806, upload-time = "2026-03-29T13:19:33.887Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83", size = 16632682, upload-time = "2026-03-29T13:19:37.336Z" },
-    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed", size = 17019810, upload-time = "2026-03-29T13:19:40.963Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959", size = 18357394, upload-time = "2026-03-29T13:19:44.859Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed", size = 5959556, upload-time = "2026-03-29T13:19:47.661Z" },
-    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf", size = 12317311, upload-time = "2026-03-29T13:19:50.67Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d", size = 10222060, upload-time = "2026-03-29T13:19:54.229Z" },
-    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5", size = 14822302, upload-time = "2026-03-29T13:19:57.585Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7", size = 5327407, upload-time = "2026-03-29T13:20:00.601Z" },
-    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93", size = 6647631, upload-time = "2026-03-29T13:20:02.855Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e", size = 15727691, upload-time = "2026-03-29T13:20:06.004Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40", size = 16681241, upload-time = "2026-03-29T13:20:09.417Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e", size = 17085767, upload-time = "2026-03-29T13:20:13.126Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392", size = 18403169, upload-time = "2026-03-29T13:20:17.096Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477, upload-time = "2026-03-29T13:20:20.195Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487, upload-time = "2026-03-29T13:20:22.946Z" },
-    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002, upload-time = "2026-03-29T13:20:25.909Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353, upload-time = "2026-03-29T13:20:29.504Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914, upload-time = "2026-03-29T13:20:33.547Z" },
-    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005, upload-time = "2026-03-29T13:20:36.45Z" },
-    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974, upload-time = "2026-03-29T13:20:39.014Z" },
-    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591, upload-time = "2026-03-29T13:20:42.146Z" },
-    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700, upload-time = "2026-03-29T13:20:46.204Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781, upload-time = "2026-03-29T13:20:50.242Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959, upload-time = "2026-03-29T13:20:54.019Z" },
-    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768, upload-time = "2026-03-29T13:20:56.912Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181, upload-time = "2026-03-29T13:20:59.548Z" },
-    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035, upload-time = "2026-03-29T13:21:02.524Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958, upload-time = "2026-03-29T13:21:05.671Z" },
-    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020, upload-time = "2026-03-29T13:21:08.635Z" },
-    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758, upload-time = "2026-03-29T13:21:10.949Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948, upload-time = "2026-03-29T13:21:14.047Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325, upload-time = "2026-03-29T13:21:17.561Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883, upload-time = "2026-03-29T13:21:21.106Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474, upload-time = "2026-03-29T13:21:24.828Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
-    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
-]
-
-[[package]]
-name = "pandas"
-version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/f1/392f8c5bfc16f66a0d2d41561c01627c228fe7ed2a0d056ef11315042570/pandas-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fed2ff7fd9779120e388e285fc029bd5cf9490cdd2e4166a9ee22c0e49a9ab09", size = 10357846, upload-time = "2026-05-11T18:52:36.143Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/3d/b16412745651e855f357e5e66930248688378853a6e2698a214e331fba1f/pandas-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b168fc218fd80a6cbdbdbc1a97ddc7889ed057d7eb45f50d866ceab5f39904c4", size = 9899550, upload-time = "2026-05-11T18:52:38.976Z" },
-    { url = "https://files.pythonhosted.org/packages/31/a8/fa2535168fffcedf67f4f6de28d2dd903a747ca7c8ea6989451aaeb3a92f/pandas-3.0.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0383c72c75cdcca61a9e116e611143902dbfd08bff356829c2f6d1cf40a9ca8c", size = 10412965, upload-time = "2026-05-11T18:52:41.915Z" },
-    { url = "https://files.pythonhosted.org/packages/65/b6/09b01cdbc15224e2850365192d17b7bdebb8bdbd8780ed221fcdf0d9a515/pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6dc0b3fd2169c9157deed50b4d519553a3655c8c6a96027136d654592be973a9", size = 10894600, upload-time = "2026-05-11T18:52:45.02Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/a4/2eb28f2fccb4ced4a2c79ab2a5dee9ade1ebf44922ebad6fea158c9f95d4/pandas-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7e65d5407dc0b394f509699650e4a2ec01c0514f21850f453fa60f3be79a5dbf", size = 11422824, upload-time = "2026-05-11T18:52:48.058Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/45/830bb57f533a4604b355e07edcb8ea18cf88b5f94e5fca92f27052d7c597/pandas-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8894dc474d648fe7b6ff0ca9b0bd73950d19952bc1a6534540762c5d79d305c", size = 11950889, upload-time = "2026-05-11T18:52:50.905Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/c5/fc1b368f303087d20e8c9bf3d6ceb186263cfac0ade735cd938538bea839/pandas-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:c7be265b62cef88e253a941e4698604973736dcfe242fdb5198f0f7bc473cdcc", size = 9755463, upload-time = "2026-05-11T18:52:53.386Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bd/fda8f9705b1b09c6ebe14bfc0fa0e4ec8584d54ea673628f157ff55131af/pandas-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:557409bc4178e70ee8d9ddb494798e51ebf6ea59330f6be22c51bab2a7db6c49", size = 9066158, upload-time = "2026-05-11T18:52:56.038Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/90/62d8302883c44308c477e222c3daf7c813a34c8e96985882fbd53d964352/pandas-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:67b3b64c11910cfa29f4e94a14d3bff9ee693b6fc76055e7cad549cee0aec5fa", size = 10331071, upload-time = "2026-05-11T18:52:58.838Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/ae/6a6493c783a101f165e4356953ba3c74d6f77f0042fa7d753da9dfbb640c/pandas-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:39436b377d56d2a2e52d0395bdbee171f01068e99af5250509aceeb929f765c7", size = 9875690, upload-time = "2026-05-11T18:53:01.431Z" },
-    { url = "https://files.pythonhosted.org/packages/62/7c/5df8e9f56c69a2769fbe9382a5ef8f2658c007e376434e1e2cbb57ad895f/pandas-3.0.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4be06d68f9ddcfc645b87534911da79a8fbffc7573c80e0edcf42a5020624d8", size = 10381634, upload-time = "2026-05-11T18:53:04.393Z" },
-    { url = "https://files.pythonhosted.org/packages/99/68/1237369725aa617bb358263d535803e3053fdbc593513ec5ed9c9896b5b6/pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4eeb6830daf35a71cc09649bd823e2b542dac246cdee9614c6e4bd65028cd6a", size = 10891243, upload-time = "2026-05-11T18:53:07.643Z" },
-    { url = "https://files.pythonhosted.org/packages/25/93/77d108e8af7222b4a503ebde0e30215b1c2e4f8e53a526431890f22d5586/pandas-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1928e07221f82db493cd4af1e23c1bfca524a19a4699887975bff68f49a72bfb", size = 11388659, upload-time = "2026-05-11T18:53:10.634Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/bd/eff5b4399f332ac386c853f6cd2bd3fa2ca0061b9f36ecd9c4d7c4265649/pandas-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51b1fe551acb77dac643c6fda86084d8d446c10fe64b06a9cc29c4cc8540e7f2", size = 11942880, upload-time = "2026-05-11T18:53:13.536Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/20/559ace4200982c3887d0b86bfd0d856a2143ef8ddab63cc07934951a964c/pandas-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:a82d532a3351d435432cd913edbccaf8b8e01d4dd0e5ced5a8d2e8ecd94c7e44", size = 9757091, upload-time = "2026-05-11T18:53:16.306Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/66/69055a09fe200f29f922a3eeec4804611900b95f52d932ece3393c3c0c19/pandas-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:275c14e0fce14a2ec20eee474aecd305478ea3c1e6f6a9d8fe219a165542717e", size = 9057282, upload-time = "2026-05-11T18:53:18.768Z" },
-    { url = "https://files.pythonhosted.org/packages/57/0e/efe801b0e6811e8e650cd21b7f2608e30f08a7067e2bf6e8752b0d56ee3c/pandas-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:46997386d528eb40376ecd6b033cf4a8a1e5282580f68f43de875b78cba2199d", size = 10767016, upload-time = "2026-05-11T18:53:21.227Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/dc/eb55135a1d5f0f0519f28da1f609a206d2cad1f9c35c32d51e38dd7261ae/pandas-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261e308dfb22448384b7580cf719d2f998fe2966c92893c3e77d14008af1f066", size = 10420210, upload-time = "2026-05-11T18:53:23.982Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/3e/b1d5d955ce33ffecb407465a60bc32769d74fcf68224b7ae67ae11d4dea4/pandas-3.0.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd1a5d1def6a46002e964510bdc67c368aa0951df5d1d9f8365336f5a1f490cd", size = 10336126, upload-time = "2026-05-11T18:53:26.731Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/76/a01261711ab60a22d71b862f0de20e4c504bf80457270ad8cb42110f6abc/pandas-3.0.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d72828c20c6d6e83e1e22a6a3b47b326b71664112fa9705dcbccfd7a39b62085", size = 10728051, upload-time = "2026-05-11T18:53:29.125Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/21/ea191195e587b18cf682e97f433f81b2d0fbe341380e80a3e0d6e4403c8e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870", size = 11350796, upload-time = "2026-05-11T18:53:32.056Z" },
-    { url = "https://files.pythonhosted.org/packages/64/69/f0eaaf54939f0e8c6768fd06be9af2cef9b36048b96dfb9e1b2c685a807e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f", size = 11799741, upload-time = "2026-05-11T18:53:34.985Z" },
-    { url = "https://files.pythonhosted.org/packages/45/a4/865e0e510cae5fc2194de4db28be638952de942571ba9125934fd9c01d47/pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13", size = 10499958, upload-time = "2026-05-11T18:53:37.857Z" },
-    { url = "https://files.pythonhosted.org/packages/86/54/effdcc3c0ff7a08037889200e148ebe94c16c4f653be078c7b3675955df1/pandas-3.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3650109c0f22879df8bd6179ab9ee3d7f1d1d4e7e0094a3f0032d9f51e2e64ac", size = 10336065, upload-time = "2026-05-11T18:53:41.099Z" },
-    { url = "https://files.pythonhosted.org/packages/68/10/bf2d6738d72748b961a3751ab89522d58c54efc36a8e1a12161216cd45cf/pandas-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bab900348131a7db1f69a7309ef141fd5680f1487094193bcbbb61791573bf8f", size = 9926101, upload-time = "2026-05-11T18:53:43.515Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/e9/e35cf11c8a136e757b956f5f0efdcaa50aecde85ea055f1898dfc68262f3/pandas-3.0.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba7e08b9ac1d54569cd1e256e3668975ed624d6826f7b68df0342b012007bddb", size = 10457553, upload-time = "2026-05-11T18:53:46.394Z" },
-    { url = "https://files.pythonhosted.org/packages/58/3b/1cdec6772bdbaf7b25dab360c59f03cadf05492dd724c6540af905389b07/pandas-3.0.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d71c63ae4ebdbf70209742096f1fc46a83a0613c99d4b23766cced9ff8cd62a", size = 10914065, upload-time = "2026-05-11T18:53:49.134Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/c2/1ef644445fcd72e3627bceec77e3560636f87ddce4ed841afe76b83b5bf9/pandas-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360", size = 11459188, upload-time = "2026-05-11T18:53:52.527Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/49/4d8d4f42cbc9c4adc7a1870f269c02cbd6cd40d059622c06fb298addcbad/pandas-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:335f62418ed562cfc3c49e9e196375c28b729dcef8543abf4f9438e381bf3c76", size = 11982966, upload-time = "2026-05-11T18:53:55.043Z" },
-    { url = "https://files.pythonhosted.org/packages/38/55/792619469bab9882d8bbd5865d45a72f6478762d04a9af4bf0d08c503e95/pandas-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:3c20a521bbb85902f79f7270c80a59e1b5452d96d170c034f207181870f97ac5", size = 9876755, upload-time = "2026-05-11T18:53:58.067Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/af/33c469653b0ba03b50c3a98192d4c07f0c75c66b263ceb097fce0ee97d31/pandas-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:a2d2dff8a04f3917b55ab3910c32990f8ddf7eceba114947838cefa976a68977", size = 9198658, upload-time = "2026-05-11T18:54:00.733Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/fa/b8c257bd76b8bd060c3a9151c1fca05e9b9c5e3af5d0f549c0356f6d143d/pandas-3.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0d589105b3c14645af1738ff279b2995102d8f7a03b0a66dc8d95550eb513e04", size = 10787242, upload-time = "2026-05-11T18:54:03.564Z" },
-    { url = "https://files.pythonhosted.org/packages/54/eb/f19206ffb0bf1919002969aa448b4702c6594845156a6f8050674855aac3/pandas-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13fc1e853d9e04743d11ba75a985ccbc2a317fe07d8af61e445a6fd24dacd6a6", size = 10436369, upload-time = "2026-05-11T18:54:06.311Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/24/c7c39fb4fe22b71a0c2d78bf0c585c600092d85f94f086d2b3b2f6ca27e2/pandas-3.0.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:819959dab7bbd0049c15623fbac4e29a191b9528160a61fb1032242d8ced2d9c", size = 10358306, upload-time = "2026-05-11T18:54:09.085Z" },
-    { url = "https://files.pythonhosted.org/packages/16/ec/dd2a9eb7fa1204df88c0864164e35b228ac581062ac612ba0a67fd812e4c/pandas-3.0.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:60ae316d3fd75d1858d450d0db0103ea2be3e7d4a95ec2f064f7e2ae63f7b028", size = 10758394, upload-time = "2026-05-11T18:54:11.956Z" },
-    { url = "https://files.pythonhosted.org/packages/95/6e/00c61ea8e85b4f6d8d35e11852a1a4998fc7fafc91c6a602d1cc9c972d64/pandas-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd3a518890b400d32f9023722dc9a9a5c969f00b415419a3c06c043f09bb5d7d", size = 11375717, upload-time = "2026-05-11T18:54:14.539Z" },
-    { url = "https://files.pythonhosted.org/packages/31/89/8fc1c268969fac43688d65fd92e67df24bd128d53cb4d2eee534cd307399/pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a", size = 11828897, upload-time = "2026-05-11T18:54:17.146Z" },
-    { url = "https://files.pythonhosted.org/packages/56/3b/e7d20dea247a3e6dc0bd8a6953854afbedc03951def4e7371e05e7263e25/pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1", size = 10900855, upload-time = "2026-05-11T18:54:19.72Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/54/68a0978d1ef8502b8492099beaa6e7a0c1b32e3b5d4f677f5810cb08711c/pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1", size = 9466464, upload-time = "2026-05-11T18:54:22.754Z" },
 ]
 
 [[package]]
@@ -1483,7 +1370,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1520,21 +1407,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/be/6a/edd939cc6fa04b6415aaa9bf19720fc74ead81234b3d38542e0005816d4d/polars-1.42.1-py3-none-any.whl", hash = "sha256:3c0c65cdfa21a621650c4bdcbbccf93964d052fd766c3e70e84a55d961c259fd", size = 837622, upload-time = "2026-06-30T04:56:34.686Z" },
 ]
 
-[package.optional-dependencies]
-sqlalchemy = [
-    { name = "pandas" },
-    { name = "pyarrow" },
-    { name = "sqlalchemy" },
-]
-
 [[package]]
 name = "polars-hist-db"
 version = "0.12.53"
 source = { editable = "." }
 dependencies = [
     { name = "nats-py" },
-    { name = "pandas" },
-    { name = "polars", extra = ["sqlalchemy"] },
+    { name = "polars" },
     { name = "pyarrow" },
     { name = "pymysql" },
     { name = "pytz" },
@@ -1552,7 +1431,7 @@ nats = [
     { name = "nats-py" },
 ]
 sqlalchemy = [
-    { name = "polars", extra = ["sqlalchemy"] },
+    { name = "polars" },
 ]
 xtdb = [
     { name = "adbc-driver-flightsql" },
@@ -1580,9 +1459,8 @@ requires-dist = [
     { name = "adbc-driver-flightsql", marker = "extra == 'xtdb'", specifier = ">=1.11.0" },
     { name = "nats-py", specifier = ">=2.15.0" },
     { name = "nats-py", marker = "extra == 'nats'" },
-    { name = "pandas", specifier = ">=3.0.3" },
-    { name = "polars", extras = ["sqlalchemy"], specifier = ">=1.42.1" },
-    { name = "polars", extras = ["sqlalchemy"], marker = "extra == 'sqlalchemy'" },
+    { name = "polars", specifier = ">=1.42.1" },
+    { name = "polars", marker = "extra == 'sqlalchemy'" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'xtdb'", specifier = ">=3.3.4" },
     { name = "pyarrow", specifier = ">=25.0.0" },
     { name = "pycrdt", marker = "extra == 'crdt'", specifier = ">=0.14.1" },


### PR DESCRIPTION
## Summary

- write audit entries inside the database transaction and ACK JetStream messages only after commit
- run blocking database batches in a worker thread with bounded retry backoff and configurable heartbeats
- fix timestamp cleanup, deletion counts, DSV defaults, audit ordering, scrape limits, and owned-engine disposal
- remove Pandas data-copy paths, bound timing storage, and reduce audit/database chatter
- return structured run results while deprecating silent error handling

## Validation

- `.venv/bin/ruff check polars_hist_db tests`
- `.venv/bin/mypy polars_hist_db`
- `uv lock --check --offline`
- `.venv/bin/pytest -q` (228 passed, 14 live integration tests deselected)

## Deferred

Live MariaDB, XTDB, and NATS failure-path validation remains for an environment with those services. Larger backend splits and parallel worker queues are intentionally deferred pending production profiling.