### PR TITLE
feat: add bounded ingestion workers

### DIFF
--- a/docs/configuration.qmd
+++ b/docs/configuration.qmd
@@ -38,6 +38,20 @@ deduplication, transforms, foreign-key handling, and unchanged-row filtering
 have already run. Lower this value for smaller XTDB nodes or raise it only after
 load testing retained/replay workloads.
 
+## ingestion
+
+Dataset execution is bounded and preserves ordering for datasets that write to
+the same tables. Independent datasets can run concurrently:
+
+```yaml
+ingestion:
+  max_workers: 2
+  queue_size: 2
+```
+
+Both values default to `1`. Increase `max_workers` only after confirming the
+database pool and target database can sustain the additional concurrent writes.
+
 ## table_configs
 
 A collection of tables that will be managed by this configuration.

--- a/polars_hist_db/config/__init__.py
+++ b/polars_hist_db/config/__init__.py
@@ -1,4 +1,5 @@
 from .config import (
+    IngestionConfig,
     ParityConfig,
     ParitySemanticForeignKeyConfig,
     PolarsHistDbConfig,
@@ -23,6 +24,7 @@ from .input.ingest_fn_registry import IngestFnRegistry, IngestFnSignature
 
 __all__ = [
     "PolarsHistDbConfig",
+    "IngestionConfig",
     "ParityConfig",
     "ParitySemanticForeignKeyConfig",
     "DbEngineConfig",

--- a/polars_hist_db/config/config.py
+++ b/polars_hist_db/config/config.py
@@ -9,6 +9,18 @@ from ..backends.config import DbEngineConfig
 
 
 @dataclass(frozen=True)
+class IngestionConfig:
+    max_workers: int = 1
+    queue_size: int = 1
+
+    def __post_init__(self):
+        if self.max_workers < 1:
+            raise ValueError("ingestion.max_workers must be at least 1")
+        if self.queue_size < 1:
+            raise ValueError("ingestion.queue_size must be at least 1")
+
+
+@dataclass(frozen=True)
 class ParitySemanticForeignKeyConfig:
     source: str
     target: str
@@ -64,9 +76,11 @@ class PolarsHistDbConfig:
         table_params = get_nested_key(cfg_dict, table_configs_path)
         db_params = get_nested_key(cfg_dict, ["db"]) or {}
         parity_params = get_nested_key(cfg_dict, ["parity"]) or {}
+        ingestion_params = get_nested_key(cfg_dict, ["ingestion"]) or {}
 
         self.db_config = DbEngineConfig.from_mapping(db_params)
         self.parity = ParityConfig(**parity_params)
+        self.ingestion = IngestionConfig(**ingestion_params)
         self.tables = TableConfigs(items=table_params)
 
         if dataset_params:

--- a/polars_hist_db/dataset/entrypoint.py
+++ b/polars_hist_db/dataset/entrypoint.py
@@ -1,3 +1,4 @@
+import asyncio
 from dataclasses import dataclass
 from datetime import datetime
 import logging
@@ -14,6 +15,7 @@ from ..loaders.input_source_factory import InputSourceFactory
 from ..utils.clock import Clock
 
 from ..config import PolarsHistDbConfig, DatasetConfig, TableConfig, TableConfigs
+from ..config.config import IngestionConfig
 from ..config.input.input_source import InputConfig
 from .scrape import try_run_pipeline_as_transaction
 
@@ -46,46 +48,122 @@ async def run_datasets(
     if engine is None:
         engine = backend.create_engine(config.db_config)
 
-    num_datasets_processed = 0
-    errors: list[Exception] = []
-    adbc_connection = None
-    try:
-        selected_datasets = [
-            dataset
-            for dataset in config.datasets.datasets
-            if dataset_name is None or dataset.name == dataset_name
-        ]
-        if selected_datasets:
-            _create_config_tables(engine, config.tables, backend)
-        for dataset in selected_datasets:
-            if getattr(backend, "name", None) == "xtdb" and adbc_connection is None:
-                adbc_connection = backend.create_adbc_connection(config.db_config)
-
-            num_datasets_processed += 1
-            LOGGER.info("scraping dataset %s", dataset.name)
-            error = await _run_dataset(
-                dataset.input_config,
-                dataset,
-                config.tables,
-                engine,
-                debug_capture_output,
-                backend,
-                adbc_connection=adbc_connection,
-                js=js,
-                raise_on_error=raise_on_error,
-            )
-            if error is not None:
-                errors.append(error)
-    finally:
-        if adbc_connection is not None:
-            adbc_connection.close()
-        if owns_engine:
-            engine.dispose()
-
-    if num_datasets_processed == 0:
+    selected_datasets = [
+        dataset
+        for dataset in config.datasets.datasets
+        if dataset_name is None or dataset.name == dataset_name
+    ]
+    if not selected_datasets:
         LOGGER.error("no datasets processed for %s", dataset_name)
+        if owns_engine:
+            await asyncio.to_thread(engine.dispose)
+        return RunResult(0, 0, ())
 
-    return RunResult(num_datasets_processed, len(errors), tuple(errors))
+    ingestion = getattr(config, "ingestion", IngestionConfig())
+    errors: list[Optional[Exception]] = [None] * len(selected_datasets)
+    try:
+        await asyncio.to_thread(_create_config_tables, engine, config.tables, backend)
+        await _run_dataset_workers(
+            selected_datasets,
+            config,
+            engine,
+            backend,
+            ingestion,
+            errors,
+            debug_capture_output,
+            js,
+            raise_on_error,
+        )
+    finally:
+        if owns_engine:
+            await asyncio.to_thread(engine.dispose)
+
+    failures = tuple(error for error in errors if error is not None)
+    return RunResult(len(selected_datasets), len(failures), failures)
+
+
+def _dataset_table_keys(dataset: DatasetConfig) -> tuple[tuple[str, str], ...]:
+    pipeline = getattr(dataset, "pipeline", None)
+    if pipeline is None:
+        return ()
+    return tuple(sorted(set(pipeline.get_pipeline_items().values())))
+
+
+async def _run_dataset_workers(
+    datasets: list[DatasetConfig],
+    config: PolarsHistDbConfig,
+    engine: Engine,
+    backend,
+    ingestion: IngestionConfig,
+    errors: list[Optional[Exception]],
+    debug_capture_output: Optional[List[Tuple[datetime, pl.DataFrame]]],
+    js: Optional[JetStreamContext],
+    raise_on_error: bool,
+) -> None:
+    worker_count = min(ingestion.max_workers, len(datasets))
+    queue: asyncio.Queue[Optional[tuple[int, DatasetConfig]]] = asyncio.Queue(
+        maxsize=ingestion.queue_size
+    )
+    table_locks = {
+        key: asyncio.Lock()
+        for dataset in datasets
+        for key in _dataset_table_keys(dataset)
+    }
+
+    async def producer() -> None:
+        for item in enumerate(datasets):
+            await queue.put(item)
+        for _ in range(worker_count):
+            await queue.put(None)
+
+    async def worker() -> None:
+        while True:
+            item = await queue.get()
+            try:
+                if item is None:
+                    return
+                index, dataset = item
+                locks = [table_locks[key] for key in _dataset_table_keys(dataset)]
+                acquired_locks: list[asyncio.Lock] = []
+                adbc_connection = None
+                try:
+                    for lock in locks:
+                        await lock.acquire()
+                        acquired_locks.append(lock)
+                    if getattr(backend, "name", None) == "xtdb":
+                        adbc_connection = await asyncio.to_thread(
+                            backend.create_adbc_connection, config.db_config
+                        )
+                    LOGGER.info("scraping dataset %s", dataset.name)
+                    errors[index] = await _run_dataset(
+                        dataset.input_config,
+                        dataset,
+                        config.tables,
+                        engine,
+                        debug_capture_output,
+                        backend,
+                        adbc_connection=adbc_connection,
+                        js=js,
+                        raise_on_error=raise_on_error,
+                    )
+                finally:
+                    if adbc_connection is not None:
+                        await asyncio.to_thread(adbc_connection.close)
+                    for lock in reversed(acquired_locks):
+                        lock.release()
+            finally:
+                queue.task_done()
+
+    tasks = [asyncio.create_task(producer())] + [
+        asyncio.create_task(worker()) for _ in range(worker_count)
+    ]
+    try:
+        await asyncio.gather(*tasks)
+    except BaseException:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
 
 
 def _create_config_tables(engine: Engine, tables: TableConfigs, backend):

--- a/polars_hist_db/loaders/dsv_input_source.py
+++ b/polars_hist_db/loaders/dsv_input_source.py
@@ -1,3 +1,4 @@
+import asyncio
 from hashlib import sha256
 from datetime import datetime
 import logging
@@ -121,12 +122,19 @@ class DsvCrawlerInputSource(InputSource[DsvCrawlerInputConfig]):
                         "__created_at": [self.config.payload_time],
                     }
                 )
-                if self._search_and_filter_files(
-                    candidates, table_schema, table_name, engine
-                ).is_empty():
+                filtered = await asyncio.to_thread(
+                    self._search_and_filter_files,
+                    candidates,
+                    table_schema,
+                    table_name,
+                    engine,
+                )
+                if filtered.is_empty():
                     return
                 yield (
-                    self._process_payload(payload, self.config.payload_time),
+                    await asyncio.to_thread(
+                        self._process_payload, payload, self.config.payload_time
+                    ),
                     (_make_dsv_finalizer(data_source, self.config.payload_time)),
                 )
                 return
@@ -135,8 +143,13 @@ class DsvCrawlerInputSource(InputSource[DsvCrawlerInputConfig]):
             if self.config.search_paths is None:
                 raise ValueError("Either payload or search_paths must be provided")
 
-            csv_files_df = self._search_and_filter_files(
-                self.files(), table_schema, table_name, engine
+            csv_files_df = await asyncio.to_thread(self.files)
+            csv_files_df = await asyncio.to_thread(
+                self._search_and_filter_files,
+                csv_files_df,
+                table_schema,
+                table_name,
+                engine,
             )
 
             timings = Clock()
@@ -151,7 +164,9 @@ class DsvCrawlerInputSource(InputSource[DsvCrawlerInputConfig]):
 
                 start_time = time.perf_counter()
 
-                partitions = self._process_payload(Path(csv_file), file_time)
+                partitions = await asyncio.to_thread(
+                    self._process_payload, Path(csv_file), file_time
+                )
 
                 yield partitions, _make_dsv_file_finalizer(csv_file, file_time)
 

--- a/polars_hist_db/loaders/jetstream_input_source.py
+++ b/polars_hist_db/loaders/jetstream_input_source.py
@@ -1,7 +1,7 @@
 import asyncio
 from datetime import datetime
 import logging
-from typing import AsyncGenerator, List, Tuple
+from typing import Any, AsyncGenerator, List, Tuple
 
 from nats.js.api import ConsumerConfig
 from nats.js.client import JetStreamContext
@@ -40,6 +40,93 @@ class JetStreamInputSource(InputSource[JetStreamInputConfig]):
     async def cleanup(self) -> None:
         # Caller owns the NATS client — do not close it here
         pass
+
+    def _prepare_batch(
+        self,
+        msgs: list[Any],
+        msg_ts: datetime,
+        engine: Engine,
+        table_schema: str,
+        table_name: str,
+        subject: str,
+    ) -> tuple[List[Tuple[datetime, pl.DataFrame]], BatchFinalizer]:
+        all_dfs = []
+        msg_audits = []
+        for msg in msgs:
+            df = load_df_from_msg(msg, msg_ts, self.config.payload_ingest)
+            msg_audits.extend(
+                list(df.select("__path", "__created_at").unique().iter_rows())
+            )
+            all_dfs.append(df)
+
+        df = pl.concat(all_dfs)
+        num_items_received = len(df)
+        received_items_ts = (
+            df.select(
+                pl.concat_list(pl.min("__created_at"), pl.max("__created_at"))
+                .explode()
+                .sort()
+                .unique()
+                .dt.strftime("%Y-%m-%d %H:%M:%S")
+            )
+            .get_column("__created_at")
+            .to_list()
+        )
+        df = self._search_and_filter_files(df, table_schema, table_name, engine)
+        audit_entries = df["__path"].unique().to_list()
+        df = df.drop("__path", "__created_at").pipe(
+            apply_transformations, self.column_definitions
+        )
+        LOGGER.info(
+            "got [%d/%d] %s@t=%s...",
+            len(df),
+            num_items_received,
+            subject,
+            received_items_ts,
+        )
+        record_uploader_batch(
+            table=f"{table_schema}.{table_name}",
+            subject=subject,
+            received=num_items_received,
+            written=len(df),
+        )
+        partitions = self._apply_time_partitioning(df, msg_ts)
+
+        def write_audit_before_commit(
+            connection: Connection,
+            modified_tables: List[Tuple[str, str]],
+        ) -> bool:
+            for audit_log_id, created_at in msg_audits:
+                result = True
+                if audit_log_id in audit_entries:
+                    for modified_schema, modified_table in modified_tables:
+                        result = result and AuditOps(modified_schema).add_entry(
+                            "nats-jetstream",
+                            audit_log_id,
+                            modified_table,
+                            connection,
+                            created_at,
+                        )
+                if not result:
+                    LOGGER.error(
+                        "audit for [%s.%s - %s]: FAILED",
+                        table_schema,
+                        table_name,
+                        audit_log_id,
+                    )
+                    raise NonRetryableException("Failed to update audit log")
+            return True
+
+        async def ack_after_commit() -> None:
+            for msg in msgs:
+                await msg.ack()
+
+        return partitions, BatchFinalizer(write_audit_before_commit, ack_after_commit)
+
+    async def _heartbeat(self, msgs: list[Any]) -> None:
+        while True:
+            await asyncio.sleep(self.config.jetstream.fetch.heartbeat_interval)
+            await asyncio.gather(*(msg.in_progress() for msg in msgs))
 
     async def next_df(
         self, engine: Engine
@@ -118,123 +205,20 @@ class JetStreamInputSource(InputSource[JetStreamInputConfig]):
                         remaining_msgs -= len(msgs)
                     msg_ts: datetime = msgs[-1].metadata.timestamp
 
-                    all_dfs = []
-                    msg_audits = []
-                    for msg in msgs:
-                        df = load_df_from_msg(msg, msg_ts, self.config.payload_ingest)
-                        msg_audits.extend(
-                            list(
-                                df.select("__path", "__created_at").unique().iter_rows()
-                            )
-                        )
-                        all_dfs.append(df)
-
-                    df = pl.concat(all_dfs)
-
-                    num_items_received = len(df)
-                    received_items_ts = (
-                        df.select(
-                            pl.concat_list(
-                                pl.min("__created_at"), pl.max("__created_at")
-                            )
-                            .explode()
-                            .sort()
-                            .unique()
-                            .dt.strftime("%Y-%m-%d %H:%M:%S")
-                        )
-                        .get_column("__created_at")
-                        .to_list()
-                    )
-
-                    df = self._search_and_filter_files(
-                        df, table_schema, table_name, engine
-                    )
-
-                    audit_entries = df["__path"].unique().to_list()
-
-                    df = df.drop("__path", "__created_at").pipe(
-                        apply_transformations, self.column_definitions
-                    )
-                    LOGGER.info(
-                        "got [%d/%d] %s@t=%s...",
-                        len(df),
-                        num_items_received,
-                        js_sub_cfg.subject,
-                        received_items_ts,
-                    )
-                    record_uploader_batch(
-                        table=f"{table_schema}.{table_name}",
-                        subject=js_sub_cfg.subject,
-                        received=num_items_received,
-                        written=len(df),
-                    )
-
-                    partitions = self._apply_time_partitioning(df, msg_ts)
-
-                    def _make_finalizer(
-                        bound_msgs: list,
-                        bound_msg_audits: list,
-                        bound_audit_entries: List[str],
-                    ) -> BatchFinalizer:
-                        def write_audit_before_commit(
-                            connection: Connection,
-                            modified_tables: List[Tuple[str, str]],
-                        ) -> bool:
-                            for audit_log_id, created_at in bound_msg_audits:
-                                result = True
-                                if audit_log_id in bound_audit_entries:
-                                    for (
-                                        modified_schema,
-                                        modified_table,
-                                    ) in modified_tables:
-                                        aops = AuditOps(modified_schema)
-                                        result = result and aops.add_entry(
-                                            "nats-jetstream",
-                                            audit_log_id,
-                                            modified_table,
-                                            connection,
-                                            created_at,
-                                        )
-
-                                if not result:
-                                    LOGGER.error(
-                                        "audit for [%s.%s - %s]: FAILED",
-                                        table_schema,
-                                        table_name,
-                                        audit_log_id,
-                                    )
-                                    raise NonRetryableException(
-                                        "Failed to update audit log"
-                                    )
-
-                            return True
-
-                        async def ack_after_commit() -> None:
-                            for msg in bound_msgs:
-                                await msg.ack()
-
-                        return BatchFinalizer(
-                            write_audit_before_commit, ack_after_commit
-                        )
-
-                    async def heartbeat(bound_msgs: list) -> None:
-                        while True:
-                            await asyncio.sleep(
-                                self.config.jetstream.fetch.heartbeat_interval
-                            )
-                            await asyncio.gather(
-                                *(msg.in_progress() for msg in bound_msgs)
-                            )
-
                     heartbeat_task = (
-                        asyncio.create_task(heartbeat(msgs))
+                        asyncio.create_task(self._heartbeat(msgs))
                         if self.config.jetstream.fetch.heartbeat_interval > 0
                         else None
                     )
                     try:
-                        yield (
-                            partitions,
-                            _make_finalizer(msgs, msg_audits, audit_entries),
+                        yield await asyncio.to_thread(
+                            self._prepare_batch,
+                            msgs,
+                            msg_ts,
+                            engine,
+                            table_schema,
+                            table_name,
+                            js_sub_cfg.subject,
                         )
                     finally:
                         if heartbeat_task is not None:

--- a/tests/dataset/test_dataset_workers.py
+++ b/tests/dataset/test_dataset_workers.py
@@ -1,0 +1,188 @@
+import asyncio
+from datetime import datetime, timezone
+from threading import get_ident
+from types import SimpleNamespace
+
+import polars as pl
+import pytest
+
+from polars_hist_db.config import IngestionConfig, PolarsHistDbConfig
+from polars_hist_db.dataset.entrypoint import _run_dataset_workers
+from polars_hist_db.loaders.dsv_input_source import DsvCrawlerInputSource
+
+
+def _dataset(name: str, table: str):
+    return SimpleNamespace(
+        name=name,
+        input_config=object(),
+        pipeline=SimpleNamespace(get_pipeline_items=lambda: {0: ("sample", table)}),
+    )
+
+
+def test_ingestion_worker_config_is_bounded():
+    assert IngestionConfig() == IngestionConfig(max_workers=1, queue_size=1)
+    with pytest.raises(ValueError, match="max_workers"):
+        IngestionConfig(max_workers=0)
+    with pytest.raises(ValueError, match="queue_size"):
+        IngestionConfig(queue_size=0)
+
+    config = PolarsHistDbConfig(
+        {
+            "table_configs": [],
+            "datasets": [],
+            "ingestion": {"max_workers": 3, "queue_size": 4},
+        },
+        table_configs_path=["table_configs"],
+        datasets_path=["datasets"],
+    )
+    assert config.ingestion == IngestionConfig(max_workers=3, queue_size=4)
+
+
+@pytest.mark.asyncio
+async def test_dsv_preparation_runs_off_the_event_loop():
+    event_loop_thread = get_ident()
+    preparation_threads = []
+    payload_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    source = object.__new__(DsvCrawlerInputSource)
+    source.config = SimpleNamespace(
+        has_payload=lambda: True,
+        payload="id\n1\n",
+        payload_time=payload_time,
+    )
+    source.dataset = SimpleNamespace(
+        pipeline=SimpleNamespace(get_main_table_name=lambda: ("sample", "items"))
+    )
+
+    def filter_files(candidates, table_schema, table_name, engine):
+        preparation_threads.append(get_ident())
+        return candidates
+
+    def process_payload(payload, timestamp):
+        preparation_threads.append(get_ident())
+        return [(timestamp, pl.DataFrame({"id": [1]}))]
+
+    source._search_and_filter_files = filter_files
+    source._process_payload = process_payload
+
+    generator = await source.next_df(object())
+    partitions, _finalizer = await anext(generator)
+    await generator.aclose()
+
+    assert partitions[0][1]["id"].to_list() == [1]
+    assert preparation_threads
+    assert all(thread != event_loop_thread for thread in preparation_threads)
+
+
+@pytest.mark.asyncio
+async def test_independent_datasets_run_concurrently(monkeypatch):
+    active = 0
+    peak = 0
+    both_started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_run_dataset(*args, **kwargs):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        if active == 2:
+            both_started.set()
+        try:
+            await release.wait()
+        finally:
+            active -= 1
+
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.entrypoint._run_dataset", fake_run_dataset
+    )
+    datasets = [_dataset("first", "one"), _dataset("second", "two")]
+    task = asyncio.create_task(
+        _run_dataset_workers(
+            datasets,
+            SimpleNamespace(db_config=object(), tables=object()),
+            object(),
+            SimpleNamespace(name="mariadb"),
+            IngestionConfig(max_workers=2, queue_size=1),
+            [None, None],
+            None,
+            None,
+            True,
+        )
+    )
+
+    await asyncio.wait_for(both_started.wait(), timeout=1)
+    release.set()
+    await task
+
+    assert peak == 2
+
+
+@pytest.mark.asyncio
+async def test_datasets_writing_the_same_table_remain_ordered(monkeypatch):
+    active = 0
+    peak = 0
+
+    async def fake_run_dataset(*args, **kwargs):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0)
+        active -= 1
+
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.entrypoint._run_dataset", fake_run_dataset
+    )
+    datasets = [_dataset("first", "shared"), _dataset("second", "shared")]
+
+    await _run_dataset_workers(
+        datasets,
+        SimpleNamespace(db_config=object(), tables=object()),
+        object(),
+        SimpleNamespace(name="mariadb"),
+        IngestionConfig(max_workers=2, queue_size=1),
+        [None, None],
+        None,
+        None,
+        True,
+    )
+
+    assert peak == 1
+
+
+@pytest.mark.asyncio
+async def test_worker_failure_cancels_sibling_dataset(monkeypatch):
+    both_started = asyncio.Event()
+    cancelled = asyncio.Event()
+    started = 0
+
+    async def fake_run_dataset(input_config, dataset, *args, **kwargs):
+        nonlocal started
+        started += 1
+        if started == 2:
+            both_started.set()
+        await both_started.wait()
+        if dataset.name == "failing":
+            raise RuntimeError("dataset failed")
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.entrypoint._run_dataset", fake_run_dataset
+    )
+    datasets = [_dataset("failing", "one"), _dataset("sibling", "two")]
+
+    with pytest.raises(RuntimeError, match="dataset failed"):
+        await _run_dataset_workers(
+            datasets,
+            SimpleNamespace(db_config=object(), tables=object()),
+            object(),
+            SimpleNamespace(name="mariadb"),
+            IngestionConfig(max_workers=2, queue_size=1),
+            [None, None],
+            None,
+            None,
+            True,
+        )
+
+    assert cancelled.is_set()


### PR DESCRIPTION
## Summary
- add configurable ingestion worker and queue limits with safe sequential defaults
- run independent datasets concurrently while serializing datasets that share target tables
- move DSV and JetStream batch preparation off the event loop while keeping heartbeats and ACKs async

## Validation
- 229 non-integration tests passed
- Ruff passed
- mypy passed
- integration tests not run locally because the configured Docker daemon was unavailable