### PR TITLE
perf: cache pipeline configuration lookups

### DIFF
--- a/polars_hist_db/config/dataset.py
+++ b/polars_hist_db/config/dataset.py
@@ -33,6 +33,21 @@ class DeltaConfig:
 @dataclass
 class Pipeline:
     items: pl.DataFrame
+    _header_maps: Dict[str, Dict[str, str]] = field(
+        init=False, repr=False, compare=False
+    )
+    _item_types: Dict[str, Tuple[str, ...]] = field(
+        init=False, repr=False, compare=False
+    )
+    _extract_items: Dict[int, pl.DataFrame] = field(
+        init=False, repr=False, compare=False
+    )
+    _empty_extract_items: pl.DataFrame = field(init=False, repr=False, compare=False)
+    _main_table_name: Tuple[str, str] = field(init=False, repr=False, compare=False)
+    _table_names: Tuple[str, ...] = field(init=False, repr=False, compare=False)
+    _pipeline_items: Dict[int, Tuple[str, str]] = field(
+        init=False, repr=False, compare=False
+    )
 
     def __post_init__(self):
         item_schema = IngestionColumnConfig.df_schema()
@@ -64,10 +79,55 @@ class Pipeline:
             .alias("column_type"),
         )
 
-        if len(items.filter(type="primary").select("table").unique()) != 1:
+        primary_item = items.filter(type="primary").select("table", "schema").unique()
+        if len(primary_item) != 1:
             raise ValueError("invalid pipeline, required exactly one primary table")
 
         self.items = items
+        self._main_table_name = (primary_item[0, "schema"], primary_item[0, "table"])
+        self._table_names = tuple(
+            items.get_column("table").unique(maintain_order=True).to_list()
+        )
+        self._pipeline_items = {
+            pipeline_id: (schema, table)
+            for pipeline_id, schema, table in items.select("id", "schema", "table")
+            .unique(maintain_order=True)
+            .iter_rows()
+        }
+
+        self._header_maps = {table: {} for table in self._table_names}
+        for table, source, target in (
+            items.select("table", "source", "target").drop_nulls().iter_rows()
+        ):
+            self._header_maps[table][target] = source
+
+        self._item_types = {
+            table: tuple(
+                items.filter(table=table)
+                .get_column("type")
+                .unique(maintain_order=True)
+                .to_list()
+            )
+            for table in self._table_names
+        }
+
+        extract_items = (
+            items.filter(pl.col("column_type").is_in(["data", "computed"]))
+            .with_columns(source=pl.coalesce("source", "target"))
+            .select(
+                "id",
+                "table",
+                "source",
+                "target",
+                "required",
+                "deduce_foreign_key",
+            )
+        )
+        self._extract_items = {
+            pipeline_id: extract_items.filter(id=pipeline_id).drop("id")
+            for pipeline_id in self._pipeline_items
+        }
+        self._empty_extract_items = extract_items.head(0).drop("id")
 
     def build_ingestion_column_definitions(
         self, all_tables: TableConfigs
@@ -171,55 +231,26 @@ class Pipeline:
         return columns
 
     def get_header_map(self, table: str) -> Dict[str, str]:
-        will_copy = (
-            self.items.filter(table=table).select("source", "target").drop_nulls()
-        )
-        return {row["target"]: row["source"] for row in will_copy.iter_rows(named=True)}
+        return dict(self._header_maps.get(table, {}))
 
     def item_type(self, table: str) -> str:
-        df = self.items.filter(table=table).select("type").unique()
-        if len(df) != 1:
+        item_types = self._item_types.get(table, ())
+        if len(item_types) != 1:
             raise ValueError("invalid pipeline")
 
-        result: str = df[0, "type"]
-        return result
+        return item_types[0]
 
     def extract_items(self, pipeline_id: int) -> pl.DataFrame:
-        df = (
-            self.items.filter(id=pipeline_id)
-            # .drop("table")
-            .filter(pl.col("column_type").is_in(["data", "computed"]))
-            .with_columns(source=pl.coalesce("source", "target"))
-            .select("table", "source", "target", "required", "deduce_foreign_key")
-        )
-
-        return df
+        return self._extract_items.get(pipeline_id, self._empty_extract_items)
 
     def get_main_table_name(self) -> Tuple[str, str]:
-        if self.items.is_empty():
-            raise ValueError("missing pipeline")
-
-        primary_item = (
-            self.items.filter(type="primary").select("table", "schema").unique()
-        )
-        if len(primary_item) != 1:
-            raise ValueError("invalid pipeline, required exactly one primary table")
-
-        table_name: str = primary_item[0, "table"]
-        table_schema: str = primary_item[0, "schema"]
-        return table_schema, table_name
+        return self._main_table_name
 
     def get_table_names(self) -> List[str]:
-        return self.items["table"].unique(maintain_order=True).to_list()
+        return list(self._table_names)
 
     def get_pipeline_items(self) -> Dict[int, Tuple[str, str]]:
-        pipeline_items = self.items.select("id", "schema", "table").unique(
-            maintain_order=True
-        )
-        result: Dict[int, Tuple[str, str]] = {
-            id: (schema, table) for (id, schema, table) in pipeline_items.iter_rows()
-        }
-        return result
+        return dict(self._pipeline_items)
 
 
 @dataclass

--- a/tests/config/test_pipeline_config.py
+++ b/tests/config/test_pipeline_config.py
@@ -1,0 +1,43 @@
+from polars_hist_db.config.dataset import Pipeline
+
+
+def test_pipeline_reuses_cached_lookups():
+    pipeline = Pipeline(
+        [
+            {
+                "schema": "ref",
+                "table": "countries",
+                "columns": [{"source": "country", "target": "name"}],
+            },
+            {
+                "schema": "sample",
+                "table": "events",
+                "type": "primary",
+                "columns": [
+                    {"source": "id", "target": "id", "required": True},
+                    {"source": "country", "target": "country_id"},
+                ],
+            },
+        ]
+    )
+
+    extract_items = pipeline.extract_items(1)
+    header_map = pipeline.get_header_map("events")
+    header_map["mutated"] = "outside"
+
+    assert pipeline.get_main_table_name() == ("sample", "events")
+    assert pipeline.get_table_names() == ["countries", "events"]
+    assert pipeline.get_pipeline_items() == {
+        0: ("ref", "countries"),
+        1: ("sample", "events"),
+    }
+    assert pipeline.item_type("countries") == "extract"
+    assert pipeline.get_header_map("events") == {"id": "id", "country_id": "country"}
+    assert pipeline.extract_items(1) is extract_items
+    assert extract_items.to_dict(as_series=False) == {
+        "table": ["events", "events"],
+        "source": ["id", "country"],
+        "target": ["id", "country_id"],
+        "required": [True, False],
+        "deduce_foreign_key": [False, False],
+    }


### PR DESCRIPTION
## Summary
- derive immutable pipeline lookup metadata once during configuration parsing
- reuse cached main-table, table, item-type, header-map, and extraction projections during ingestion
- preserve the existing public API and defensive copies for mutable return values

## Validation
- 235 non-integration tests passed
- Ruff check and format passed
- mypy passed