### PR TITLE
refactor: replace pipeline metadata dataframes

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -29,6 +29,7 @@ from sqlalchemy.engine import Engine
 from ..config import (
     DeltaConfig,
     ForeignKeyConfig,
+    PipelineExtractColumn,
     TableColumnConfig,
     TableConfig,
     ValidTimeConfig,
@@ -1319,18 +1320,22 @@ def _dedupe_xtdb_staging_dataframe(
     return df.unique(subset=unique_columns, keep="last", maintain_order=True)
 
 
-def _xtdb_deduced_foreign_key_columns(col_info: pl.DataFrame) -> dict[str, str]:
-    return dict(
-        col_info.filter("deduce_foreign_key").select("source", "target").iter_rows()
-    )
+def _xtdb_deduced_foreign_key_columns(
+    col_info: Iterable[PipelineExtractColumn],
+) -> dict[str, str]:
+    return {
+        column.source: column.target for column in col_info if column.deduce_foreign_key
+    }
 
 
-def _xtdb_deduced_value_columns(col_info: pl.DataFrame) -> dict[str, str]:
-    return dict(
-        col_info.filter(pl.col("deduce_foreign_key").not_())
-        .select("source", "target")
-        .iter_rows()
-    )
+def _xtdb_deduced_value_columns(
+    col_info: Iterable[PipelineExtractColumn],
+) -> dict[str, str]:
+    return {
+        column.source: column.target
+        for column in col_info
+        if not column.deduce_foreign_key
+    }
 
 
 def _xtdb_is_textual_config_column(table_config: TableConfig, column_name: str) -> bool:

--- a/polars_hist_db/config/__init__.py
+++ b/polars_hist_db/config/__init__.py
@@ -10,6 +10,7 @@ from .dataset import (
     DatasetsConfig,
     IngestionColumnConfig,
     DeltaConfig,
+    PipelineExtractColumn,
     ValidTimeConfig,
 )
 from .table import (
@@ -33,6 +34,7 @@ __all__ = [
     "TableColumnConfig",
     "IngestionColumnConfig",
     "DeltaConfig",
+    "PipelineExtractColumn",
     "ValidTimeConfig",
     "ForeignKeyConfig",
     "TableConfig",

--- a/polars_hist_db/config/dataset.py
+++ b/polars_hist_db/config/dataset.py
@@ -222,7 +222,7 @@ class Pipeline:
                     IngestionColumnConfig(
                         column_type=column.column_type,
                         schema=column.schema,
-                        table=column.table,
+                        table=(column.table if table_column is not None else None),
                         ingestion_data_type=ingestion_type,
                         target_data_type=target_type,
                         source=column.source,
@@ -231,11 +231,7 @@ class Pipeline:
                         aggregation=column.aggregation,
                         deduce_foreign_key=column.deduce_foreign_key,
                         value_if_missing=column.value_if_missing,
-                        nullable=(
-                            table_column.nullable
-                            if table_column is not None
-                            else column.nullable
-                        ),
+                        nullable=(table_column.nullable if table_column else None),
                         required=column.required,
                     )
                 )

--- a/polars_hist_db/config/dataset.py
+++ b/polars_hist_db/config/dataset.py
@@ -1,7 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Dict, List, Literal, Optional, Sequence, Tuple
-
-import polars as pl
+from typing import Any, Dict, List, Literal, Mapping, Optional, Sequence, Tuple, cast
 import logging
 
 from .parser_config import IngestionColumnConfig
@@ -30,205 +28,267 @@ class DeltaConfig:
         return f"__{table_name}_tmp"
 
 
-@dataclass
+PipelineColumnType = Literal["data", "computed", "dsv_only", "time_partition_only"]
+
+
+@dataclass(frozen=True)
+class PipelineColumn:
+    pipeline_id: int
+    schema: str
+    table: str
+    item_type: str
+    column_type: PipelineColumnType
+    source: Optional[str] = None
+    target: Optional[str] = None
+    target_data_type: Optional[str] = None
+    ingestion_data_type: Optional[str] = None
+    required: bool = False
+    transforms: Mapping[str, Any] = field(default_factory=dict)
+    aggregation: Optional[str] = None
+    deduce_foreign_key: bool = False
+    value_if_missing: Optional[str] = None
+    nullable: bool = True
+
+
+@dataclass(frozen=True)
+class PipelineExtractColumn:
+    table: str
+    source: str
+    target: str
+    required: bool = False
+    deduce_foreign_key: bool = False
+
+
+@dataclass(init=False)
 class Pipeline:
-    items: pl.DataFrame
+    items: Tuple[PipelineColumn, ...]
     _header_maps: Dict[str, Dict[str, str]] = field(
         init=False, repr=False, compare=False
     )
     _item_types: Dict[str, Tuple[str, ...]] = field(
         init=False, repr=False, compare=False
     )
-    _extract_items: Dict[int, pl.DataFrame] = field(
+    _extract_items: Dict[int, Tuple[PipelineExtractColumn, ...]] = field(
         init=False, repr=False, compare=False
     )
-    _empty_extract_items: pl.DataFrame = field(init=False, repr=False, compare=False)
     _main_table_name: Tuple[str, str] = field(init=False, repr=False, compare=False)
     _table_names: Tuple[str, ...] = field(init=False, repr=False, compare=False)
     _pipeline_items: Dict[int, Tuple[str, str]] = field(
         init=False, repr=False, compare=False
     )
 
-    def __post_init__(self):
-        item_schema = IngestionColumnConfig.df_schema()
-        items = (
-            pl.from_records(self.items)
-            .with_row_index(name="id")
-            .explode("columns", empty_as_null=True)
-            .unnest("columns")
-        )
+    def __init__(self, items: Sequence[Mapping[str, Any] | PipelineColumn]) -> None:
+        if all(isinstance(item, PipelineColumn) for item in items):
+            columns = tuple(cast(PipelineColumn, item) for item in items)
+        else:
+            raw_items = cast(Sequence[Mapping[str, Any]], items)
+            parsed_columns: List[PipelineColumn] = []
+            for pipeline_id, item in enumerate(raw_items):
+                item_columns: Sequence[Mapping[str, Any]] = item.get("columns") or ({},)
+                parsed_columns.extend(
+                    self._parse_column(pipeline_id, item, column)
+                    for column in item_columns
+                )
+            columns = tuple(parsed_columns)
 
-        items = items.with_columns(
-            pl.lit(None).cast(t).alias(c)
-            for c, t in item_schema.items()
-            if c not in items.columns
-        ).with_columns(
-            pl.col("type").fill_null("extract"),
-            pl.col("required").fill_null(False),
-            pl.col("nullable").fill_null(True),
-            pl.col("deduce_foreign_key").fill_null(False),
-            pl.when(pl.col("column_type").is_null())
-            .then(
-                pl.when(pl.col("target").is_null())
-                .then(pl.lit("dsv_only"))
-                .when(pl.col("source").is_null())
-                .then(pl.lit("computed"))
-                .otherwise(pl.lit("data"))
-            )
-            .otherwise(pl.col("column_type"))
-            .alias("column_type"),
-        )
-
-        primary_item = items.filter(type="primary").select("table", "schema").unique()
-        if len(primary_item) != 1:
+        primary_items = {
+            (column.schema, column.table)
+            for column in columns
+            if column.item_type == "primary"
+        }
+        if len(primary_items) != 1:
             raise ValueError("invalid pipeline, required exactly one primary table")
 
-        self.items = items
-        self._main_table_name = (primary_item[0, "schema"], primary_item[0, "table"])
-        self._table_names = tuple(
-            items.get_column("table").unique(maintain_order=True).to_list()
-        )
-        self._pipeline_items = {
-            pipeline_id: (schema, table)
-            for pipeline_id, schema, table in items.select("id", "schema", "table")
-            .unique(maintain_order=True)
-            .iter_rows()
-        }
+        self.items = columns
+        self._main_table_name = next(iter(primary_items))
+        self._table_names = tuple(dict.fromkeys(column.table for column in columns))
+        self._pipeline_items = {}
+        for column in columns:
+            self._pipeline_items.setdefault(
+                column.pipeline_id, (column.schema, column.table)
+            )
 
         self._header_maps = {table: {} for table in self._table_names}
-        for table, source, target in (
-            items.select("table", "source", "target").drop_nulls().iter_rows()
+        for column in columns:
+            if column.source is not None and column.target is not None:
+                self._header_maps[column.table][column.target] = column.source
+
+        item_types: Dict[str, List[str]] = {table: [] for table in self._table_names}
+        for column in columns:
+            if column.item_type not in item_types[column.table]:
+                item_types[column.table].append(column.item_type)
+        self._item_types = {table: tuple(types) for table, types in item_types.items()}
+
+        self._extract_items = {pipeline_id: () for pipeline_id in self._pipeline_items}
+        for pipeline_id in self._pipeline_items:
+            self._extract_items[pipeline_id] = tuple(
+                PipelineExtractColumn(
+                    table=column.table,
+                    source=column.source or column.target or "",
+                    target=column.target or "",
+                    required=column.required,
+                    deduce_foreign_key=column.deduce_foreign_key,
+                )
+                for column in columns
+                if column.pipeline_id == pipeline_id
+                and column.column_type in {"data", "computed"}
+            )
+
+        if any(
+            not column.source or not column.target
+            for extract_columns in self._extract_items.values()
+            for column in extract_columns
         ):
-            self._header_maps[table][target] = source
+            raise ValueError("data and computed pipeline columns require a target")
 
-        self._item_types = {
-            table: tuple(
-                items.filter(table=table)
-                .get_column("type")
-                .unique(maintain_order=True)
-                .to_list()
+    @staticmethod
+    def _parse_column(
+        pipeline_id: int,
+        item: Mapping[str, Any],
+        column: Mapping[str, Any],
+    ) -> PipelineColumn:
+        source = column.get("source")
+        target = column.get("target")
+        column_type = column.get("column_type")
+        if column_type is None:
+            column_type = (
+                "dsv_only"
+                if target is None
+                else "computed"
+                if source is None
+                else "data"
             )
-            for table in self._table_names
-        }
 
-        extract_items = (
-            items.filter(pl.col("column_type").is_in(["data", "computed"]))
-            .with_columns(source=pl.coalesce("source", "target"))
-            .select(
-                "id",
-                "table",
-                "source",
-                "target",
-                "required",
-                "deduce_foreign_key",
-            )
+        return PipelineColumn(
+            pipeline_id=pipeline_id,
+            schema=item["schema"],
+            table=item["table"],
+            item_type=item.get("type") or "extract",
+            column_type=cast(PipelineColumnType, column_type),
+            source=source,
+            target=target,
+            target_data_type=column.get("target_data_type"),
+            ingestion_data_type=column.get("ingestion_data_type"),
+            required=bool(column.get("required")),
+            transforms=column.get("transforms") or {},
+            aggregation=column.get("aggregation"),
+            deduce_foreign_key=bool(column.get("deduce_foreign_key")),
+            value_if_missing=column.get("value_if_missing"),
+            nullable=True if column.get("nullable") is None else column["nullable"],
         )
-        self._extract_items = {
-            pipeline_id: extract_items.filter(id=pipeline_id).drop("id")
-            for pipeline_id in self._pipeline_items
-        }
-        self._empty_extract_items = extract_items.head(0).drop("id")
+
+    @staticmethod
+    def _resolved_types(
+        column: PipelineColumn,
+        table_column: Optional[TableColumnConfig],
+        table_schema: str,
+        table_name: str,
+    ) -> Tuple[str, str]:
+        table_data_type = table_column.data_type if table_column is not None else None
+        target_data_type = (
+            column.target_data_type or table_data_type or column.ingestion_data_type
+        )
+        ingestion_data_type = (
+            column.ingestion_data_type or table_data_type or target_data_type
+        )
+        if target_data_type is None or ingestion_data_type is None:
+            LOGGER.error("Missing types for pipeline column %s", column)
+            raise ValueError(f"Missing types in {table_schema}.{table_name}")
+        return ingestion_data_type, target_data_type
 
     def build_ingestion_column_definitions(
         self, all_tables: TableConfigs
     ) -> List[IngestionColumnConfig]:
-        tmp_cols = self.items.filter(
-            pl.col("column_type").is_in(["dsv_only", "time_partition_only"])
-        )
-        pipeline_cols = self.items.filter(
-            pl.col("column_type").is_in(["dsv_only", "time_partition_only"]).not_()
-        )
-        merged_cols = pl.concat([pipeline_cols, tmp_cols])
-        all_dfs = self._merge_with_table_config(
-            merged_cols, ["schema", "table", "source", "target"], all_tables
-        )
-
-        schema_keys = IngestionColumnConfig.df_schema().keys()
+        temporary_types = {"dsv_only", "time_partition_only"}
+        ordered_columns = [
+            column for column in self.items if column.column_type not in temporary_types
+        ] + [column for column in self.items if column.column_type in temporary_types]
         result = []
-        for df in all_dfs:
-            df = df.with_columns(
-                name=pl.coalesce("target", "source"),
-            )
-            for row in df.iter_rows(named=True):
-                row_dict = {c: row[c] for c in schema_keys if c in row}
-                cc = IngestionColumnConfig(**row_dict)
-                result.append(cc)
-
+        for table in all_tables.items:
+            table_columns = {column.name: column for column in table.columns}
+            seen = set()
+            for column in ordered_columns:
+                if column.table != table.name:
+                    continue
+                key = (column.schema, column.table, column.source, column.target)
+                if key in seen:
+                    continue
+                seen.add(key)
+                table_column = table_columns.get(column.target or "")
+                ingestion_type, target_type = self._resolved_types(
+                    column, table_column, table.schema, table.name
+                )
+                result.append(
+                    IngestionColumnConfig(
+                        column_type=column.column_type,
+                        schema=column.schema,
+                        table=column.table,
+                        ingestion_data_type=ingestion_type,
+                        target_data_type=target_type,
+                        source=column.source,
+                        target=column.target,
+                        transforms=dict(column.transforms),
+                        aggregation=column.aggregation,
+                        deduce_foreign_key=column.deduce_foreign_key,
+                        value_if_missing=column.value_if_missing,
+                        nullable=(
+                            table_column.nullable
+                            if table_column is not None
+                            else column.nullable
+                        ),
+                        required=column.required,
+                    )
+                )
         return result
-
-    def _merge_with_table_config(
-        self,
-        pipeline_cols: pl.DataFrame,
-        unique_key: List[str],
-        all_tables: TableConfigs,
-    ) -> List[pl.DataFrame]:
-        all_dfs = []
-        for tbl_cfg in all_tables.items:
-            tbl_cols = tbl_cfg.columns_df().rename({"data_type": "tbl_data_type"})
-            pipeline_tbl = pipeline_cols.filter(table=tbl_cfg.name)
-            merged_tbl = (
-                pipeline_tbl.unique(subset=unique_key, maintain_order=True)
-                .drop([c for c in pipeline_tbl.columns if c in tbl_cols.columns])
-                .join(tbl_cols, left_on=["target"], right_on=["name"], how="left")
-                .with_columns(
-                    pl.coalesce(
-                        "target_data_type", "tbl_data_type", "ingestion_data_type"
-                    ).alias("target_data_type")
-                )
-                .with_columns(
-                    pl.coalesce(
-                        "ingestion_data_type", "tbl_data_type", "target_data_type"
-                    ).alias("ingestion_data_type")
-                )
-            )
-
-            missing_types = merged_tbl.select(
-                "id",
-                "table",
-                "source",
-                "target",
-                "ingestion_data_type",
-                "target_data_type",
-                "tbl_data_type",
-                is_missing=pl.col("ingestion_data_type").is_null()
-                | pl.col("target_data_type").is_null(),
-            ).filter(pl.col("is_missing"))
-            if not missing_types.is_empty():
-                LOGGER.error("Missing types for dataframe %s", missing_types)
-                raise ValueError(f"Missing types in {tbl_cfg.schema}.{tbl_cfg.name}")
-
-            all_dfs.append(merged_tbl)
-
-        all_dfs = [df for df in all_dfs if not df.is_empty()]
-
-        return all_dfs
 
     def build_delta_table_column_configs(
         self, all_tables: TableConfigs, table_name: str
     ) -> List[TableColumnConfig]:
-        pipeline_cols = self.items.filter(
-            pl.col("column_type").is_in(["data", "computed"])
-        )
-        all_dfs = self._merge_with_table_config(
-            pipeline_cols, ["table", "source", "target"], all_tables
-        )
+        candidates = []
+        for table in all_tables.items:
+            table_columns = {column.name: column for column in table.columns}
+            seen = set()
+            for column in self.items:
+                if column.table != table.name or column.column_type not in {
+                    "data",
+                    "computed",
+                }:
+                    continue
+                key = (column.table, column.source, column.target)
+                if key in seen:
+                    continue
+                seen.add(key)
+                table_column = table_columns.get(column.target or "")
+                _, target_type = self._resolved_types(
+                    column, table_column, table.schema, table.name
+                )
+                candidates.append(
+                    (column, table_column, column.source or column.target, target_type)
+                )
 
-        candidate_cols = (
-            pl.concat(all_dfs)
-            .sort("type")
-            .with_columns(
-                name=pl.coalesce("source", "target"),
-                data_type=pl.col("target_data_type"),
+        candidates.sort(key=lambda candidate: candidate[0].item_type)
+        last_index = {name: index for index, (_, _, name, _) in enumerate(candidates)}
+        return [
+            TableColumnConfig(
+                table=table_name,
+                name=name,
+                data_type=data_type,
+                default_value=(
+                    table_column.default_value if table_column is not None else None
+                ),
+                autoincrement=(
+                    table_column.autoincrement if table_column is not None else False
+                ),
+                nullable=(table_column.nullable if table_column is not None else True),
+                unique_constraint=(
+                    list(table_column.unique_constraint)
+                    if table_column is not None
+                    else []
+                ),
             )
-            .unique(subset=["name"], keep="last", maintain_order=True)
-            .drop("target", "source")
-        )
-
-        columns = TableColumnConfig.from_dataframe(
-            candidate_cols, table_name_override=table_name
-        )
-
-        return columns
+            for index, (_, table_column, name, data_type) in enumerate(candidates)
+            if name is not None and last_index[name] == index
+        ]
 
     def get_header_map(self, table: str) -> Dict[str, str]:
         return dict(self._header_maps.get(table, {}))
@@ -240,8 +300,8 @@ class Pipeline:
 
         return item_types[0]
 
-    def extract_items(self, pipeline_id: int) -> pl.DataFrame:
-        return self._extract_items.get(pipeline_id, self._empty_extract_items)
+    def extract_items(self, pipeline_id: int) -> Tuple[PipelineExtractColumn, ...]:
+        return self._extract_items.get(pipeline_id, ())
 
     def get_main_table_name(self) -> Tuple[str, str]:
         return self._main_table_name

--- a/polars_hist_db/config/fn_builtins.py
+++ b/polars_hist_db/config/fn_builtins.py
@@ -42,7 +42,12 @@ def apply_type_casts(
 
     for polars_dtype_str in dtypes:
         polars_dtype = getattr(sys.modules["polars"], polars_dtype_str)
-        df = df.with_columns(pl.col(result_col).cast(polars_dtype))
+        expression = pl.col(result_col)
+        if polars_dtype == pl.Date and df.schema[result_col] == pl.String:
+            expression = expression.str.to_date()
+        else:
+            expression = expression.cast(polars_dtype)
+        df = df.with_columns(expression)
 
     return df
 

--- a/polars_hist_db/config/parser_config.py
+++ b/polars_hist_db/config/parser_config.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger(__name__)
 class IngestionColumnConfig:
     column_type: Literal["data", "computed", "dsv_only", "time_partition_only"]
     schema: str
-    table: str
+    table: Optional[str]
     ingestion_data_type: str
     target_data_type: str
     source: Optional[str] = None
@@ -23,7 +23,7 @@ class IngestionColumnConfig:
     aggregation: Optional[str] = None
     deduce_foreign_key: bool = False
     value_if_missing: Optional[str] = None
-    nullable: bool = True
+    nullable: Optional[bool] = True
     required: bool = False
 
     def __post_init__(self):

--- a/polars_hist_db/config/table.py
+++ b/polars_hist_db/config/table.py
@@ -216,8 +216,8 @@ class TableConfig:
 
     def dtypes(self) -> Mapping[str, pl.DataType]:
         result = {
-            row["name"]: PolarsType.from_sql(row["data_type"])
-            for row in self.columns_df().iter_rows(named=True)
+            column.name: PolarsType.from_sql(column.data_type)
+            for column in self.columns
         }
 
         return result
@@ -241,18 +241,21 @@ class ForeignKeyConfig:
 @dataclass
 class TableConfigs:
     items: List[TableConfig]
+    _by_name: Dict[str, TableConfig] = field(init=False, repr=False, compare=False)
 
     def __post_init__(self):
         self.items = [TableConfig(**tc_dict) for tc_dict in self.items]
         for tc in self.items:
             tc._resolve_foreign_keys(*self.items)
+        self._by_name = {}
+        for table in self.items:
+            self._by_name.setdefault(table.name, table)
 
     def __getitem__(self, name: str) -> TableConfig:
-        tc = next((tc for tc in self.items if tc.name == name), None)
-        if tc:
-            return tc
-
-        raise ValueError(f"TableConfig {name} not found")
+        try:
+            return self._by_name[name]
+        except KeyError as exc:
+            raise ValueError(f"TableConfig {name} not found") from exc
 
     def names(self) -> List[str]:
         return [tc.name for tc in self.items]

--- a/polars_hist_db/dataset/extract_item.py
+++ b/polars_hist_db/dataset/extract_item.py
@@ -52,7 +52,7 @@ def scrape_extract_item(
     TableConfigOps(connection).create(target_table_config)
 
     col_info = pipeline.extract_items(pipeline_id)
-    required_cols = col_info.filter("required")["source"].to_list()
+    required_cols = [column.source for column in col_info if column.required]
 
     # these case can pass through
     # require columns are all present in source data
@@ -76,14 +76,14 @@ def scrape_extract_item(
     )
 
     found_source_cols = [
-        str(c.name) for c in tbo.get_column_intersection(col_info["source"].to_list())
+        str(c.name)
+        for c in tbo.get_column_intersection([column.source for column in col_info])
     ]
 
     col_map_dict: Mapping[str, str] = {
-        src: tgt
-        for src, tgt in col_info.filter(pl.col("source").is_in(found_source_cols))
-        .select("source", "target")
-        .iter_rows()
+        column.source: column.target
+        for column in col_info
+        if column.source in found_source_cols
     }
 
     ni, nu, nd = DeltaTableOps(

--- a/polars_hist_db/dataset/foreign_key_helper.py
+++ b/polars_hist_db/dataset/foreign_key_helper.py
@@ -1,11 +1,11 @@
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 import polars as pl
 from sqlalchemy import ColumnElement, and_, Column, Connection, select
 from sqlalchemy.sql.functions import coalesce
 
 from ..core import DataframeOps, TableOps
-from ..config import TableConfig
+from ..config import PipelineExtractColumn, TableConfig
 
 LOGGER = logging.getLogger(__name__)
 
@@ -14,11 +14,13 @@ def _get_column_info(
     table_config: TableConfig, col_map: Dict[str, str], col_name: str
 ) -> Optional[Dict[str, Any]]:
     """Retrieve column information for the given column name."""
-    col_info = table_config.columns_df()
-    row = col_info.filter(pl.col("name") == col_map[col_name])
-    if row.is_empty():
+    column = next(
+        (column for column in table_config.columns if column.name == col_map[col_name]),
+        None,
+    )
+    if column is None:
         return None
-    return {"nullable": row[0, "nullable"], "default_value": row[0, "default_value"]}
+    return {"nullable": column.nullable, "default_value": column.default_value}
 
 
 def _coalesce_with_default(
@@ -38,22 +40,29 @@ def _coalesce_with_default(
     return col
 
 
-def _get_foreign_key_columns(col_info: pl.DataFrame) -> List[str]:
+def _get_foreign_key_columns(
+    col_info: Sequence[PipelineExtractColumn],
+) -> List[str]:
     """Retrieve columns that need foreign key deducing."""
-    return col_info.filter("deduce_foreign_key")["source"].to_list()
+    return [column.source for column in col_info if column.deduce_foreign_key]
 
 
-def _get_value_columns(col_info: pl.DataFrame) -> Dict[str, str]:
+def _get_value_columns(
+    col_info: Sequence[PipelineExtractColumn],
+) -> Dict[str, str]:
     """Retrieve columns that do not need foreign key deducing."""
-    df = col_info.filter(pl.col("deduce_foreign_key").not_()).select("source", "target")
-    return dict(df.iter_rows())
+    return {
+        column.source: column.target
+        for column in col_info
+        if not column.deduce_foreign_key
+    }
 
 
 def _prepare_population_set(
     table_schema: str,
     src_table_name: str,
     parent_table_config: TableConfig,
-    col_info: pl.DataFrame,
+    col_info: Sequence[PipelineExtractColumn],
     connection: Connection,
 ) -> pl.DataFrame:
     """Prepare population set to deduce foreign keys."""
@@ -66,8 +75,7 @@ def _prepare_population_set(
 
     src_primary_keys = [src_tbl.c[k] for k in src_tbl.primary_key.columns.keys()]
     parent_implied_cols = [
-        parent_tbl.c[col]
-        for col in col_info.filter("deduce_foreign_key").select("target").iter_rows()
+        parent_tbl.c[column.target] for column in col_info if column.deduce_foreign_key
     ]
 
     value_col_map = _get_value_columns(col_info)
@@ -93,7 +101,7 @@ def deduce_foreign_keys(
     src_table_schema: str,
     src_table_name: str,
     parent_table_config: TableConfig,
-    col_info: pl.DataFrame,
+    col_info: Sequence[PipelineExtractColumn],
     connection: Connection,
 ):
     src_implied_col_names = _get_foreign_key_columns(col_info)
@@ -105,7 +113,7 @@ def deduce_foreign_keys(
         src_table_name,
         parent_table_config.name,
     )
-    src_parent_col_map = dict(col_info.select("source", "target").iter_rows())
+    src_parent_col_map = {column.source: column.target for column in col_info}
 
     population_set_df = _prepare_population_set(
         src_table_schema, src_table_name, parent_table_config, col_info, connection

--- a/polars_hist_db/dataset/primary_item.py
+++ b/polars_hist_db/dataset/primary_item.py
@@ -88,8 +88,8 @@ def scrape_primary_item(
     source_tbl = tbo.get_table_metadata()
 
     upload_items = pipeline.extract_items(pipeline_id)
-    selected_columns = upload_items["source"].to_list()
-    src_tgt_colname_map = dict(upload_items.select("source", "target").iter_rows())
+    selected_columns = [item.source for item in upload_items]
+    src_tgt_colname_map = {item.source: item.target for item in upload_items}
     valid_time = dataset.valid_time_for_table(
         main_table_config.schema, main_table_config.name
     )

--- a/polars_hist_db/loaders/jetstream_input_source.py
+++ b/polars_hist_db/loaders/jetstream_input_source.py
@@ -64,7 +64,7 @@ class JetStreamInputSource(InputSource[JetStreamInputConfig]):
         received_items_ts = (
             df.select(
                 pl.concat_list(pl.min("__created_at"), pl.max("__created_at"))
-                .explode()
+                .explode(empty_as_null=True)
                 .sort()
                 .unique()
                 .dt.strftime("%Y-%m-%d %H:%M:%S")

--- a/polars_hist_db/pipeline_projection.py
+++ b/polars_hist_db/pipeline_projection.py
@@ -70,8 +70,8 @@ def project_staged_pipeline_item_dataframe(
     valid_time: Optional[ValidTimeConfig],
 ) -> pl.DataFrame:
     upload_items = dataset.pipeline.extract_items(pipeline_id)
-    src_tgt_colname_map = dict(upload_items.select("source", "target").iter_rows())
-    selected_columns = upload_items["source"].to_list()
+    src_tgt_colname_map = {item.source: item.target for item in upload_items}
+    selected_columns = [item.source for item in upload_items]
     selected_columns = _include_valid_time_source_columns(
         selected_columns,
         src_tgt_colname_map,
@@ -103,8 +103,7 @@ def project_staged_pipeline_item_dataframe(
 
         if rejected_columns:
             raise ValueError(
-                "column mismatch on "
-                f"{set(rejected_columns)} in {upload_items['source'].to_list()}"
+                f"column mismatch on {set(rejected_columns)} in {selected_columns}"
             )
 
         stage_df = stage_df.with_columns(fill_columns)

--- a/tests/config/test_fn_builtins.py
+++ b/tests/config/test_fn_builtins.py
@@ -1,0 +1,15 @@
+import warnings
+
+import polars as pl
+
+from polars_hist_db.config.fn_builtins import apply_type_casts
+
+
+def test_apply_type_casts_parses_string_dates_without_deprecation_warning():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        result = apply_type_casts(
+            pl.DataFrame({"date": ["2026-07-18"]}), "date", ["Date"]
+        )
+
+    assert result.schema["date"] == pl.Date

--- a/tests/config/test_pipeline_config.py
+++ b/tests/config/test_pipeline_config.py
@@ -104,16 +104,18 @@ def test_pipeline_builds_normalized_table_metadata_without_dataframes():
     )
 
     definitions = {
-        (column.table, column.source): column
+        (column.schema, column.source or column.target): column
         for column in pipeline.build_ingestion_column_definitions(tables)
     }
     delta_columns = pipeline.build_delta_table_column_configs(tables, "upload")
 
-    assert definitions[("countries", "country_id")].deduce_foreign_key is True
-    assert definitions[("countries", "country")].target_data_type == "VARCHAR(64)"
-    assert definitions[("events", "id")].required is True
-    assert definitions[("events", "raw_date")].column_type == "dsv_only"
-    assert definitions[("events", None)].transforms == {"parse_date": []}
+    assert definitions[("ref", "country_id")].deduce_foreign_key is True
+    assert definitions[("ref", "country")].target_data_type == "VARCHAR(64)"
+    assert definitions[("sample", "id")].required is True
+    assert definitions[("sample", "raw_date")].column_type == "dsv_only"
+    assert definitions[("sample", "raw_date")].table is None
+    assert definitions[("sample", "event_date")].transforms == {"parse_date": []}
+    assert definitions[("sample", "event_date")].table is None
     assert [(column.name, column.data_type) for column in delta_columns] == [
         ("country", "VARCHAR(64)"),
         ("id", "INT"),

--- a/tests/config/test_pipeline_config.py
+++ b/tests/config/test_pipeline_config.py
@@ -1,4 +1,9 @@
-from polars_hist_db.config.dataset import Pipeline
+from polars_hist_db.config import TableConfigs
+from polars_hist_db.config.dataset import (
+    Pipeline,
+    PipelineColumn,
+    PipelineExtractColumn,
+)
 
 
 def test_pipeline_reuses_cached_lookups():
@@ -26,6 +31,8 @@ def test_pipeline_reuses_cached_lookups():
     header_map["mutated"] = "outside"
 
     assert pipeline.get_main_table_name() == ("sample", "events")
+    assert isinstance(pipeline.items, tuple)
+    assert all(isinstance(column, PipelineColumn) for column in pipeline.items)
     assert pipeline.get_table_names() == ["countries", "events"]
     assert pipeline.get_pipeline_items() == {
         0: ("ref", "countries"),
@@ -34,10 +41,81 @@ def test_pipeline_reuses_cached_lookups():
     assert pipeline.item_type("countries") == "extract"
     assert pipeline.get_header_map("events") == {"id": "id", "country_id": "country"}
     assert pipeline.extract_items(1) is extract_items
-    assert extract_items.to_dict(as_series=False) == {
-        "table": ["events", "events"],
-        "source": ["id", "country"],
-        "target": ["id", "country_id"],
-        "required": [True, False],
-        "deduce_foreign_key": [False, False],
+    assert extract_items == (
+        PipelineExtractColumn("events", "id", "id", required=True),
+        PipelineExtractColumn("events", "country", "country_id"),
+    )
+
+
+def test_pipeline_builds_normalized_table_metadata_without_dataframes():
+    pipeline = Pipeline(
+        [
+            {
+                "schema": "ref",
+                "table": "countries",
+                "columns": [
+                    {
+                        "source": "country_id",
+                        "target": "id",
+                        "deduce_foreign_key": True,
+                    },
+                    {"source": "country", "target": "name"},
+                ],
+            },
+            {
+                "schema": "sample",
+                "table": "events",
+                "type": "primary",
+                "columns": [
+                    {"source": "id", "target": "id", "required": True},
+                    {"source": "country_id", "target": "country_id"},
+                    {"source": "raw_date", "ingestion_data_type": "VARCHAR(10)"},
+                    {
+                        "target": "event_date",
+                        "column_type": "time_partition_only",
+                        "target_data_type": "DATE",
+                        "transforms": {"parse_date": []},
+                    },
+                ],
+            },
+        ]
+    )
+    tables = TableConfigs(
+        items=[
+            {
+                "schema": "ref",
+                "name": "countries",
+                "primary_keys": ["id"],
+                "columns": [
+                    {"name": "id", "data_type": "INT", "nullable": False},
+                    {"name": "name", "data_type": "VARCHAR(64)"},
+                ],
+            },
+            {
+                "schema": "sample",
+                "name": "events",
+                "primary_keys": ["id"],
+                "columns": [
+                    {"name": "id", "data_type": "INT", "nullable": False},
+                    {"name": "country_id", "data_type": "INT"},
+                ],
+            },
+        ]
+    )
+
+    definitions = {
+        (column.table, column.source): column
+        for column in pipeline.build_ingestion_column_definitions(tables)
     }
+    delta_columns = pipeline.build_delta_table_column_configs(tables, "upload")
+
+    assert definitions[("countries", "country_id")].deduce_foreign_key is True
+    assert definitions[("countries", "country")].target_data_type == "VARCHAR(64)"
+    assert definitions[("events", "id")].required is True
+    assert definitions[("events", "raw_date")].column_type == "dsv_only"
+    assert definitions[("events", None)].transforms == {"parse_date": []}
+    assert [(column.name, column.data_type) for column in delta_columns] == [
+        ("country", "VARCHAR(64)"),
+        ("id", "INT"),
+        ("country_id", "INT"),
+    ]

--- a/tests/dataset/test_default_values.py
+++ b/tests/dataset/test_default_values.py
@@ -35,7 +35,12 @@ async def test_value_if_missing(fixture_with_defaults):
 
     base_config.datasets.datasets[0].input_config.set_payload(dsv_1, ts_1)
     uploaded_partitions = list()
-    await run_datasets(base_config, engine, debug_capture_output=uploaded_partitions)
+    await run_datasets(
+        base_config,
+        engine,
+        debug_capture_output=uploaded_partitions,
+        raise_on_error=True,
+    )
 
     df_1 = pl.concat([df for _, df in uploaded_partitions])
     df_read, df_read_history = read_df_from_db(engine, table_schema, table_config)
@@ -60,7 +65,12 @@ async def test_value_if_missing(fixture_with_defaults):
 
     base_config.datasets.datasets[0].input_config.set_payload(dsv_2, ts_2)
     uploaded_partitions = list()
-    await run_datasets(base_config, engine, debug_capture_output=uploaded_partitions)
+    await run_datasets(
+        base_config,
+        engine,
+        debug_capture_output=uploaded_partitions,
+        raise_on_error=True,
+    )
 
     df_2 = pl.concat([df for _, df in uploaded_partitions])
     df_read, df_read_history = read_df_from_db(engine, table_schema, table_config)

--- a/tests/dataset/test_staging_invariant.py
+++ b/tests/dataset/test_staging_invariant.py
@@ -52,6 +52,6 @@ async def test_run_datasets_leaves_stage_table_empty(fixture_simple, request):
     dsv = "id,double_col,varchar_col\n1,1.5,alpha\n2,2.5,beta\n"
 
     dataset.input_config.set_payload(dsv, ts)
-    await run_datasets(base_config, engine)
+    await run_datasets(base_config, engine, raise_on_error=True)
 
     assert _stage_row_count(engine, dataset, backend_name) == 0

--- a/tests/dataset/test_turkey_dsv.py
+++ b/tests/dataset/test_turkey_dsv.py
@@ -32,7 +32,11 @@ async def test_load_file(fixture_with_config):
 
     uploaded_dfs = []
     await run_datasets(
-        base_config, engine, "turkey_food_prices_dsv", debug_capture_output=uploaded_dfs
+        base_config,
+        engine,
+        "turkey_food_prices_dsv",
+        debug_capture_output=uploaded_dfs,
+        raise_on_error=True,
     )
 
     uploaded_df = pl.concat([df for _, df in uploaded_dfs]).rename(

--- a/tests/dataset/test_turkey_jetstream.py
+++ b/tests/dataset/test_turkey_jetstream.py
@@ -83,6 +83,7 @@ async def test_turkey_stream(nats_js, fixture_with_config):
         "turkey_food_prices_jetstream",
         debug_capture_output=uploaded_dfs,
         js=js,
+        raise_on_error=True,
     )
 
     uploaded_df = pl.concat([df for _, df in uploaded_dfs])

--- a/tests/test_pipeline_projection.py
+++ b/tests/test_pipeline_projection.py
@@ -1,23 +1,16 @@
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 import polars as pl
 import pytest
 
-from polars_hist_db.config import TableColumnConfig, TableConfig, ValidTimeConfig
+from polars_hist_db.config import (
+    TableColumnConfig,
+    TableConfig,
+    ValidTimeConfig,
+)
+from polars_hist_db.config.dataset import Pipeline
 from polars_hist_db.pipeline_projection import project_staged_pipeline_item_dataframe
-
-
-class _Pipeline:
-    def __init__(self, items: pl.DataFrame):
-        self._items = items
-
-    def extract_items(self, pipeline_id: int) -> pl.DataFrame:
-        return self._items.filter(pl.col("id") == pipeline_id)
-
-
-class _Dataset:
-    def __init__(self, items: pl.DataFrame):
-        self.pipeline = _Pipeline(items)
 
 
 def _table_config() -> TableConfig:
@@ -32,16 +25,20 @@ def _table_config() -> TableConfig:
     )
 
 
-def _dataset() -> _Dataset:
-    return _Dataset(
-        pl.DataFrame(
-            {
-                "id": [0, 0],
-                "schema": ["source", "source"],
-                "table": ["events", "events"],
-                "source": ["id", "event_value"],
-                "target": ["id", "event_value"],
-            }
+def _dataset() -> SimpleNamespace:
+    return SimpleNamespace(
+        pipeline=Pipeline(
+            [
+                {
+                    "schema": "source",
+                    "table": "events",
+                    "type": "primary",
+                    "columns": [
+                        {"source": "id", "target": "id"},
+                        {"source": "event_value", "target": "event_value"},
+                    ],
+                }
+            ]
         )
     )
 


### PR DESCRIPTION
## Summary
- replace ingestion-time pipeline metadata DataFrames with frozen dataclasses and indexed dictionaries
- update projection, foreign-key, primary/extract, and XTDB consumers
- preserve public DataFrame conversion helpers as compatibility boundaries
- add normalized-table and foreign-key metadata regression coverage

## Validation
- `uv run pytest -m "not integration"` (239 passed, 1 skipped)
- `uv run mypy polars_hist_db`
- `uv run ruff check --config .shared/ruff.toml .`
- `uv run ruff format --check --config .shared/ruff.toml .`