### PR TITLE
perf: vectorize XTDB foreign key payloads

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -1343,42 +1343,57 @@ def _xtdb_is_integer_config_column(table_config: TableConfig, column_name: str) 
     return data_type in {"BIGINT", "INT", "INTEGER", "MEDIUMINT", "SMALLINT", "TINYINT"}
 
 
-def _xtdb_deduced_foreign_key_id(
+def _xtdb_deduced_foreign_key_payload(
     table_config: TableConfig,
     value_targets: list[str],
-    row: dict[str, Any],
-) -> str:
-    encoded_parts = [
-        [column, _xtdb_json_safe_key_value(row[column])] for column in value_targets
-    ]
-    return f"xtdb-fk-v1:{table_config.schema}.{table_config.name}:" + json.dumps(
-        encoded_parts, separators=(",", ":"), ensure_ascii=False
-    )
+    schema: Mapping[str, pl.DataType],
+) -> pl.Expr:
+    encoded_parts = []
+    for column in value_targets:
+        value = pl.col(column)
+        dtype = schema[column]
+        if isinstance(dtype, pl.Datetime):
+            timezone_suffix = "%:z" if dtype.time_zone else ""
+            value = value.dt.strftime(f"%Y-%m-%dT%H:%M:%S%.f{timezone_suffix}")
+        elif dtype == pl.Date or dtype.is_decimal():
+            value = value.cast(pl.String)
 
-
-def _xtdb_deduced_numeric_foreign_key_id(
-    table_config: TableConfig,
-    target_column: str,
-    value_targets: list[str],
-    row: dict[str, Any],
-) -> int:
-    encoded_parts = [
-        [column, _xtdb_json_safe_key_value(row[column])] for column in value_targets
-    ]
-    payload = f"xtdb-fk-v1:{table_config.schema}.{table_config.name}:" + json.dumps(
-        encoded_parts, separators=(",", ":"), ensure_ascii=False
-    )
-    digest = hashlib.sha256(payload.encode("utf-8")).digest()
-    bits = (
-        63
-        if any(
-            column.name == target_column and column.data_type.upper() == "BIGINT"
-            for column in table_config.columns
+        encoded_column = json.dumps(column, ensure_ascii=False)
+        encoded_value = (
+            pl.struct(value.alias(column))
+            .struct.json_encode()
+            .str.strip_prefix(f"{{{encoded_column}:")
+            .str.strip_suffix("}")
         )
-        else 31
+        encoded_parts.append(
+            pl.concat_str(
+                pl.lit("["),
+                pl.lit(encoded_column),
+                pl.lit(","),
+                encoded_value,
+                pl.lit("]"),
+            )
+        )
+
+    return pl.concat_str(
+        pl.lit(f"xtdb-fk-v1:{table_config.schema}.{table_config.name}:["),
+        pl.concat_str(encoded_parts, separator=","),
+        pl.lit("]"),
     )
-    generated = int.from_bytes(digest[:8], "big") & ((1 << bits) - 1)
-    return -(generated or 1)
+
+
+def _xtdb_deduced_numeric_foreign_key_ids(payloads: pl.Series, bits: int) -> pl.Series:
+    mask = (1 << bits) - 1
+
+    def generated_id(payload: str) -> int:
+        digest = hashlib.sha256(payload.encode("utf-8")).digest()
+        generated = int.from_bytes(digest[:8], "big") & mask
+        return -(generated or 1)
+
+    return pl.Series(
+        [generated_id(payload) for payload in payloads],
+        dtype=pl.Int64,
+    )
 
 
 def _xtdb_parent_row_cache_key(
@@ -2258,31 +2273,25 @@ class XtdbStagingOps:
                     else pl.col(target_column).is_null()
                 ).alias(f"__xtdb_generated_{target_column}")
             )
+            generated_payload = _xtdb_deduced_foreign_key_payload(
+                table_config, value_targets, generated.schema
+            )
             if _xtdb_is_integer_config_column(table_config, target_column):
-                generated_value = (
-                    pl.struct(value_targets)
-                    .map_elements(
-                        partial(
-                            _xtdb_deduced_numeric_foreign_key_id,
-                            table_config,
-                            target_column,
-                            value_targets,
-                        ),
-                        return_dtype=pl.Int64,
+                bits = (
+                    63
+                    if any(
+                        column.name == target_column
+                        and column.data_type.upper() == "BIGINT"
+                        for column in table_config.columns
                     )
-                    .alias(target_column)
+                    else 31
                 )
+                generated_value = generated_payload.map_batches(
+                    partial(_xtdb_deduced_numeric_foreign_key_ids, bits=bits),
+                    return_dtype=pl.Int64,
+                ).alias(target_column)
             else:
-                generated_value = (
-                    pl.struct(value_targets)
-                    .map_elements(
-                        lambda row: _xtdb_deduced_foreign_key_id(
-                            table_config, value_targets, row
-                        ),
-                        return_dtype=pl.String,
-                    )
-                    .alias(target_column)
-                )
+                generated_value = generated_payload.alias(target_column)
             if source_column not in candidates.columns:
                 generated = generated.with_columns(generated_value)
                 continue

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -1,10 +1,15 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
+from decimal import Decimal
 from unittest.mock import Mock
 
 import polars as pl
 import pytest
 
-from polars_hist_db.backends.xtdb import XtdbBackend, XtdbStagingOps
+from polars_hist_db.backends.xtdb import (
+    XtdbBackend,
+    XtdbStagingOps,
+    _xtdb_deduced_foreign_key_payload,
+)
 from polars_hist_db.config import (
     DatasetConfig,
     TableColumnConfig,
@@ -23,6 +28,27 @@ def _empty_numeric_key_occupancy():
     return pl.DataFrame(
         {"id": [None], "__xtdb_minimum_id": [None]},
         schema={"id": pl.Int64, "__xtdb_minimum_id": pl.Int64},
+    )
+
+
+def test_xtdb_generated_foreign_key_payload_preserves_canonical_ids():
+    table_config = TableConfig(schema="ref", name="events", columns=[])
+    values = pl.DataFrame(
+        {
+            "name": ['a"b'],
+            "day": [date(2020, 1, 2)],
+            "at": [datetime(2020, 1, 2, 3, 4, 5, 123400, tzinfo=timezone.utc)],
+            "amount": [Decimal("2.10")],
+        }
+    )
+
+    payload = values.select(
+        _xtdb_deduced_foreign_key_payload(table_config, values.columns, values.schema)
+    ).item()
+
+    assert payload == (
+        'xtdb-fk-v1:ref.events:[["name","a\\"b"],["day","2020-01-02"],'
+        '["at","2020-01-02T03:04:05.123400+00:00"],["amount","2.10"]]'
     )
 
 
@@ -940,8 +966,7 @@ def test_xtdb_staging_generates_numeric_foreign_key_when_source_key_is_missing(
     )
 
     generated_id = result[0, "id"]
-    assert isinstance(generated_id, int)
-    assert generated_id < 0
+    assert generated_id == -970706434
     assert inserted["df"].to_dict(as_series=False) == {
         "id": [generated_id],
         "name": ["Southern Europe"],


### PR DESCRIPTION
## Summary
- build canonical XTDB foreign-key payloads with native Polars expressions
- replace per-row Python callbacks with one batched SHA-256 operation for numeric IDs
- preserve existing textual and numeric generated IDs, including temporal and decimal natural keys

## Performance
- 100k generated numeric keys: 0.209s -> 0.069s (~3.0x faster)

## Validation
- 234 non-integration tests passed
- Ruff check and format passed
- mypy passed