### PR TITLE
feat(types): enforce database type contracts

### DIFF
--- a/docs/backend-contract.qmd
+++ b/docs/backend-contract.qmd
@@ -26,6 +26,8 @@ Backend implementations must preserve these behaviours:
 - Read a whole table into a strongly typed `polars.DataFrame`.
 - Read query results into a strongly typed `polars.DataFrame`.
 - Write dataframes into configured tables using the configured schema.
+- Reject implicit type conversion at the database boundary. A caller may opt
+  into a strict conversion for one operation with `force_type_coercion=True`.
 - Create configured tables idempotently.
 - Add missing configured columns without silently dropping existing data.
 - Apply default values in the same places as the current dataframe insert path.
@@ -91,6 +93,10 @@ until it passes the same contract tests.
 - Round-trip dates, datetimes, decimals, booleans, categoricals, integers,
   floats, strings, and nulls without lossy conversion.
 - Preserve decimal precision needed by finance and commodity-volume data.
+- Treat `TableConfig` as authoritative. Unknown types and heterogeneous
+  physical scalar unions fail closed rather than falling back to text.
+- Allow null-only columns to adopt their configured type without treating that
+  as a value conversion.
 
 ### Reads
 
@@ -211,12 +217,13 @@ as `id` is renamed to `_id` before Polars writes to XTDB, while composite-key
 tables receive a synthetic `_id` column and keep their original key columns.
 Existing MariaDB insert behaviour remains unchanged.
 
-This is schema declaration, not MariaDB-style type enforcement. Empty declared
-XTDB columns surface through `information_schema`, and XTDB widens column types
-from inserted data. The adapter therefore keeps Arrow/Polars and
-`TableConfig` as the typed boundary while the spike proves whether live XTDB
-ingestion preserves the precision and nullability guarantees required by
-the consuming application.
+XTDB remains dynamically typed internally, so the adapter enforces the stable
+contract at its boundary. Configured writes require matching Polars dtypes by
+default, use native typed parameters or Arrow columns, and never convert bad
+values to null. Reflection compares XTDB's inferred physical type family with
+the configured type and rejects heterogeneous scalar unions. Explicit forced
+conversion uses Polars strict casts and emits a warning, metric, and trace
+event; rejected contracts emit an error, metric, and trace event.
 
 The first live pgwire round trip passes against `ghcr.io/xtdb/xtdb:nightly`:
 

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -34,7 +34,8 @@ from ..config import (
 )
 from ..core import TimeHint
 from ..pipeline_projection import project_staged_pipeline_item_dataframe
-from ..types import PolarsType
+from ..observability import record_database_type_contract
+from ..types import PolarsType, TypeContractError
 from .config import DbEngineConfig
 from .base import (
     TableHealthResult,
@@ -57,6 +58,7 @@ from .xtdb_transport import (
     _xtdb_column_identifier,
     _xtdb_document_id_columns,
     _xtdb_json_safe_key_value,
+    _xtdb_physical_column_map,
     _xtdb_table_query_target_column,
     _xtdb_temporal_basis_clause,
     _xtdb_timestamp_literal,
@@ -131,6 +133,96 @@ def _xtdb_type_to_config_type(data_type: str) -> str:
         ":TIMESTAMP": "TIMESTAMP",
     }
     return xtdb_types.get(normalized, normalized)
+
+
+def _xtdb_physical_type_family(data_type: str) -> str:
+    normalized = data_type.upper().strip()
+    if normalized.startswith("[:UNION"):
+        members = set(
+            re.findall(
+                r"\[:(?:DECIMAL|TIMESTAMP-TZ|TIMESTAMP-LOCAL|DATE|TIME)[^\]]*\]"
+                r"|:(?:I8|I16|I32|I64|F32|F64|UTF8|BOOL|BOOLEAN)\b",
+                normalized,
+            )
+        )
+        if not members and ":NULL" in normalized:
+            return "NULL"
+        if len(members) != 1:
+            return "UNION"
+        normalized = members.pop()
+
+    if normalized == ":NULL":
+        return "NULL"
+    if normalized.startswith("[:DECIMAL") or normalized.startswith(
+        ("DECIMAL", "NUMERIC")
+    ):
+        return "DECIMAL"
+    if normalized.startswith("[:TIMESTAMP-TZ"):
+        return "TIMESTAMP WITH TIME ZONE"
+    if normalized.startswith("[:TIMESTAMP-LOCAL"):
+        return "TIMESTAMP"
+    if normalized.startswith("[:DATE"):
+        return "DATE"
+    if normalized.startswith("[:TIME"):
+        return "TIME"
+    return _xtdb_cast_type(_xtdb_type_to_config_type(normalized))
+
+
+def _xtdb_configured_type_family(data_type: str) -> str:
+    cast_type = _xtdb_cast_type(data_type)
+    if cast_type.startswith(("DECIMAL", "NUMERIC")):
+        return "DECIMAL"
+    return cast_type
+
+
+def _validate_xtdb_physical_types(
+    metadata: pl.DataFrame,
+    table_config: TableConfig,
+) -> None:
+    physical_columns = _xtdb_physical_column_map(table_config)
+    expected = {
+        physical_columns[column.name]: _xtdb_configured_type_family(column.data_type)
+        for column in table_config.columns
+        if column.name not in _XTDB_SYSTEM_COLUMNS
+    }
+    document_id_columns = _xtdb_document_id_columns(table_config)
+    if document_id_columns != ["_id"]:
+        expected["_id"] = (
+            "TEXT"
+            if len(document_id_columns) > 1
+            else _xtdb_configured_type_family(
+                next(
+                    column.data_type
+                    for column in table_config.columns
+                    if column.name == document_id_columns[0]
+                )
+            )
+        )
+
+    for row in metadata.iter_rows(named=True):
+        column = str(row["column_name"])
+        if column in _XTDB_SYSTEM_COLUMNS:
+            continue
+        expected_type = expected.get(column)
+        actual_type = _xtdb_physical_type_family(str(row["data_type"]))
+        if expected_type is not None and actual_type in {expected_type, "NULL"}:
+            continue
+
+        record_database_type_contract(
+            backend="xtdb",
+            operation="schema_reflection",
+            expected_type=expected_type or "DECLARED_COLUMN",
+            actual_type=actual_type,
+            forced=False,
+            outcome="rejected",
+        )
+        message = (
+            f"XTDB physical schema does not satisfy the configured type contract "
+            f"for {table_config.schema}.{table_config.name}.{column}: expected "
+            f"{expected_type or 'a declared column'}, received {row['data_type']}"
+        )
+        LOGGER.error(message)
+        raise TypeContractError(message)
 
 
 def _is_nullable(value: object) -> bool:
@@ -980,6 +1072,7 @@ class XtdbTableConfigOps:
             table_name,
         )
         if configured_table is not None:
+            _validate_xtdb_physical_types(metadata, configured_table)
             return configured_table
 
         columns = []

--- a/polars_hist_db/backends/xtdb_transport.py
+++ b/polars_hist_db/backends/xtdb_transport.py
@@ -209,11 +209,20 @@ def _xtdb_cast_type_from_polars(dtype: pl.DataType) -> str:
         return "BOOLEAN"
     if dtype == pl.Date:
         return "DATE"
+    if dtype == pl.Time:
+        return "TIME"
     if isinstance(dtype, pl.Datetime):
         return (
             "TIMESTAMP WITH TIME ZONE" if dtype.time_zone is not None else "TIMESTAMP"
         )
-    return "TEXT"
+    if isinstance(dtype, pl.Decimal):
+        return f"DECIMAL({dtype.precision},{dtype.scale})"
+    if dtype in {pl.String, pl.Utf8, pl.Categorical}:
+        return "TEXT"
+    raise ValueError(
+        f"Unsupported XTDB Polars type {dtype}; provide a supported typed "
+        "DataFrame or an explicit TableConfig"
+    )
 
 
 def _xtdb_insert_casts(
@@ -235,7 +244,11 @@ def _xtdb_insert_casts(
 
     casts = []
     for name, dtype in df.schema.items():
-        casts.append(configured_types.get(name, _xtdb_cast_type_from_polars(dtype)))
+        casts.append(
+            configured_types[name]
+            if name in configured_types
+            else _xtdb_cast_type_from_polars(dtype)
+        )
     return casts
 
 
@@ -273,24 +286,19 @@ def _xtdb_physical_configured_column_dtypes(
 def _apply_xtdb_configured_column_dtypes(
     df: pl.DataFrame,
     table_config: Optional[TableConfig],
+    *,
+    force_type_coercion: bool = False,
 ) -> pl.DataFrame:
     if table_config is None:
         return df
 
-    configured_dtypes = _xtdb_configured_column_dtypes(table_config)
-    casts = []
-    for column, dtype in configured_dtypes.items():
-        if column not in df.columns:
-            continue
-
-        source_expr = pl.col(column)
-        if df.schema[column] == pl.Categorical and dtype not in {pl.String, pl.Utf8}:
-            source_expr = source_expr.cast(pl.String)
-        casts.append(source_expr.cast(dtype, strict=False))
-
-    if not casts:
-        return df
-    return df.with_columns(casts)
+    return PolarsType.enforce_database_schema(
+        df,
+        _xtdb_configured_column_dtypes(table_config),
+        backend="xtdb",
+        operation="table_insert",
+        force_type_coercion=force_type_coercion,
+    )
 
 
 def _iter_xtdb_insert_chunks(
@@ -823,11 +831,16 @@ class XtdbDataframeOps:
         table_name: str,
         table_config: Optional[TableConfig] = None,
         update_time: Optional[datetime] = None,
+        force_type_coercion: bool = False,
     ) -> int:
         if table_config is not None:
             _xtdb_physical_column_map(table_config)
         df = _prepare_xtdb_insert_dataframe(df, table_config)
-        df = _apply_xtdb_configured_column_dtypes(df, table_config)
+        df = _apply_xtdb_configured_column_dtypes(
+            df,
+            table_config,
+            force_type_coercion=force_type_coercion,
+        )
         if df.is_empty():
             return 0
 
@@ -940,6 +953,7 @@ class XtdbAdbcDataframeOps:
         table_name: str,
         table_config: Optional[TableConfig] = None,
         update_time: Optional[datetime] = None,
+        force_type_coercion: bool = False,
     ) -> int:
         if update_time is not None:
             raise NotImplementedError(
@@ -953,7 +967,11 @@ class XtdbAdbcDataframeOps:
             return 0
 
         df = _prepare_xtdb_insert_dataframe(df, table_config)
-        df = _apply_xtdb_configured_column_dtypes(df, table_config)
+        df = _apply_xtdb_configured_column_dtypes(
+            df,
+            table_config,
+            force_type_coercion=force_type_coercion,
+        )
         for chunk in _iter_xtdb_insert_chunks(df, self.max_rows_per_insert):
             arrow_table = _normalize_xtdb_ingest_arrow(chunk.to_arrow())
             with self.connection.cursor() as cursor:

--- a/polars_hist_db/core/dataframe.py
+++ b/polars_hist_db/core/dataframe.py
@@ -205,6 +205,7 @@ class DataframeOps:
         uniqueness_col_set: Iterable[str],
         prefill_nulls_with_default: bool,
         clear_table_first: bool = False,
+        force_type_coercion: bool = False,
     ) -> int:
         tbo = TableOps(table_schema, table_name, self.connection)
         tbl = tbo.get_table_metadata()
@@ -244,6 +245,13 @@ class DataframeOps:
                     )
 
         df = _remove_duplicate_rows(df, uniqueness_col_set)
+        df = PolarsType.enforce_database_schema(
+            df,
+            PolarsType._get_polars_dtypes_from_table(tbl),
+            backend=getattr(getattr(self.connection, "dialect", None), "name", "sql"),
+            operation="table_insert",
+            force_type_coercion=force_type_coercion,
+        )
         _prevalidate_insert_from_dataframe(df, tbl, disable_check=False)
 
         LOGGER.debug(

--- a/polars_hist_db/observability.py
+++ b/polars_hist_db/observability.py
@@ -87,3 +87,42 @@ def record_uploader_batch(
             dropped_c.add(max(0, received - written), attributes=attrs)
     except Exception:  # noqa: BLE001, S110 - metrics are best-effort
         pass
+
+
+def record_database_type_contract(
+    *,
+    backend: str,
+    operation: str,
+    expected_type: str,
+    actual_type: str,
+    forced: bool,
+    outcome: str,
+) -> None:
+    """Record a database-boundary type violation or forced conversion."""
+    attrs = {
+        "backend": backend,
+        "operation": operation,
+        "expected_type": expected_type,
+        "actual_type": actual_type,
+        "forced": forced,
+        "outcome": outcome,
+    }
+    counter_name = (
+        "database_type_coercions_total"
+        if forced
+        else "database_type_contract_violations_total"
+    )
+    counter = _get_counter(
+        counter_name,
+        "Database-boundary type contract outcomes.",
+    )
+    try:
+        if counter is not None:
+            counter.add(1, attributes=attrs)
+        from opentelemetry import trace
+
+        span = trace.get_current_span()
+        if span is not None:
+            span.add_event("database.type_contract", attrs)
+    except Exception:  # noqa: BLE001, S110 - telemetry is best-effort
+        pass

--- a/polars_hist_db/types.py
+++ b/polars_hist_db/types.py
@@ -18,7 +18,36 @@ from sqlalchemy.dialects import mysql
 from sqlalchemy.types import TypeEngine
 from sqlalchemy.sql.sqltypes import NullType
 
+from .observability import record_database_type_contract
+
 LOGGER = logging.getLogger(__name__)
+
+
+class TypeContractError(TypeError):
+    """A DataFrame does not satisfy a database table's declared types."""
+
+
+def _polars_type_family(dtype: pl.DataType) -> str:
+    if dtype in {pl.String, pl.Utf8, pl.Categorical}:
+        return "string"
+    if dtype.is_integer():
+        return "integer"
+    if dtype.is_float():
+        return "float"
+    if dtype.is_decimal():
+        return "decimal"
+    if dtype == pl.Boolean:
+        return "boolean"
+    if dtype == pl.Date:
+        return "date"
+    if dtype == pl.Time:
+        return "time"
+    if isinstance(dtype, pl.Datetime):
+        return "timestamp_tz" if dtype.time_zone is not None else "timestamp"
+    if dtype == pl.Null:
+        return "null"
+    return "other"
+
 
 # This mapping is used by all three converters.
 TYPE_PRIORITY_MAP: List[Tuple[str, pl.DataType, TypeEngine]] = [
@@ -230,6 +259,77 @@ class PolarsType:
                 )
         df = PolarsType.cast_str_to_cat(df)
         return df
+
+    @staticmethod
+    def enforce_database_schema(
+        df: pl.DataFrame,
+        expected_schema: Mapping[str, pl.DataType],
+        *,
+        backend: str,
+        operation: str,
+        force_type_coercion: bool = False,
+    ) -> pl.DataFrame:
+        """Fail closed on implicit database-boundary type conversions."""
+        result = df
+        string_types = {pl.String, pl.Utf8, pl.Categorical}
+        for column, expected in expected_schema.items():
+            if column not in df.columns:
+                continue
+            actual = df.schema[column]
+            if (
+                actual == expected
+                or actual in string_types
+                and expected in string_types
+            ):
+                continue
+            if actual == pl.Null:
+                result = result.with_columns(pl.col(column).cast(expected))
+                continue
+
+            message = (
+                f"{backend} {operation} type contract failed for column {column!r}: "
+                f"expected {expected}, received {actual}"
+            )
+            if not force_type_coercion:
+                record_database_type_contract(
+                    backend=backend,
+                    operation=operation,
+                    expected_type=_polars_type_family(expected),
+                    actual_type=_polars_type_family(actual),
+                    forced=False,
+                    outcome="rejected",
+                )
+                LOGGER.error(message)
+                raise TypeContractError(
+                    f"{message}; pass force_type_coercion=True for an explicit "
+                    "strict conversion"
+                )
+            LOGGER.warning("%s; applying explicit strict conversion", message)
+            source = pl.col(column)
+            if actual == pl.Categorical and expected not in string_types:
+                source = source.cast(pl.String)
+            try:
+                result = result.with_columns(source.cast(expected, strict=True))
+            except Exception:
+                record_database_type_contract(
+                    backend=backend,
+                    operation=operation,
+                    expected_type=_polars_type_family(expected),
+                    actual_type=_polars_type_family(actual),
+                    forced=True,
+                    outcome="failed",
+                )
+                raise
+            record_database_type_contract(
+                backend=backend,
+                operation=operation,
+                expected_type=_polars_type_family(expected),
+                actual_type=_polars_type_family(actual),
+                forced=True,
+                outcome="coerced",
+            )
+
+        return result
 
     @staticmethod
     def cast_str_to_cat(

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -16,6 +16,7 @@ from polars_hist_db.backends.xtdb import (
     _execute_xtdb_transaction,
     _xtdb_cast_type,
     _xtdb_declared_columns,
+    _validate_xtdb_physical_types,
 )
 from polars_hist_db.config import (
     DeltaConfig,
@@ -1341,6 +1342,32 @@ def test_xtdb_table_reflection_errors_when_table_has_no_metadata(monkeypatch):
         ValueError, match="XTDB table metadata not found for test.records"
     ):
         ops.from_table("test", "records")
+
+
+def test_xtdb_physical_schema_rejects_heterogeneous_scalar_union():
+    table_config = TableConfig(
+        schema="test",
+        name="records",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "seen_at", "DATETIME"),
+        ],
+    )
+    metadata = pl.DataFrame(
+        {
+            "column_name": ["_id", "id", "seen_at"],
+            "data_type": [
+                ":i64",
+                ":i64",
+                '[:union #{:utf8 [:timestamp-tz :micro "UTC"] :null}]',
+            ],
+            "is_nullable": ["NO", "NO", "YES"],
+        }
+    )
+
+    with pytest.raises(TypeError, match="physical schema"):
+        _validate_xtdb_physical_types(metadata, table_config)
 
 
 def test_xtdb_declared_columns_quotes_non_identifier_column_names():

--- a/tests/backends/test_xtdb_dataframe_ops.py
+++ b/tests/backends/test_xtdb_dataframe_ops.py
@@ -16,6 +16,7 @@ from polars_hist_db.backends.xtdb import (
 )
 from polars_hist_db.config import TableColumnConfig, TableConfig
 from polars_hist_db.core import TimeHint
+from polars_hist_db.types import TypeContractError
 
 
 def _single_executemany_call(driver_connection: Mock):
@@ -634,6 +635,7 @@ def test_xtdb_dataframe_ops_uses_native_casts_for_mysql_compatibility_types():
         "test",
         "compat_types",
         table_config=table_config,
+        force_type_coercion=True,
     )
 
     insert_call = _single_executemany_call(driver_connection)
@@ -722,6 +724,7 @@ def test_xtdb_dataframe_ops_casts_categorical_values_to_configured_decimal():
         "test",
         "records",
         table_config=table_config,
+        force_type_coercion=True,
     )
 
     insert_call = _single_executemany_call(driver_connection)
@@ -758,6 +761,7 @@ def test_xtdb_dataframe_ops_quotes_reserved_insert_columns():
         "source_a",
         "entity_info",
         table_config=table_config,
+        force_type_coercion=True,
     )
 
     insert_sql = _single_executemany_call(driver_connection).args[0]
@@ -792,6 +796,7 @@ def test_xtdb_dataframe_ops_encodes_insert_columns_with_slashes():
         "source_a",
         "entity_info",
         table_config=table_config,
+        force_type_coercion=True,
     )
 
     insert_call = _single_executemany_call(driver_connection)
@@ -833,6 +838,7 @@ def test_xtdb_dataframe_ops_uses_underscore_column_mapping():
         "source_a",
         "entity_info",
         table_config=table_config,
+        force_type_coercion=True,
     )
 
     insert_sql = _single_executemany_call(driver_connection).args[0]
@@ -868,6 +874,62 @@ def test_xtdb_dataframe_ops_rejects_physical_column_mapping_collisions():
             "source_a",
             "entity_info",
             table_config=table_config,
+        )
+
+
+def test_xtdb_dataframe_ops_rejects_implicit_type_coercion():
+    connection = Mock()
+    connection.connection.driver_connection = Mock()
+    ops = XtdbDataframeOps(connection)
+    table_config = TableConfig(
+        schema="test",
+        name="records",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "seen_at", "DATETIME"),
+        ],
+    )
+
+    with pytest.raises(TypeContractError, match="force_type_coercion=True"):
+        ops.table_insert(
+            pl.DataFrame({"id": [1], "seen_at": ["2030-01-01T00:00:00Z"]}),
+            "test",
+            "records",
+            table_config=table_config,
+        )
+
+
+def test_xtdb_dataframe_ops_rejects_unknown_unconfigured_type():
+    connection = Mock()
+    connection.connection.driver_connection = Mock()
+    ops = XtdbDataframeOps(connection)
+
+    with pytest.raises(ValueError, match="Unsupported XTDB Polars type"):
+        ops.table_insert(pl.DataFrame({"values": [[1, 2]]}), "test", "records")
+
+
+def test_xtdb_dataframe_ops_forced_conversion_never_replaces_bad_values_with_null():
+    connection = Mock()
+    connection.connection.driver_connection = Mock()
+    ops = XtdbDataframeOps(connection)
+    table_config = TableConfig(
+        schema="test",
+        name="records",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "amount", "DOUBLE"),
+        ],
+    )
+
+    with pytest.raises(pl.exceptions.InvalidOperationError):
+        ops.table_insert(
+            pl.DataFrame({"id": [1], "amount": ["not-a-number"]}),
+            "test",
+            "records",
+            table_config=table_config,
+            force_type_coercion=True,
         )
 
 

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -120,6 +120,33 @@ def test_record_uploader_batch_noop_without_otel(monkeypatch):
     )
 
 
+def test_record_database_type_contract_uses_low_cardinality_attributes(monkeypatch):
+    meter = _install_fake_otel(monkeypatch)
+
+    observability.record_database_type_contract(
+        backend="xtdb",
+        operation="table_insert",
+        expected_type="timestamp_tz",
+        actual_type="string",
+        forced=False,
+        outcome="rejected",
+    )
+
+    assert meter.counters["database_type_contract_violations_total"].calls == [
+        (
+            1,
+            {
+                "backend": "xtdb",
+                "operation": "table_insert",
+                "expected_type": "timestamp_tz",
+                "actual_type": "string",
+                "forced": False,
+                "outcome": "rejected",
+            },
+        )
+    ]
+
+
 def test_record_uploader_batch_ignores_negative_counts(monkeypatch):
     meter = _install_fake_otel(monkeypatch)
 


### PR DESCRIPTION
## Summary
- reject implicit DataFrame type conversion at SQL and XTDB write boundaries
- require an explicit per-operation force flag for strict conversion
- validate configured XTDB types against inferred physical scalar types
- fail on unknown types instead of falling back to text
- emit low-cardinality metrics, trace events, and detailed logs for rejected and forced conversions

## Compatibility
This intentionally changes configured writes to fail closed. Callers must supply correctly typed DataFrames or explicitly set `force_type_coercion=True` for a single strict conversion operation. Null-only columns and equivalent string encodings remain supported without forcing.

## Verification
- `uv run pytest -q` (247 passed, 15 deselected)
- `uv run ruff check polars_hist_db tests`
- `uv run mypy polars_hist_db`