### PR TITLE
perf: avoid copying DSV time partitions

### DIFF
--- a/polars_hist_db/__init__.py
+++ b/polars_hist_db/__init__.py
@@ -1,8 +1,6 @@
 from os import getenv
 import polars as pl
 
-pl.enable_string_cache()
-
 
 def enable_debug_mode() -> None:
     pl.Config.set_tbl_cols(-1)

--- a/polars_hist_db/config/dataset.py
+++ b/polars_hist_db/config/dataset.py
@@ -39,7 +39,7 @@ class Pipeline:
         items = (
             pl.from_records(self.items)
             .with_row_index(name="id")
-            .explode("columns")
+            .explode("columns", empty_as_null=True)
             .unnest("columns")
         )
 

--- a/polars_hist_db/core/dataframe.py
+++ b/polars_hist_db/core/dataframe.py
@@ -105,16 +105,14 @@ class DataframeOps:
         for col in df.columns:
             if col in default_values.keys():
                 col_polars_dtype = df[col].dtype
-                if col_polars_dtype == pl.Boolean:
-                    default_value = PolarsType.convert_str_value(
-                        default_values[col], col_polars_dtype
-                    )
-                elif col_polars_dtype == pl.Time:
+                if col_polars_dtype == pl.Time:
                     default_value = pl.lit(
                         time.fromisoformat(default_values[col])
                     ).cast(col_polars_dtype)
                 else:
-                    default_value = pl.lit(default_values[col]).cast(col_polars_dtype)
+                    default_value = PolarsType.convert_str_value(
+                        default_values[col], col_polars_dtype
+                    )
 
                 df = df.with_columns(pl.col(col).fill_null(default_value))
 

--- a/polars_hist_db/loaders/input_source.py
+++ b/polars_hist_db/loaders/input_source.py
@@ -129,7 +129,7 @@ class InputSource(ABC, Generic[TConfig]):
                     .dt.offset_by(bucket_offset)
                     .cast(pl.dtype_of(time_col))
                 )
-                .sort(["__bucket", time_col])
+                .sort(time_col)
                 .unique(
                     [*header_keys, "__bucket"],
                     keep=unique_strategy,

--- a/polars_hist_db/loaders/input_source.py
+++ b/polars_hist_db/loaders/input_source.py
@@ -129,7 +129,7 @@ class InputSource(ABC, Generic[TConfig]):
                     .dt.offset_by(bucket_offset)
                     .cast(pl.dtype_of(time_col))
                 )
-                .sort(time_col)
+                .sort(["__bucket", time_col])
                 .unique(
                     [*header_keys, "__bucket"],
                     keep=unique_strategy,
@@ -142,11 +142,16 @@ class InputSource(ABC, Generic[TConfig]):
                     prepared_df, time_col, "__bucket", bucket_offset
                 )
 
-            partitions = prepared_df.partition_by(
-                "__bucket", include_key=False, as_dict=True, maintain_order=True
+            partition_sizes = (
+                prepared_df.group_by("__bucket", maintain_order=True).len().rows()
             )
-
-            result = [(k[0], v) for k, v in partitions.items()]
+            result = []
+            offset = 0
+            for bucket, size in partition_sizes:
+                result.append(
+                    (bucket, prepared_df.slice(offset, size).drop("__bucket"))
+                )
+                offset += size
 
         else:
             result = [(payload_time, df)]

--- a/polars_hist_db/utils/flatten.py
+++ b/polars_hist_db/utils/flatten.py
@@ -25,7 +25,7 @@ def flatten(df: pl.DataFrame) -> pl.DataFrame:
     ]
 
     if len(list_cols) > 0:
-        df = df.explode(list_cols)
+        df = df.explode(list_cols, empty_as_null=True)
 
     if len(struct_cols) > 0:
         df = df.with_columns(*map(prefix_field, struct_cols)).unnest(*struct_cols)

--- a/tests/core/test_correctness_regressions.py
+++ b/tests/core/test_correctness_regressions.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 import polars as pl
 import pytest
@@ -21,6 +21,17 @@ def test_boolean_string_defaults_are_parsed():
     result = DataframeOps.fill_nulls_with_defaults(df, {"enabled": "false"})
 
     assert result["enabled"].to_list() == [False]
+
+
+def test_date_string_defaults_are_parsed_without_deprecation_warning(recwarn):
+    df = pl.DataFrame({"as_of": [None]}, schema={"as_of": pl.Date})
+
+    result = DataframeOps.fill_nulls_with_defaults(df, {"as_of": "1985-10-26"})
+
+    assert not [
+        warning for warning in recwarn if warning.category is DeprecationWarning
+    ]
+    assert result["as_of"].to_list() == [date(1985, 10, 26)]
 
 
 def test_missing_dsv_columns_are_added_to_rows():

--- a/tests/loaders/test_dsv_input_source.py
+++ b/tests/loaders/test_dsv_input_source.py
@@ -1,7 +1,12 @@
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
+import polars as pl
 import pytest
 
+from polars_hist_db.config import TableConfig
+from polars_hist_db.config.dataset import TimePartition
+from polars_hist_db.loaders.dsv_input_source import DsvCrawlerInputSource
 from polars_hist_db.loaders.dsv_input_source import _make_dsv_file_finalizer
 
 
@@ -20,3 +25,44 @@ async def test_dsv_file_commit_succeeds_when_no_tables_changed(monkeypatch):
     )
 
     assert finalizer.write_audit_before_commit(object(), []) is True
+
+
+def test_time_partitioning_handles_interleaved_csv_rows():
+    source = object.__new__(DsvCrawlerInputSource)
+    source.tables = {
+        "events": TableConfig(
+            name="events",
+            schema="sample",
+            columns=[],
+            primary_keys=["id"],
+        )
+    }
+    source.dataset = SimpleNamespace(
+        pipeline=SimpleNamespace(
+            get_main_table_name=lambda: ("sample", "events"),
+            get_header_map=lambda table: {"id": "id"},
+        ),
+        time_partition=TimePartition(
+            column="event_time",
+            bucket_interval="1d",
+            bucket_strategy="round_down",
+        ),
+    )
+    source.config = SimpleNamespace(filter_past_events=False)
+    source.previous_payload_time = datetime.min
+    jan_1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    jan_2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+    rows = pl.DataFrame(
+        {
+            "id": [2, 1, 3, 4],
+            "event_time": [jan_2, jan_1, jan_2, jan_1],
+        }
+    )
+
+    partitions = source._apply_time_partitioning(rows, jan_2)
+
+    assert [timestamp for timestamp, _ in partitions] == [jan_1, jan_2]
+    assert [frame.get_column("id").to_list() for _, frame in partitions] == [
+        [1, 4],
+        [2, 3],
+    ]


### PR DESCRIPTION
## Summary
- sort transformed rows explicitly by bucket and event time, so CSV input order is irrelevant
- replace `partition_by(..., as_dict=True)` copies with ordered slice views over one backing frame
- preserve replayable partition lists for transaction retries and whole-file audit semantics

## Validation
- regression test with interleaved timestamps
- `uv run pytest -q` (232 passed, 15 deselected)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy .`