### PR TITLE
feat(backends): own connection lifecycle

### DIFF
--- a/polars_hist_db/backends/base.py
+++ b/polars_hist_db/backends/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 import re
 from typing import TYPE_CHECKING, Any, Protocol
@@ -67,6 +68,10 @@ class HistoricalDbBackend(Protocol):
     name: str
 
     def create_engine(self, config: DbEngineConfig) -> Any: ...
+
+    def connection_scope(self, engine: Any) -> AbstractContextManager[Any]:
+        """Open a backend-correct connection and commit successful work."""
+        ...
 
     def dataframes(self, connection: Any) -> Any: ...
 

--- a/polars_hist_db/backends/mariadb.py
+++ b/polars_hist_db/backends/mariadb.py
@@ -48,6 +48,10 @@ class MariaDbBackend:
             max_overflow=config.max_overflow,
         )
 
+    def connection_scope(self, engine: Engine) -> Any:
+        """Open one atomic MariaDB unit of work."""
+        return engine.begin()
+
     def dataframes(self, connection: Any) -> DataframeOps:
         return DataframeOps(connection)
 

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from contextlib import contextmanager
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from functools import partial
@@ -8,7 +9,16 @@ import logging
 import math
 import re
 from urllib.parse import quote
-from typing import TYPE_CHECKING, Any, Iterable, Literal, Mapping, Optional, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Iterable,
+    Iterator,
+    Literal,
+    Mapping,
+    Optional,
+    cast,
+)
 
 import polars as pl
 import pyarrow as pa
@@ -2436,6 +2446,13 @@ class XtdbBackend:
             engine.dialect, "_backslash_escapes", False
         )
         return engine
+
+    @contextmanager
+    def connection_scope(self, engine: Engine) -> Iterator[Any]:
+        """Open a scope for XTDB stores, which manage their own transactions."""
+        with engine.connect() as connection:
+            yield connection
+            connection.commit()
 
     def adbc_uri(self, config: DbEngineConfig) -> str:
         adbc_port = config.adbc_port or 9832

--- a/polars_hist_db/dataset/entrypoint.py
+++ b/polars_hist_db/dataset/entrypoint.py
@@ -168,13 +168,7 @@ async def _run_dataset_workers(
 
 def _create_config_tables(engine: Engine, tables: TableConfigs, backend):
     """Create permanent config tables (idempotent)."""
-    if getattr(backend, "name", None) == "xtdb":
-        with engine.connect() as connection:
-            backend.table_configs(connection).create_all(tables)
-            connection.commit()
-        return
-
-    with engine.begin() as connection:
+    with backend.connection_scope(engine) as connection:
         backend.table_configs(connection).create_all(tables)
 
 

--- a/polars_hist_db/dataset/scrape.py
+++ b/polars_hist_db/dataset/scrape.py
@@ -1,6 +1,5 @@
 import asyncio
 from datetime import datetime
-from contextlib import nullcontext
 import logging
 from random import uniform
 from typing import Any, List, Optional, Set, Tuple
@@ -18,12 +17,6 @@ from .extract_item import scrape_extract_item
 from .primary_item import scrape_primary_item
 
 LOGGER = logging.getLogger(__name__)
-
-
-def _pipeline_transaction_context(connection: Connection, is_xtdb: bool):
-    if is_xtdb:
-        return nullcontext()
-    return connection.begin()
 
 
 def _scrape_pipeline_item(
@@ -101,93 +94,88 @@ def _run_pipeline_as_transaction(
     header_keys = [tbl_to_header_map.get(k, k) for k in main_table_config.primary_keys]
     is_xtdb = getattr(backend, "name", None) == "xtdb"
 
-    with engine.connect() as connection:
-        with _pipeline_transaction_context(connection, is_xtdb):
-            staging = (
-                backend.staging(
-                    connection,
-                    adbc_connection=adbc_connection,
-                )
-                if is_xtdb
-                else None
+    with backend.connection_scope(engine) as connection:
+        staging = (
+            backend.staging(
+                connection,
+                adbc_connection=adbc_connection,
             )
-            if delta_table_config is not None and not is_xtdb:
-                _ensure_delta_table(
-                    connection,
+            if is_xtdb
+            else None
+        )
+        if delta_table_config is not None and not is_xtdb:
+            _ensure_delta_table(
+                connection,
+                delta_table_config,
+                dataset.delta_config.is_temporary_table,
+            )
+        modified_tables: Set[Tuple[str, str]] = set()
+        for i, (ts, partition_df) in enumerate(partitions):
+            stage_run_id = None
+            assert isinstance(ts, datetime), f"timestamp is not a datetime [{type(ts)}]"
+            LOGGER.info(
+                "-- (%d/%d) time_partition[%s] %d rows",
+                i + 1,
+                len(partitions),
+                ts.isoformat(),
+                len(partition_df),
+            )
+
+            if not is_xtdb:
+                DataframeOps(connection).table_insert(
+                    partition_df,
+                    dataset.delta_table_schema,
+                    dataset.name,
+                    uniqueness_col_set=header_keys,
+                    prefill_nulls_with_default=True,
+                    clear_table_first=True,
+                )
+            else:
+                if delta_table_config is None:
+                    raise ValueError("XTDB ingest requires delta table config")
+                if staging is None:
+                    raise ValueError("XTDB ingest requires staging ops")
+                stage_run_id = f"{dataset.name}:{uuid4()}"
+                staging.insert_partition(
+                    partition_df,
                     delta_table_config,
-                    dataset.delta_config.is_temporary_table,
-                )
-            modified_tables: Set[Tuple[str, str]] = set()
-            for i, (ts, partition_df) in enumerate(partitions):
-                stage_run_id = None
-                assert isinstance(ts, datetime), (
-                    f"timestamp is not a datetime [{type(ts)}]"
-                )
-                LOGGER.info(
-                    "-- (%d/%d) time_partition[%s] %d rows",
-                    i + 1,
-                    len(partitions),
-                    ts.isoformat(),
-                    len(partition_df),
+                    stage_run_id,
+                    ts,
+                    uniqueness_col_set=header_keys,
+                    prefill_nulls_with_default=True,
                 )
 
-                if not is_xtdb:
-                    DataframeOps(connection).table_insert(
-                        partition_df,
-                        dataset.delta_table_schema,
-                        dataset.name,
-                        uniqueness_col_set=header_keys,
-                        prefill_nulls_with_default=True,
-                        clear_table_first=True,
-                    )
-                else:
-                    if delta_table_config is None:
-                        raise ValueError("XTDB ingest requires delta table config")
-                    if staging is None:
-                        raise ValueError("XTDB ingest requires staging ops")
-                    stage_run_id = f"{dataset.name}:{uuid4()}"
-                    staging.insert_partition(
-                        partition_df,
-                        delta_table_config,
-                        stage_run_id,
-                        ts,
-                        uniqueness_col_set=header_keys,
-                        prefill_nulls_with_default=True,
-                    )
-
-                try:
-                    for pipeline_id, (
+            try:
+                for pipeline_id, (
+                    target_schema,
+                    target_table,
+                ) in dataset.pipeline.get_pipeline_items().items():
+                    did_modify = _scrape_pipeline_item(
+                        pipeline_id,
+                        dataset,
                         target_schema,
                         target_table,
-                    ) in dataset.pipeline.get_pipeline_items().items():
-                        did_modify = _scrape_pipeline_item(
-                            pipeline_id,
-                            dataset,
-                            target_schema,
-                            target_table,
-                            tables,
-                            ts,
-                            connection,
-                            partition_df=partition_df,
-                            stage_run_id=stage_run_id,
-                            staging=staging,
-                            backend=backend,
-                        )
+                        tables,
+                        ts,
+                        connection,
+                        partition_df=partition_df,
+                        stage_run_id=stage_run_id,
+                        staging=staging,
+                        backend=backend,
+                    )
 
-                        if did_modify:
-                            modified_item = (target_schema, target_table)
-                            modified_tables.add(modified_item)
-                finally:
-                    if is_xtdb and stage_run_id is not None and staging is not None:
-                        staging.cleanup_run(stage_run_id)
+                    if did_modify:
+                        modified_item = (target_schema, target_table)
+                        modified_tables.add(modified_item)
+            finally:
+                if is_xtdb and stage_run_id is not None and staging is not None:
+                    staging.cleanup_run(stage_run_id)
 
-            if delta_table_config is not None:
-                backend.finalize_ingest_run(connection, delta_table_config)
+        if delta_table_config is not None:
+            backend.finalize_ingest_run(connection, delta_table_config)
 
-            if not finalizer.write_audit_before_commit(
-                connection, sorted(modified_tables)
-            ):
-                raise NonRetryableException("Failed to update audit log")
+        if not finalizer.write_audit_before_commit(connection, sorted(modified_tables)):
+            raise NonRetryableException("Failed to update audit log")
 
 
 async def try_run_pipeline_as_transaction(

--- a/polars_hist_db/parity.py
+++ b/polars_hist_db/parity.py
@@ -408,8 +408,7 @@ def read_parity_tables(
         ]
 
     tables: dict[str, pl.DataFrame] = {}
-    connection_context = engine.connect if backend.name == "xtdb" else engine.begin
-    with connection_context() as connection:
+    with backend.connection_scope(engine) as connection:
         dataframe_ops = backend.dataframes(connection)
         for table_config in table_configs:
             read_sql = _table_read_sql(
@@ -430,15 +429,12 @@ def read_parity_tables(
 
 def _create_config_tables(config: PolarsHistDbConfig, engine: Engine) -> None:
     backend = backend_from_config(config.db_config)
-    connection_context = engine.connect if backend.name == "xtdb" else engine.begin
-    with connection_context() as connection:
+    with backend.connection_scope(engine) as connection:
         if backend.name == "mariadb":
             for schema in config.tables.schemas():
                 DbOps(connection).db_create(schema)
         backend.table_configs(connection).drop_all(config.tables)
         backend.table_configs(connection).create_all(config.tables)
-        if backend.name == "xtdb":
-            connection.commit()
 
 
 def _should_prepare_backend_tables(backend_name: str) -> bool:

--- a/tests/backends/test_connection_scope.py
+++ b/tests/backends/test_connection_scope.py
@@ -1,0 +1,38 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from polars_hist_db.backends import MariaDbBackend, XtdbBackend
+
+
+def test_mariadb_connection_scope_uses_engine_transaction():
+    engine = MagicMock()
+    connection = engine.begin.return_value.__enter__.return_value
+
+    with MariaDbBackend().connection_scope(engine) as active:
+        assert active is connection
+
+    engine.begin.assert_called_once_with()
+    engine.connect.assert_not_called()
+
+
+def test_xtdb_connection_scope_commits_successful_connection():
+    engine = MagicMock()
+    connection = engine.connect.return_value.__enter__.return_value
+
+    with XtdbBackend().connection_scope(engine) as active:
+        assert active is connection
+
+    engine.connect.assert_called_once_with()
+    engine.begin.assert_not_called()
+    connection.commit.assert_called_once_with()
+
+
+def test_xtdb_connection_scope_does_not_commit_failure():
+    engine = MagicMock()
+    connection = engine.connect.return_value.__enter__.return_value
+
+    with pytest.raises(RuntimeError), XtdbBackend().connection_scope(engine):
+        raise RuntimeError("failed operation")
+
+    connection.commit.assert_not_called()

--- a/tests/dataset/test_backend_entrypoint.py
+++ b/tests/dataset/test_backend_entrypoint.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from polars_hist_db.backends import DbEngineConfig
+from polars_hist_db.backends import DbEngineConfig, get_backend
 from polars_hist_db.dataset import run_datasets
 from polars_hist_db.dataset.entrypoint import _create_config_tables
 
@@ -94,6 +94,9 @@ class _FakeBackendWithTableConfigOps:
     def table_configs(self, connection):
         self.connection = connection
         return self.ops
+
+    def connection_scope(self, engine):
+        return get_backend(self.name).connection_scope(engine)
 
 
 class _FailingInputSource:

--- a/tests/dataset/test_scrape_transactions.py
+++ b/tests/dataset/test_scrape_transactions.py
@@ -3,54 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 from polars_hist_db.loaders.input_source import BatchFinalizer
-from polars_hist_db.dataset.scrape import _pipeline_transaction_context
 from polars_hist_db.dataset.scrape import try_run_pipeline_as_transaction
-
-
-class _FakeTransaction:
-    def __init__(self):
-        self.entered = False
-        self.exited = False
-
-    def __enter__(self):
-        self.entered = True
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        self.exited = True
-        return False
-
-
-class _FakeConnection:
-    def __init__(self):
-        self.transaction = _FakeTransaction()
-        self.begin_called = False
-
-    def begin(self):
-        self.begin_called = True
-        return self.transaction
-
-
-def test_pipeline_transaction_context_uses_sqlalchemy_transaction_for_mariadb():
-    connection = _FakeConnection()
-
-    with _pipeline_transaction_context(connection, is_xtdb=False):
-        pass
-
-    assert connection.begin_called is True
-    assert connection.transaction.entered is True
-    assert connection.transaction.exited is True
-
-
-def test_pipeline_transaction_context_uses_plain_context_for_xtdb():
-    connection = _FakeConnection()
-
-    with _pipeline_transaction_context(connection, is_xtdb=True):
-        pass
-
-    assert connection.begin_called is False
-    assert connection.transaction.entered is False
-    assert connection.transaction.exited is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a backend-neutral connection scope to the backend contract
- keep MariaDB work inside one SQLAlchemy transaction
- let XTDB stores own explicit transactions without invalidating caller contexts
- migrate ingestion and parity callers away from backend conditionals

## Verification
- mypy: 147 source files
- pytest: 236 passed, 1 skipped