### PR TITLE
feat: publish tracked benchmark history

### DIFF
--- a/.github/workflows/bespoke_xtdb-benchmark-history.yaml
+++ b/.github/workflows/bespoke_xtdb-benchmark-history.yaml
@@ -5,17 +5,20 @@ on:
     branches: [master]
     paths:
       - 'benchmarks/xtdb_delta.py'
+      - 'benchmarks/record_history.py'
       - 'polars_hist_db/backends/xtdb.py'
+      - 'polars_hist_db/loaders/input_source.py'
       - '.github/workflows/bespoke_xtdb-benchmark-history.yaml'
       - 'pyproject.toml'
       - 'uv.lock'
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
 
 concurrency:
-  group: pages
+  group: xtdb-benchmark-history
   cancel-in-progress: false
 
 jobs:
@@ -23,6 +26,8 @@ jobs:
     runs-on: ${{ fromJSON(vars.RUNNER_PROFILES)[vars.RUNNER_PROFILE].default }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - uses: astral-sh/setup-uv@v8.3.2
 
@@ -36,14 +41,28 @@ jobs:
           --value-columns 8
           --repeats 3
           --fk-match-fractions 0,0.5,1
+          --partition-rows 500000
+          --partition-buckets 365
           --json-output benchmark-results.json
 
       - name: Record benchmark history
-        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
-        with:
-          tool: customSmallerIsBetter
-          output-file-path: benchmark-results.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: true
-          gh-pages-branch: gh-pages
-          benchmark-data-dir-path: dev/bench/xtdb-delta
+        run: >-
+          uv run python benchmarks/record_history.py
+          benchmark-results.json docs/benchmark-history.json
+          --commit "$GITHUB_SHA"
+          --repository "$GITHUB_REPOSITORY"
+          --runner "$RUNNER_OS/$RUNNER_ARCH"
+
+      - name: Commit benchmark history
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/benchmark-history.json
+          git commit -m "chore(benchmarks): record ${GITHUB_SHA::7} [skip ci]"
+          git pull --rebase origin master
+          git push origin HEAD:master
+
+      - name: Republish Quarto docs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run publish-quarto-docs.yaml --ref master

--- a/benchmarks/record_history.py
+++ b/benchmarks/record_history.py
@@ -1,0 +1,80 @@
+"""Append custom benchmark results to the tracked documentation history."""
+
+from argparse import ArgumentParser
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import platform
+from typing import Any
+
+import polars as pl
+
+
+def record_history(
+    results_path: Path,
+    history_path: Path,
+    *,
+    commit: str,
+    repository: str,
+    runner: str,
+    timestamp: str | None = None,
+    limit: int = 100,
+) -> dict[str, Any]:
+    results = json.loads(results_path.read_text())
+    if not isinstance(results, list) or not all(
+        isinstance(result, dict) and {"name", "unit", "value"}.issubset(result)
+        for result in results
+    ):
+        raise ValueError("benchmark results must be a list of name/unit/value objects")
+
+    history: dict[str, Any] = (
+        json.loads(history_path.read_text())
+        if history_path.exists()
+        else {"schema_version": 1, "suite": "ingestion", "entries": []}
+    )
+    entries = [
+        entry for entry in history.get("entries", []) if entry.get("commit") != commit
+    ]
+    entries.append(
+        {
+            "commit": commit,
+            "repository": repository,
+            "timestamp": timestamp or datetime.now(timezone.utc).isoformat(),
+            "runner": runner,
+            "python": platform.python_version(),
+            "polars": pl.__version__,
+            "benchmarks": results,
+        }
+    )
+    history["entries"] = entries[-limit:]
+    history_path.parent.mkdir(parents=True, exist_ok=True)
+    history_path.write_text(json.dumps(history, indent=2) + "\n")
+    return history
+
+
+def main() -> None:
+    parser = ArgumentParser()
+    parser.add_argument("results", type=Path)
+    parser.add_argument("history", type=Path)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--runner", required=True)
+    parser.add_argument("--timestamp")
+    parser.add_argument("--limit", type=int, default=100)
+    args = parser.parse_args()
+    try:
+        record_history(
+            args.results,
+            args.history,
+            commit=args.commit,
+            repository=args.repository,
+            runner=args.runner,
+            timestamp=args.timestamp,
+            limit=args.limit,
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        parser.exit(1, f"error: {exc}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/xtdb_delta.py
+++ b/benchmarks/xtdb_delta.py
@@ -1,4 +1,4 @@
-"""Benchmark XTDB delta and foreign-key scaling.
+"""Benchmark XTDB delta, normalized foreign keys, and DSV partitioning.
 
 Examples:
     uv run python benchmarks/xtdb_delta.py
@@ -9,6 +9,7 @@ Examples:
 
 from argparse import ArgumentParser
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 import gc
 import json
 import os
@@ -16,6 +17,7 @@ from pathlib import Path
 import re
 from statistics import median
 from time import perf_counter
+from types import SimpleNamespace
 from typing import Any
 
 import polars as pl
@@ -25,6 +27,8 @@ from polars_hist_db.backends.xtdb import (
     _filter_xtdb_unchanged_rows,
 )
 from polars_hist_db.config import DatasetConfig, TableColumnConfig, TableConfig
+from polars_hist_db.config.dataset import TimePartition
+from polars_hist_db.loaders.dsv_input_source import DsvCrawlerInputSource
 
 
 @dataclass
@@ -235,6 +239,61 @@ def benchmark_foreign_keys(
     )
 
 
+def benchmark_time_partitions(
+    row_count: int, bucket_count: int, repeats: int
+) -> tuple[float, float, int]:
+    if row_count < bucket_count:
+        raise ValueError("row count cannot be smaller than bucket count")
+    if bucket_count < 1:
+        raise ValueError("bucket count must be positive")
+
+    start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    rows = (
+        pl.DataFrame({"id": range(row_count)})
+        .with_columns(
+            event_time=pl.lit(start) + pl.duration(days=pl.col("id") % bucket_count)
+        )
+        .sample(fraction=1, shuffle=True, seed=42)
+    )
+    source: Any = object.__new__(DsvCrawlerInputSource)
+    source.tables = {
+        "events": TableConfig(
+            schema="benchmark",
+            name="events",
+            columns=[],
+            primary_keys=["id"],
+        )
+    }
+    source.dataset = SimpleNamespace(
+        pipeline=SimpleNamespace(
+            get_main_table_name=lambda: ("benchmark", "events"),
+            get_header_map=lambda _table: {"id": "id"},
+        ),
+        time_partition=TimePartition(
+            column="event_time",
+            bucket_interval="1d",
+            bucket_strategy="round_down",
+        ),
+    )
+    source.config = SimpleNamespace(filter_past_events=False)
+    source.previous_payload_time = datetime.min
+
+    timings = []
+    partition_count = 0
+    for _ in range(repeats):
+        gc.collect()
+        started = perf_counter()
+        partitions = source._apply_time_partitioning(
+            rows, start + timedelta(days=bucket_count - 1)
+        )
+        timings.append(perf_counter() - started)
+        partition_count = len(partitions)
+        assert partition_count == bucket_count
+        assert sum(len(partition) for _, partition in partitions) == row_count
+
+    return median(timings), rows.estimated_size("mb"), partition_count
+
+
 def benchmark_remote_sample(dsn: str, table: str, limit: int) -> None:
     if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*", table):
         raise ValueError("remote table must be an unquoted schema.table identifier")
@@ -261,6 +320,8 @@ def main() -> None:
     parser.add_argument("--target-gb", type=float, default=100)
     parser.add_argument("--bandwidth-gbps", default="1,10,100")
     parser.add_argument("--fk-match-fractions", default="0,0.5,1")
+    parser.add_argument("--partition-rows", type=int, default=500_000)
+    parser.add_argument("--partition-buckets", type=int, default=365)
     parser.add_argument("--remote-table")
     parser.add_argument("--remote-limit", type=int, default=50_000)
     parser.add_argument("--json-output")
@@ -326,6 +387,27 @@ def main() -> None:
                     "value": elapsed,
                 }
             )
+
+    partition_elapsed, partition_mb, partition_count = benchmark_time_partitions(
+        args.partition_rows,
+        args.partition_buckets,
+        args.repeats,
+    )
+    print("partition_rows,partition_buckets,input_mb,unordered_partition_seconds")
+    print(
+        f"{args.partition_rows},{partition_count},{partition_mb:.2f},"
+        f"{partition_elapsed:.3f}"
+    )
+    results.append(
+        {
+            "name": (
+                f"time partitioning {args.partition_rows} rows / "
+                f"{partition_count} buckets"
+            ),
+            "unit": "seconds",
+            "value": partition_elapsed,
+        }
+    )
 
     if args.remote_table:
         dsn = os.environ.get("XTDB_BENCHMARK_DSN")

--- a/docs/_quarto.yaml
+++ b/docs/_quarto.yaml
@@ -1,6 +1,9 @@
 project:
   type: website
   output-dir: _site
+  resources:
+  - benchmark-history.json
+  - benchmark-history.js
 
 website:
   title: "Polars Hist DB"
@@ -16,6 +19,8 @@ website:
       text: Configuration
     - href: api.qmd
       text: API Reference
+    - href: benchmarks.qmd
+      text: Benchmarks
     right:
     - text: GitHub
       icon: github
@@ -31,6 +36,7 @@ website:
       - replicated-overrides.qmd
       - api.qmd
       - backend-contract.qmd
+      - benchmarks.qmd
       - examples.qmd
 
   page-footer:

--- a/docs/benchmark-history.js
+++ b/docs/benchmark-history.js
@@ -1,0 +1,108 @@
+(() => {
+  const status = document.querySelector("#benchmark-status");
+  const latestContainer = document.querySelector("#benchmark-latest");
+  const select = document.querySelector("#benchmark-select");
+  const chart = document.querySelector("#benchmark-chart");
+
+  const escapeHtml = (value) => String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+
+  const formatValue = (value, unit) => {
+    const digits = Math.abs(value) < 0.1 ? 4 : 3;
+    return `${Number(value).toFixed(digits)} ${unit}`;
+  };
+
+  const findBenchmark = (entry, name) =>
+    entry.benchmarks.find((benchmark) => benchmark.name === name);
+
+  const renderChart = (entries, name) => {
+    const samples = entries
+      .map((entry) => ({ entry, benchmark: findBenchmark(entry, name) }))
+      .filter(({ benchmark }) => benchmark);
+    if (!samples.length) {
+      chart.textContent = "No samples are available for this benchmark.";
+      return;
+    }
+
+    const width = 900;
+    const height = 280;
+    const padding = 48;
+    const values = samples.map(({ benchmark }) => Number(benchmark.value));
+    const low = Math.min(...values);
+    const high = Math.max(...values);
+    const span = high - low || Math.max(high, 1);
+    const x = (index) => padding
+      + index * (width - padding * 2) / Math.max(samples.length - 1, 1);
+    const y = (value) => height - padding
+      - (value - low) * (height - padding * 2) / span;
+    const points = values.map((value, index) => `${x(index)},${y(value)}`).join(" ");
+    const circles = values.map((value, index) => {
+      const sample = samples[index];
+      const label = `${sample.entry.commit.slice(0, 7)}: ${formatValue(value, sample.benchmark.unit)}`;
+      return `<circle class="point" cx="${x(index)}" cy="${y(value)}" r="4"><title>${escapeHtml(label)}</title></circle>`;
+    }).join("");
+    const unit = samples.at(-1).benchmark.unit;
+
+    chart.innerHTML = `
+      <svg viewBox="0 0 ${width} ${height}" role="img" aria-label="${escapeHtml(name)} history">
+        <line class="axis" x1="${padding}" y1="${padding}" x2="${padding}" y2="${height - padding}"></line>
+        <line class="axis" x1="${padding}" y1="${height - padding}" x2="${width - padding}" y2="${height - padding}"></line>
+        <text x="${padding}" y="${padding - 12}">${escapeHtml(formatValue(high, unit))}</text>
+        <text x="${padding}" y="${height - 14}">${escapeHtml(formatValue(low, unit))}</text>
+        <text x="${padding}" y="${height - 4}">${escapeHtml(samples[0].entry.commit.slice(0, 7))}</text>
+        <text x="${width - padding}" y="${height - 4}" text-anchor="end">${escapeHtml(samples.at(-1).entry.commit.slice(0, 7))}</text>
+        <polyline class="series" points="${points}"></polyline>
+        ${circles}
+      </svg>`;
+  };
+
+  fetch("benchmark-history.json", { cache: "no-store" })
+    .then((response) => {
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      return response.json();
+    })
+    .then((history) => {
+      const entries = history.entries || [];
+      if (!entries.length) {
+        status.textContent = "No tracked CI benchmark run has completed yet.";
+        select.disabled = true;
+        return;
+      }
+
+      const latest = entries.at(-1);
+      const previous = entries.at(-2);
+      const commitUrl = `https://github.com/${latest.repository}/commit/${latest.commit}`;
+      status.innerHTML = `Latest run: <a href="${escapeHtml(commitUrl)}"><code>${escapeHtml(latest.commit.slice(0, 7))}</code></a>
+        on ${escapeHtml(new Date(latest.timestamp).toLocaleString())} ·
+        ${escapeHtml(latest.runner)} · Python ${escapeHtml(latest.python)} · Polars ${escapeHtml(latest.polars)}`;
+
+      const rows = latest.benchmarks.map((benchmark) => {
+        const old = previous && findBenchmark(previous, benchmark.name);
+        const change = old && old.value
+          ? `${((benchmark.value - old.value) / old.value * 100).toFixed(1)}%`
+          : "—";
+        return `<tr><td>${escapeHtml(benchmark.name)}</td><td>${escapeHtml(formatValue(benchmark.value, benchmark.unit))}</td><td>${escapeHtml(change)}</td></tr>`;
+      }).join("");
+      latestContainer.innerHTML = `
+        <table class="table table-striped">
+          <thead><tr><th>Benchmark</th><th>Latest</th><th>Change from previous</th></tr></thead>
+          <tbody>${rows}</tbody>
+        </table>`;
+
+      latest.benchmarks.forEach((benchmark) => {
+        const option = document.createElement("option");
+        option.value = benchmark.name;
+        option.textContent = benchmark.name;
+        select.append(option);
+      });
+      select.addEventListener("change", () => renderChart(entries, select.value));
+      renderChart(entries, select.value);
+    })
+    .catch((error) => {
+      status.textContent = `Benchmark history could not be loaded: ${error.message}`;
+      select.disabled = true;
+    });
+})();

--- a/docs/benchmark-history.json
+++ b/docs/benchmark-history.json
@@ -1,0 +1,566 @@
+{
+  "schema_version": 1,
+  "suite": "ingestion",
+  "entries": [
+    {
+      "commit": "9fa60ae83960adb073c04632a3397c27c816c086",
+      "repository": "jr200-labs/polars-hist-db",
+      "timestamp": "2026-07-18T03:23:53.036000+00:00",
+      "runner": "historical GitHub runner",
+      "python": "unknown",
+      "polars": "unknown",
+      "benchmarks": [
+        {
+          "name": "delta 50000 stored / 50000 uploaded",
+          "value": 0.006007741000018996,
+          "unit": "seconds"
+        },
+        {
+          "name": "delta 500000 stored / 50000 uploaded",
+          "value": 0.008996892999988404,
+          "unit": "seconds"
+        },
+        {
+          "name": "delta 5000000 stored / 50000 uploaded",
+          "value": 0.02664681900000687,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 0 matched",
+          "value": 0.592318382000002,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.48985970299997916,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 1 matched",
+          "value": 0.3767290909999872,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 0 matched",
+          "value": 0.5929883450000091,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.492267083999991,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 1 matched",
+          "value": 0.3873785039999973,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 0 matched",
+          "value": 0.6431489129999761,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.5303673870000125,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 1 matched",
+          "value": 0.40186781700001006,
+          "unit": "seconds"
+        }
+      ]
+    },
+    {
+      "commit": "1bb7698ed80503413007744bb4966b3a0fb35d27",
+      "repository": "jr200-labs/polars-hist-db",
+      "timestamp": "2026-07-18T03:27:24.076000+00:00",
+      "runner": "historical GitHub runner",
+      "python": "unknown",
+      "polars": "unknown",
+      "benchmarks": [
+        {
+          "name": "delta 50000 stored / 50000 uploaded",
+          "value": 0.006888317000004918,
+          "unit": "seconds"
+        },
+        {
+          "name": "delta 500000 stored / 50000 uploaded",
+          "value": 0.009263319999988084,
+          "unit": "seconds"
+        },
+        {
+          "name": "delta 5000000 stored / 50000 uploaded",
+          "value": 0.025165688000001296,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 0 matched",
+          "value": 0.7750319550000029,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.6321264289999959,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 1 matched",
+          "value": 0.495541750000001,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 0 matched",
+          "value": 0.7769105320000023,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.6373705629999904,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 1 matched",
+          "value": 0.49594977699999276,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 0 matched",
+          "value": 0.8060146270000104,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.6683498220000104,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 1 matched",
+          "value": 0.5114797570000036,
+          "unit": "seconds"
+        }
+      ]
+    },
+    {
+      "commit": "9d1a38d0a129405b7a87c14a9fc48a79f35e9071",
+      "repository": "jr200-labs/polars-hist-db",
+      "timestamp": "2026-07-18T03:42:37.047000+00:00",
+      "runner": "historical GitHub runner",
+      "python": "unknown",
+      "polars": "unknown",
+      "benchmarks": [
+        {
+          "name": "delta 50000 stored / 50000 uploaded",
+          "value": 0.007587450000002605,
+          "unit": "seconds"
+        },
+        {
+          "name": "delta 500000 stored / 50000 uploaded",
+          "value": 0.00994167300000015,
+          "unit": "seconds"
+        },
+        {
+          "name": "delta 5000000 stored / 50000 uploaded",
+          "value": 0.028109030000010193,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 0 matched",
+          "value": 0.7807999919999986,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.6528227499999986,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 1 matched",
+          "value": 0.5066392519999994,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 0 matched",
+          "value": 0.7868258039999887,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.6453357359999927,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 1 matched",
+          "value": 0.49804008899999985,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 0 matched",
+          "value": 0.8127532230000014,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.6760736530000031,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 1 matched",
+          "value": 0.5186927120000036,
+          "unit": "seconds"
+        }
+      ]
+    },
+    {
+      "commit": "1cd7db60fddc99ea221d2fffcf70170aa43ba381",
+      "repository": "jr200-labs/polars-hist-db",
+      "timestamp": "2026-07-18T03:54:52.284000+00:00",
+      "runner": "historical GitHub runner",
+      "python": "unknown",
+      "polars": "unknown",
+      "benchmarks": [
+        {
+          "name": "delta 50000 stored / 50000 uploaded",
+          "value": 0.005518172999998683,
+          "unit": "seconds"
+        },
+        {
+          "name": "delta 500000 stored / 50000 uploaded",
+          "value": 0.007322564000006082,
+          "unit": "seconds"
+        },
+        {
+          "name": "delta 5000000 stored / 50000 uploaded",
+          "value": 0.019719303000002242,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 0 matched",
+          "value": 0.6007595659999936,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.493218677999991,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 1 matched",
+          "value": 0.38290830900000117,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 0 matched",
+          "value": 0.6018306899999999,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.4929752119999904,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 1 matched",
+          "value": 0.3851962349999951,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 0 matched",
+          "value": 0.6233067829999897,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.5196071920000094,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 1 matched",
+          "value": 0.40172924899999884,
+          "unit": "seconds"
+        }
+      ]
+    },
+    {
+      "commit": "6491f8a4749d6260156ca69a58a1d856b83cbf07",
+      "repository": "jr200-labs/polars-hist-db",
+      "timestamp": "2026-07-18T04:37:49.823000+00:00",
+      "runner": "historical GitHub runner",
+      "python": "unknown",
+      "polars": "unknown",
+      "benchmarks": [
+        {
+          "name": "delta 50000 stored / 50000 uploaded",
+          "value": 0.006716412000002947,
+          "unit": "seconds"
+        },
+        {
+          "name": "delta 500000 stored / 50000 uploaded",
+          "value": 0.009260627999992721,
+          "unit": "seconds"
+        },
+        {
+          "name": "delta 5000000 stored / 50000 uploaded",
+          "value": 0.02279743199999018,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 0 matched",
+          "value": 0.8644589720000084,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.683042357000005,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 1 matched",
+          "value": 0.5057780399999956,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 0 matched",
+          "value": 0.868199611999998,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.6927653719999967,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 1 matched",
+          "value": 0.5143726919999949,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 0 matched",
+          "value": 0.883791305999992,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.7111272629999945,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 1 matched",
+          "value": 0.5314837519999998,
+          "unit": "seconds"
+        }
+      ]
+    },
+    {
+      "commit": "31556f4e4da57e3620a9f314401db5ec8f9f93b2",
+      "repository": "jr200-labs/polars-hist-db",
+      "timestamp": "2026-07-18T05:24:07.343000+00:00",
+      "runner": "historical GitHub runner",
+      "python": "unknown",
+      "polars": "unknown",
+      "benchmarks": [
+        {
+          "name": "delta 50000 stored / 50000 uploaded",
+          "value": 0.00656603999999561,
+          "unit": "seconds"
+        },
+        {
+          "name": "delta 500000 stored / 50000 uploaded",
+          "value": 0.009161903000006077,
+          "unit": "seconds"
+        },
+        {
+          "name": "delta 5000000 stored / 50000 uploaded",
+          "value": 0.02273709600001439,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 0 matched",
+          "value": 0.6525741029999779,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.48135388299999704,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 1 matched",
+          "value": 0.30597225799999705,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 0 matched",
+          "value": 0.6658981380000171,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.4906119900000192,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 1 matched",
+          "value": 0.3098262680000232,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 0 matched",
+          "value": 0.6786045959999853,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.5005241289999844,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 1 matched",
+          "value": 0.3227472490000025,
+          "unit": "seconds"
+        }
+      ]
+    },
+    {
+      "commit": "eafd42cc829988ac9a65b19a88e0ca9ca24f263e",
+      "repository": "jr200-labs/polars-hist-db",
+      "timestamp": "2026-07-18T05:26:28.748000+00:00",
+      "runner": "historical GitHub runner",
+      "python": "unknown",
+      "polars": "unknown",
+      "benchmarks": [
+        {
+          "name": "delta 50000 stored / 50000 uploaded",
+          "value": 0.006549295999974447,
+          "unit": "seconds"
+        },
+        {
+          "name": "delta 500000 stored / 50000 uploaded",
+          "value": 0.009077915000005987,
+          "unit": "seconds"
+        },
+        {
+          "name": "delta 5000000 stored / 50000 uploaded",
+          "value": 0.025119823000011365,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 0 matched",
+          "value": 0.6452561940000123,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.47835375599998997,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 1 matched",
+          "value": 0.3036887140000033,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 0 matched",
+          "value": 0.6543754879999995,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.48967784399999914,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 1 matched",
+          "value": 0.3062197830000173,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 0 matched",
+          "value": 0.6724964219999947,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.4972429830000067,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 1 matched",
+          "value": 0.3245794209999815,
+          "unit": "seconds"
+        }
+      ]
+    },
+    {
+      "commit": "e461eafbfaeb6747c694550fad9126979e9cebb8",
+      "repository": "jr200-labs/polars-hist-db",
+      "timestamp": "2026-07-18T05:54:02.539000+00:00",
+      "runner": "historical GitHub runner",
+      "python": "unknown",
+      "polars": "unknown",
+      "benchmarks": [
+        {
+          "name": "delta 50000 stored / 50000 uploaded",
+          "value": 0.005305372000009356,
+          "unit": "seconds"
+        },
+        {
+          "name": "delta 500000 stored / 50000 uploaded",
+          "value": 0.007235180000009223,
+          "unit": "seconds"
+        },
+        {
+          "name": "delta 5000000 stored / 50000 uploaded",
+          "value": 0.023215372999999317,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 0 matched",
+          "value": 0.38528866699999753,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.28382291400001236,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 50000 stored / 50000 uploaded / 1 matched",
+          "value": 0.17916172700000743,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 0 matched",
+          "value": 0.3864688600000079,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.2873318789999928,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 500000 stored / 50000 uploaded / 1 matched",
+          "value": 0.18008405899999502,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 0 matched",
+          "value": 0.40302321999999435,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 0.5 matched",
+          "value": 0.30474342799999476,
+          "unit": "seconds"
+        },
+        {
+          "name": "foreign keys 5000000 stored / 50000 uploaded / 1 matched",
+          "value": 0.19796246999999312,
+          "unit": "seconds"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/benchmarks.qmd
+++ b/docs/benchmarks.qmd
@@ -1,0 +1,70 @@
+---
+title: "Benchmarks"
+---
+
+The benchmark suite tracks the ingestion paths most likely to dominate runtime
+as datasets grow. Results are synthetic and intended for regression tracking;
+they are not database service-level guarantees.
+
+## What is measured
+
+| Benchmark | Workload | Included | Excluded |
+|---|---|---|---|
+| Selective delta | Compare a 50,000-row upload with increasingly large current tables | Polars filtering and changed-row selection | XTDB network and write latency |
+| Normalized foreign keys | Resolve existing natural keys, generate missing IDs, and update the staged primary rows | Lookup joins, deterministic ID generation, collision handling | XTDB network and insert latency |
+| Unordered time partitioning | Sort, deduplicate, and split an interleaved DSV frame into daily buckets | Polars preparation and partition slicing | CSV decoding and database writes |
+
+The runner also prints theoretical transfer floors for 1, 10, and 100 Gbps
+links. An optional remote-read mode can measure decoding from a live XTDB
+table, but it is not part of the portable CI history because it requires a
+deployment-specific DSN.
+
+## Tracked results
+
+Each successful benchmark run on `master` appends its custom benchmark output
+to [`docs/benchmark-history.json`](benchmark-history.json). The workflow keeps
+the latest 100 commits, commits the updated history, and republishes this
+Quarto site.
+
+<div id="benchmark-status" class="benchmark-note">Loading benchmark history…</div>
+<div id="benchmark-latest"></div>
+
+### History
+
+<label for="benchmark-select"><strong>Benchmark series</strong></label>
+<select id="benchmark-select" class="form-select benchmark-select"></select>
+<div id="benchmark-chart" class="benchmark-chart"></div>
+
+## Run locally
+
+```bash
+make benchmark-xtdb-delta
+```
+
+For a smaller development run:
+
+```bash
+uv run python benchmarks/xtdb_delta.py \
+  --target-rows 50000 \
+  --upload-rows 10000 \
+  --partition-rows 100000 \
+  --repeats 1
+```
+
+The JSON consumed by CI can be generated with `--json-output`:
+
+```bash
+uv run python benchmarks/xtdb_delta.py --json-output benchmark-results.json
+```
+
+<style>
+.benchmark-note { margin: 1rem 0; color: var(--bs-secondary-color); }
+.benchmark-select { max-width: 52rem; margin: .5rem 0 1rem; }
+.benchmark-chart { overflow-x: auto; min-height: 18rem; }
+.benchmark-chart svg { width: 100%; min-width: 44rem; height: auto; }
+.benchmark-chart .axis { stroke: currentColor; opacity: .35; }
+.benchmark-chart .series { fill: none; stroke: #2780e3; stroke-width: 3; }
+.benchmark-chart .point { fill: #2780e3; }
+</style>
+
+<script src="benchmark-history.js"></script>

--- a/tests/benchmarks/test_benchmark_history.py
+++ b/tests/benchmarks/test_benchmark_history.py
@@ -1,0 +1,36 @@
+import json
+
+from benchmarks.record_history import record_history
+
+
+def test_record_history_replaces_rerun_for_same_commit(tmp_path):
+    results_path = tmp_path / "results.json"
+    history_path = tmp_path / "history.json"
+    results_path.write_text(
+        json.dumps([{"name": "partitioning", "unit": "seconds", "value": 1.2}])
+    )
+
+    first = record_history(
+        results_path,
+        history_path,
+        commit="abc123",
+        repository="jr200-labs/polars-hist-db",
+        runner="Linux/X64",
+        timestamp="2026-07-18T00:00:00+00:00",
+    )
+    results_path.write_text(
+        json.dumps([{"name": "partitioning", "unit": "seconds", "value": 1.1}])
+    )
+    second = record_history(
+        results_path,
+        history_path,
+        commit="abc123",
+        repository="jr200-labs/polars-hist-db",
+        runner="Linux/X64",
+        timestamp="2026-07-18T00:01:00+00:00",
+    )
+
+    assert len(first["entries"]) == 1
+    assert len(second["entries"]) == 1
+    assert second["entries"][0]["benchmarks"][0]["value"] == 1.1
+    assert json.loads(history_path.read_text()) == second

--- a/tests/benchmarks/test_xtdb_delta_benchmark.py
+++ b/tests/benchmarks/test_xtdb_delta_benchmark.py
@@ -1,5 +1,6 @@
 from benchmarks.xtdb_delta import (
     benchmark_foreign_keys,
+    benchmark_time_partitions,
     network_floor_seconds,
     synthetic_frames,
 )
@@ -17,3 +18,7 @@ def test_xtdb_delta_benchmark_models_target_and_upload_independently():
     )
     assert parent_mb > upload_mb
     assert (matched, created, collisions, updated) == (5, 5, 0, True)
+
+    _, input_mb, partition_count = benchmark_time_partitions(100, 10, 1)
+    assert input_mb > 0
+    assert partition_count == 10


### PR DESCRIPTION
## Summary
- benchmark unordered time partitioning alongside delta and normalized foreign-key workloads
- keep benchmark history as tracked JSON updated by GitHub Actions
- document and chart current and historical results in the Quarto site

## Validation
- 239 passed, 15 deselected
- Ruff, formatting, mypy, actionlint, and JavaScript checks
- full benchmark workload
- Quarto render