### PR TITLE
perf: prepare XTDB tables once per run

### DIFF
--- a/polars_hist_db/dataset/primary_item.py
+++ b/polars_hist_db/dataset/primary_item.py
@@ -148,7 +148,6 @@ def scrape_xtdb_pipeline_item(
         valid_time=valid_time,
     )
 
-    backend.table_configs(connection).create(table_config)
     temporal_write_kwargs = _xtdb_temporal_write_kwargs(
         table_config,
         valid_time,

--- a/tests/backends/test_xtdb_dataset_ingest.py
+++ b/tests/backends/test_xtdb_dataset_ingest.py
@@ -12,24 +12,11 @@ from polars_hist_db.dataset.extract_item import scrape_extract_item
 from polars_hist_db.dataset.primary_item import scrape_primary_item
 
 
-class _FakeTableConfigOps:
-    def __init__(self):
-        self.created = []
-
-    def create(self, table_config):
-        self.created.append(table_config)
-        return table_config
-
-
 class _FakeXtdbBackend:
     name = "xtdb"
 
     def __init__(self):
-        self.table_config_ops = _FakeTableConfigOps()
         self.temporal_upsert_calls = []
-
-    def table_configs(self, connection):
-        return self.table_config_ops
 
     def temporal_upsert(self, *args, **kwargs):
         self.temporal_upsert_calls.append((args, kwargs))
@@ -113,7 +100,6 @@ def test_xtdb_primary_ingest_uses_staged_dataframe_for_temporal_upsert():
     )
 
     assert did_modify is True
-    assert backend.table_config_ops.created == [record_table]
     assert staging.prepare_calls == [
         (
             ("stage-1", dataset, 0, record_table),
@@ -275,7 +261,6 @@ def test_xtdb_extract_ingest_uses_bulk_dataframe_ops_for_non_temporal_table():
     )
 
     assert did_modify is True
-    assert backend.table_config_ops.created == [entity_info]
     assert staging.prepare_calls == [
         (("stage-1", dataset, 1, entity_info), {"valid_time": None})
     ]

--- a/tests/backends/test_xtdb_live.py
+++ b/tests/backends/test_xtdb_live.py
@@ -18,7 +18,10 @@ from polars_hist_db.config import (
     TableConfig,
     TableConfigs,
 )
-from polars_hist_db.dataset.entrypoint import _build_delta_table_config
+from polars_hist_db.dataset.entrypoint import (
+    _build_delta_table_config,
+    _create_config_tables,
+)
 from polars_hist_db.dataset.scrape import _run_pipeline_as_transaction
 from polars_hist_db.loaders.input_source import BatchFinalizer
 
@@ -282,8 +285,8 @@ def test_xtdb_live_normalizes_foreign_keys_end_to_end():
 
     with _xtdb_engine() as engine:
         backend = XtdbBackend()
+        _create_config_tables(engine, tables, backend)
         with engine.connect() as connection:
-            backend.table_configs(connection).create(tables["live_countries"])
             backend.dataframes(connection).table_insert(
                 pl.DataFrame({"country_id": [7], "name": ["Japan"]}),
                 "public",


### PR DESCRIPTION
## Summary
- remove redundant XTDB table creation/reflection from every pipeline item
- rely on the existing run-level table preparation step
- update ingestion and live normalization tests to enforce that contract

## Validation
- `uv run pytest -q` (230 passed, 15 deselected)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy .`