### PR TITLE
perf: bound XTDB audit filtering

### DIFF
--- a/polars_hist_db/core/audit.py
+++ b/polars_hist_db/core/audit.py
@@ -318,26 +318,35 @@ class AuditOps:
             if not self._xtdb_data_table_exists(connection):
                 return data_source_items
 
-            existing_tbl_entries = (
-                _xtdb_dataframe_ops(connection)
-                .from_raw_sql(
-                    "SELECT data_source, MAX(data_source_ts) AS data_source_ts "
-                    f"FROM {self._table_sql()} "
-                    f"WHERE table_name = {_sql_literal(target_table_name)} "
-                    "GROUP BY data_source",
-                    schema_overrides={"data_source_ts": pl.Datetime("us", "UTC")},
-                )
-                .with_columns(pl.col("data_source").cast(pl.Utf8))
+            dataframe_ops = _xtdb_dataframe_ops(connection)
+            latest_log = dataframe_ops.from_raw_sql(
+                "SELECT MAX(data_source_ts) AS data_source_ts "
+                f"FROM {self._table_sql()} "
+                f"WHERE table_name = {_sql_literal(target_table_name)}",
+                schema_overrides={"data_source_ts": pl.Datetime("us", "UTC")},
             )
-
-            if existing_tbl_entries.is_empty():
+            if latest_log.is_empty() or latest_log[0, "data_source_ts"] is None:
                 return data_source_items
 
+            candidates = data_source_items.select(
+                pl.col(data_source_col_name).cast(pl.Utf8).alias("data_source")
+            ).unique(maintain_order=True)
+            existing_tbl_entries = dataframe_ops.table_query(
+                self.schema,
+                self._table_name,
+                candidates,
+                ["data_source"],
+                table_config=self._table_config(),
+            ).with_columns(pl.col("data_source").cast(pl.Utf8))
             data_source_items = self._filter_unprocessed_items(
                 data_source_items, existing_tbl_entries, data_source_col_name
             )
-            return self._filter_historic_items(
-                data_source_items, existing_tbl_entries, data_source_ts_col_name
+            latest_log_ts: datetime = latest_log[0, "data_source_ts"]
+            return data_source_items.filter(
+                pl.col(data_source_ts_col_name)
+                >= pl.lit(latest_log_ts).cast(
+                    pl.dtype_of(pl.col(data_source_ts_col_name))
+                )
             )
 
         audit_tbl = self.create(connection)

--- a/tests/backends/test_xtdb_audit_ops.py
+++ b/tests/backends/test_xtdb_audit_ops.py
@@ -123,6 +123,68 @@ def test_xtdb_audit_filter_items_returns_all_items_before_audit_data_table_exist
     assert filtered_items.equals(source_items)
 
 
+def test_xtdb_audit_filter_items_queries_only_candidate_sources(monkeypatch):
+    queried_candidates = []
+
+    class _TableConfigOps:
+        def __init__(self, connection):
+            self.connection = connection
+
+        def table_exists(self, table_schema, table_name):
+            return True
+
+        def from_table(self, table_schema, table_name):
+            return AuditOps(table_schema)._table_config()
+
+    class _DataframeOps:
+        def __init__(self, connection):
+            self.connection = connection
+
+        def from_raw_sql(self, query, schema_overrides=None):
+            assert "MAX(data_source_ts)" in query
+            assert "GROUP BY data_source" not in query
+            return pl.DataFrame(
+                {"data_source_ts": [datetime(2026, 1, 2, tzinfo=timezone.utc)]}
+            )
+
+        def table_query(
+            self,
+            table_schema,
+            table_name,
+            query_df,
+            column_selection,
+            table_config=None,
+        ):
+            queried_candidates.extend(query_df["data_source"].to_list())
+            return pl.DataFrame({"data_source": ["processed.csv"]})
+
+    monkeypatch.setattr(
+        "polars_hist_db.core.audit._xtdb_table_config_ops",
+        _TableConfigOps,
+    )
+    monkeypatch.setattr("polars_hist_db.core.audit._xtdb_dataframe_ops", _DataframeOps)
+
+    filtered_items = AuditOps("sample").filter_items(
+        pl.DataFrame(
+            {
+                "__path": ["processed.csv", "historic.csv", "new.csv"],
+                "__created_at": [
+                    datetime(2026, 1, 3, tzinfo=timezone.utc),
+                    datetime(2026, 1, 1, tzinfo=timezone.utc),
+                    datetime(2026, 1, 3, tzinfo=timezone.utc),
+                ],
+            }
+        ),
+        "__path",
+        "__created_at",
+        "trades",
+        _XtdbConnection(),
+    )
+
+    assert queried_candidates == ["processed.csv", "historic.csv", "new.csv"]
+    assert filtered_items["__path"].to_list() == ["new.csv"]
+
+
 def test_xtdb_audit_latest_entry_is_empty_before_audit_data_table_exists(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- replace the XTDB audit full-history grouping query with a scalar high-water query
- query processed audit entries only for the current candidate data sources
- preserve processed-source, historic-source, and missing-table behavior
- leave the MariaDB implementation unchanged

## Validation
- 230 non-integration tests passed
- Ruff passed
- mypy passed
- live XTDB validation deferred to integration CI because the local Docker daemon is unavailable