### PR TITLE
perf: batch XTDB numeric key collision checks

### DIFF
--- a/benchmarks/xtdb_delta.py
+++ b/benchmarks/xtdb_delta.py
@@ -31,7 +31,15 @@ from polars_hist_db.config import DatasetConfig, TableColumnConfig, TableConfig
 class CurrentRows:
     frame: pl.DataFrame
 
-    def from_raw_sql(self, _sql: str) -> pl.DataFrame:
+    def from_raw_sql(self, sql: str, *_args: Any) -> pl.DataFrame:
+        if "__xtdb_minimum_id" in sql:
+            return pl.DataFrame(
+                {
+                    "id": [None],
+                    "__xtdb_minimum_id": [self.frame["id"].min()],
+                },
+                schema={"id": pl.Int64, "__xtdb_minimum_id": pl.Int64},
+            )
         return self.frame
 
     def from_table(self, _schema: str, _table: str) -> pl.DataFrame:

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -1036,16 +1036,18 @@ def _xtdb_values_cte(name: str, df: pl.DataFrame) -> tuple[str, dict[str, Any]]:
     columns = [_xtdb_column_identifier(column) for column in df.columns]
     casts = [_xtdb_cast_type_from_polars(dtype) for dtype in df.schema.values()]
     parameters = {}
-    value_rows = []
+    row_queries = []
     for row_index, row in enumerate(df.rows()):
-        placeholders = []
+        projections = []
         for column_index, (value, cast_type) in enumerate(zip(row, casts, strict=True)):
             parameter = f"q_{row_index}_{column_index}"
             parameters[parameter] = _xtdb_parameter_value(value, cast_type)
-            placeholders.append(f"CAST(:{parameter} AS {cast_type})")
-        value_rows.append(f"({', '.join(placeholders)})")
+            projections.append(
+                f"CAST(:{parameter} AS {cast_type}) AS {columns[column_index]}"
+            )
+        row_queries.append(f"SELECT {', '.join(projections)}")
     return (
-        f"{cte_name} ({', '.join(columns)}) AS (VALUES {', '.join(value_rows)})",
+        f"{cte_name} AS ({' UNION ALL '.join(row_queries)})",
         parameters,
     )
 
@@ -1401,7 +1403,7 @@ def _xtdb_fk_needs_generated_values(stage_df: pl.DataFrame, source_column: str) 
     )
 
 
-def _cast_null_parent_lookup_columns(
+def _cast_parent_lookup_columns(
     parent_lookup: pl.DataFrame,
     generated: pl.DataFrame,
     lookup_columns: Iterable[str],
@@ -1411,7 +1413,7 @@ def _cast_null_parent_lookup_columns(
         for column in lookup_columns
         if column in parent_lookup.columns
         and column in generated.columns
-        and parent_lookup.schema[column] == pl.Null
+        and parent_lookup.schema[column] != generated.schema[column]
     ]
     if not casts:
         return parent_lookup
@@ -2099,7 +2101,10 @@ class XtdbStagingOps:
                 parent_columns,
                 row,
             )
-            if parent_key in self._projected_parent_row_cache:
+            if (
+                parent_key in self._projected_parent_row_cache
+                or parent_key in new_parent_keys
+            ):
                 continue
             rows_to_return.append(row)
             new_parent_keys.add(parent_key)
@@ -2123,38 +2128,63 @@ class XtdbStagingOps:
             ):
                 continue
 
-            occupied: set[int] = set()
-            while True:
-                existing = self._dataframes().table_query(
-                    table_config.schema,
-                    table_config.name,
-                    resolved.select(target).unique(maintain_order=True),
-                    [target],
-                    table_config=table_config,
-                )
-                occupied.update(existing.get_column(target).drop_nulls().to_list())
+            candidates = resolved.select(target).unique(maintain_order=True)
+            values_cte, parameters = _xtdb_values_cte("candidate_keys", candidates)
+            target_column = _xtdb_column_identifier(target)
+            physical_target = _xtdb_table_query_target_column(target, table_config)
+            table_name = _qualified_table_name(table_config.schema, table_config.name)
+            minimum_column = "__xtdb_minimum_id"
+            existing = self._dataframes().from_raw_sql(
+                f"WITH {values_cte}, "
+                "occupied AS ("
+                f"SELECT t.{physical_target} AS {target_column} "
+                f"FROM {table_name} AS t JOIN candidate_keys AS q "
+                f"ON t.{physical_target} = q.{target_column}"
+                "), bounds AS ("
+                f"SELECT MIN(t.{physical_target}) AS {minimum_column} "
+                f"FROM {table_name} AS t"
+                ") "
+                f"SELECT occupied.{target_column}, bounds.{minimum_column} "
+                "FROM bounds LEFT JOIN occupied ON TRUE",
+                {
+                    target: resolved.schema[target],
+                    minimum_column: resolved.schema[target],
+                },
+                {"parameters": parameters},
+            )
+            occupied = set(existing.get_column(target).drop_nulls().to_list())
+            minimum_values = existing.get_column(minimum_column).drop_nulls()
+            database_minimum = (
+                cast(int, minimum_values.min())
+                if not minimum_values.is_empty()
+                else None
+            )
 
-                used: set[int] = set()
-                values: list[int] = []
-                changed = False
-                minimum = _xtdb_integer_min(table_config, target)
-                for row in resolved.select([target, marker]).iter_rows(named=True):
-                    value = int(row[target])
-                    generated = bool(row[marker])
-                    if not generated and (value in occupied or value in used):
+            used: set[int] = set()
+            values: list[int] = []
+            minimum = _xtdb_integer_min(table_config, target)
+            for row in resolved.select([target, marker]).iter_rows(named=True):
+                value = int(row[target])
+                generated = bool(row[marker])
+                if value in occupied or value in used:
+                    if not generated:
                         raise ValueError(
                             f"Foreign key {table_config.name}.{target} is already in use"
                         )
-                    while value in occupied or value in used:
-                        value = value - 1 if value > minimum else -1
-                        changed = True
-                    used.add(value)
-                    values.append(value)
+                    lower_values = [*used]
+                    if database_minimum is not None:
+                        lower_values.append(database_minimum)
+                    floor = min(lower_values)
+                    if floor <= minimum:
+                        raise ValueError(
+                            f"No generated foreign keys remain for "
+                            f"{table_config.name}.{target}"
+                        )
+                    value = floor - 1
+                used.add(value)
+                values.append(value)
 
-                if changed:
-                    resolved = resolved.with_columns(pl.Series(target, values))
-                    continue
-                break
+            resolved = resolved.with_columns(pl.Series(target, values))
 
         return resolved
 
@@ -2270,7 +2300,7 @@ class XtdbStagingOps:
             [*fk_targets, *value_targets],
             table_config=table_config,
         )
-        parent_lookup = _cast_null_parent_lookup_columns(
+        parent_lookup = _cast_parent_lookup_columns(
             parent_lookup,
             generated,
             [*fk_targets, *value_targets],

--- a/tests/backends/test_xtdb_dataframe_ops.py
+++ b/tests/backends/test_xtdb_dataframe_ops.py
@@ -398,10 +398,10 @@ def test_xtdb_dataframe_ops_chunks_table_query(monkeypatch):
 
     assert result.to_dict(as_series=False) == {"id": [1, 2, 3, 4, 5]}
     assert ops.from_raw_sql.call_count == 3
-    assert all("VALUES" in call.args[0] for call in ops.from_raw_sql.call_args_list)
     assert all(
-        "UNION ALL" not in call.args[0] for call in ops.from_raw_sql.call_args_list
+        "UNION ALL" in call.args[0] for call in ops.from_raw_sql.call_args_list[:2]
     )
+    assert "UNION ALL" not in ops.from_raw_sql.call_args_list[2].args[0]
     assert ops.from_raw_sql.call_args_list[0].args[2] == {
         "parameters": {"q_0_0": 1, "q_1_0": 2}
     }

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -19,6 +19,13 @@ def _staging_with(stage_df, *, adbc_connection=None):
     return staging
 
 
+def _empty_numeric_key_occupancy():
+    return pl.DataFrame(
+        {"id": [None], "__xtdb_minimum_id": [None]},
+        schema={"id": pl.Int64, "__xtdb_minimum_id": pl.Int64},
+    )
+
+
 def test_xtdb_staging_partition_stays_in_memory_without_database_io():
     connection = Mock()
     delta_table_config = TableConfig(
@@ -755,7 +762,7 @@ def test_xtdb_staging_deduces_explicit_numeric_foreign_keys(monkeypatch):
     )
     monkeypatch.setattr(
         "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
-        Mock(return_value=stage_df),
+        Mock(return_value=_empty_numeric_key_occupancy()),
     )
     monkeypatch.setattr(
         "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_query",
@@ -865,7 +872,7 @@ def test_xtdb_staging_generates_numeric_foreign_key_when_source_key_is_missing(
     )
     monkeypatch.setattr(
         "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
-        Mock(return_value=stage_df),
+        Mock(return_value=_empty_numeric_key_occupancy()),
     )
     monkeypatch.setattr(
         "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_query",
@@ -977,7 +984,7 @@ def test_xtdb_staging_reuses_deduced_foreign_key_for_later_primary_item(
     )
     monkeypatch.setattr(
         "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
-        Mock(return_value=stage_df),
+        Mock(return_value=_empty_numeric_key_occupancy()),
     )
     monkeypatch.setattr(
         "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_query",
@@ -1098,7 +1105,7 @@ def test_xtdb_staging_does_not_insert_same_generated_parent_twice(
     )
     monkeypatch.setattr(
         "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
-        Mock(return_value=stage_df),
+        Mock(return_value=_empty_numeric_key_occupancy()),
     )
     monkeypatch.setattr(
         "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_query",
@@ -1349,10 +1356,15 @@ def test_xtdb_staging_resolves_generated_numeric_key_collisions(monkeypatch):
         primary_keys=["id"],
         columns=[TableColumnConfig("parents", "id", "INT", nullable=False)],
     )
-    table_query = Mock(return_value=pl.DataFrame({"id": []}, schema={"id": pl.Int64}))
+    from_raw_sql = Mock(
+        return_value=pl.DataFrame(
+            {"id": [None], "__xtdb_minimum_id": [None]},
+            schema={"id": pl.Int64, "__xtdb_minimum_id": pl.Int64},
+        )
+    )
     monkeypatch.setattr(
-        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_query",
-        table_query,
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
+        from_raw_sql,
     )
     rows = pl.DataFrame(
         {
@@ -1368,7 +1380,7 @@ def test_xtdb_staging_resolves_generated_numeric_key_collisions(monkeypatch):
     )
 
     assert result.get_column("id").to_list() == [-42, -43]
-    assert table_query.call_count == 2
+    assert from_raw_sql.call_count == 1
 
 
 def test_xtdb_staging_avoids_existing_generated_numeric_key(monkeypatch):
@@ -1378,15 +1390,12 @@ def test_xtdb_staging_avoids_existing_generated_numeric_key(monkeypatch):
         primary_keys=["id"],
         columns=[TableColumnConfig("parents", "id", "INT", nullable=False)],
     )
-    table_query = Mock(
-        side_effect=[
-            pl.DataFrame({"id": [-42]}),
-            pl.DataFrame({"id": []}, schema={"id": pl.Int64}),
-        ]
+    from_raw_sql = Mock(
+        return_value=pl.DataFrame({"id": [-42], "__xtdb_minimum_id": [-42]})
     )
     monkeypatch.setattr(
-        "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_query",
-        table_query,
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
+        from_raw_sql,
     )
     rows = pl.DataFrame({"id": [-42], "__xtdb_generated_id": [True]})
 
@@ -1397,3 +1406,30 @@ def test_xtdb_staging_avoids_existing_generated_numeric_key(monkeypatch):
     )
 
     assert result.get_column("id").to_list() == [-43]
+    assert from_raw_sql.call_count == 1
+
+
+def test_xtdb_staging_avoids_an_existing_numeric_key_chain(monkeypatch):
+    table_config = TableConfig(
+        schema="ref",
+        name="parents",
+        primary_keys=["id"],
+        columns=[TableColumnConfig("parents", "id", "INT", nullable=False)],
+    )
+    from_raw_sql = Mock(
+        return_value=pl.DataFrame({"id": [-42], "__xtdb_minimum_id": [-43]})
+    )
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb.XtdbDataframeOps.from_raw_sql",
+        from_raw_sql,
+    )
+    rows = pl.DataFrame({"id": [-42], "__xtdb_generated_id": [True]})
+
+    result = XtdbStagingOps(object())._resolve_numeric_foreign_key_collisions(
+        rows,
+        table_config,
+        ["id"],
+    )
+
+    assert result.get_column("id").to_list() == [-44]
+    assert from_raw_sql.call_count == 1


### PR DESCRIPTION
## Summary
- replace repeated numeric foreign-key collision probes with one parameterized lookup per key column
- return matching candidates and the current minimum ID together, then allocate collisions safely below that bound
- keep parameterized lookup CTEs compatible with current XTDB SQL
- normalize lookup dtypes and remove duplicate parent rows within the same batch

## Validation
- `uv run pytest -q` (231 passed, 15 deselected)
- live `test_xtdb_live_normalizes_foreign_keys_end_to_end`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy .`