### PR TITLE
fix(xtdb): reflect nullable schemas safely

### DIFF
--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -117,8 +117,15 @@ def _is_xtdb_adbc_ingest_unavailable(exc: Exception) -> bool:
     )
 
 
+def _unwrap_xtdb_optional_type(data_type: str) -> str:
+    normalized = data_type.upper().strip()
+    if normalized.startswith("[:?") and normalized.endswith("]"):
+        return normalized[3:-1].strip()
+    return normalized
+
+
 def _xtdb_type_to_config_type(data_type: str) -> str:
-    normalized = data_type.upper()
+    normalized = _unwrap_xtdb_optional_type(data_type)
     xtdb_types = {
         ":I8": "TINYINT",
         ":I16": "SMALLINT",
@@ -132,11 +139,19 @@ def _xtdb_type_to_config_type(data_type: str) -> str:
         ":DATE": "DATE",
         ":TIMESTAMP": "TIMESTAMP",
     }
+    if normalized.startswith("[:TIMESTAMP-TZ"):
+        return "TIMESTAMP WITH TIME ZONE"
+    if normalized.startswith("[:TIMESTAMP-LOCAL"):
+        return "TIMESTAMP"
+    if normalized.startswith("[:DATE"):
+        return "DATE"
+    if normalized.startswith("[:TIME"):
+        return "TIME"
     return xtdb_types.get(normalized, normalized)
 
 
 def _xtdb_physical_type_family(data_type: str) -> str:
-    normalized = data_type.upper().strip()
+    normalized = _unwrap_xtdb_optional_type(data_type)
     if normalized.startswith("[:UNION"):
         members = set(
             re.findall(
@@ -269,20 +284,38 @@ def _xtdb_table_config_metadata(
     table_schema: str,
     table_name: str,
 ) -> pl.DataFrame | None:
+    if not _xtdb_table_exists(
+        connection,
+        table_schema,
+        _XTDB_TABLE_CONFIG_METADATA_TABLE,
+    ):
+        return None
     escaped_schema = table_schema.replace("'", "''")
     escaped_name = table_name.replace("'", "''")
-    try:
-        return pl.read_database(
-            f"""
-            SELECT *
-            FROM {_xtdb_table_config_metadata_table(table_schema)}
-            WHERE table_schema = '{escaped_schema}'
-              AND table_name = '{escaped_name}'
+    return pl.read_database(
+        f"""
+        SELECT *
+        FROM {_xtdb_table_config_metadata_table(table_schema)}
+        WHERE table_schema = '{escaped_schema}'
+          AND table_name = '{escaped_name}'
+    """,
+        connection,
+    )
+
+
+def _xtdb_table_exists(connection: Any, table_schema: str, table_name: str) -> bool:
+    table_schema = _validate_identifier(table_schema)
+    table_name = _validate_identifier(table_name)
+    metadata = pl.read_database(
+        f"""
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_schema = '{table_schema}'
+              AND table_name = '{table_name}'
         """,
-            connection,
-        )
-    except Exception:
-        return None
+        connection,
+    )
+    return not metadata.is_empty()
 
 
 def _xtdb_primary_keys_from_metadata(
@@ -1030,18 +1063,7 @@ class XtdbTableConfigOps:
         )
 
     def table_exists(self, table_schema: str, table_name: str) -> bool:
-        table_schema = _validate_identifier(table_schema)
-        table_name = _validate_identifier(table_name)
-        metadata = pl.read_database(
-            f"""
-            SELECT table_name
-            FROM information_schema.tables
-            WHERE table_schema = '{table_schema}'
-              AND table_name = '{table_name}'
-        """,
-            self.connection,
-        )
-        return not metadata.is_empty()
+        return _xtdb_table_exists(self.connection, table_schema, table_name)
 
     def from_table(self, table_schema: str, table_name: str) -> TableConfig:
         table_schema = _validate_identifier(table_schema)

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -1201,6 +1201,30 @@ def test_xtdb_table_reflection_builds_table_config_from_information_schema(
     )
 
 
+def test_xtdb_table_reflection_does_not_query_missing_config_metadata(monkeypatch):
+    read_database = Mock(
+        side_effect=[
+            pl.DataFrame(
+                {
+                    "column_name": ["_id", "destination"],
+                    "data_type": [":i64", "[:? :UTF8]"],
+                    "is_nullable": ["NO", "YES"],
+                }
+            ),
+            pl.DataFrame({"table_name": []}, schema={"table_name": pl.String}),
+        ]
+    )
+    monkeypatch.setattr(pl, "read_database", read_database)
+
+    table_config = XtdbTableConfigOps(object()).from_table("test", "records")
+
+    assert [(column.name, column.data_type) for column in table_config.columns] == [
+        ("_id", "BIGINT"),
+        ("destination", "VARCHAR(255)"),
+    ]
+    assert read_database.call_count == 2
+
+
 def test_xtdb_table_reflection_prefers_configured_column_metadata(monkeypatch):
     columns_json = (
         '[{"table":"all_types","name":"id","data_type":"INT",'
@@ -1221,6 +1245,7 @@ def test_xtdb_table_reflection_prefers_configured_column_metadata(monkeypatch):
                     "is_nullable": ["NO", "YES", "YES"],
                 }
             ),
+            pl.DataFrame({"table_name": ["__polars_hist_db_xtdb_table_configs"]}),
             pl.DataFrame(
                 {
                     "primary_keys_json": ['["id"]'],
@@ -1270,6 +1295,7 @@ def test_xtdb_table_reflection_restores_foreign_key_metadata(monkeypatch):
                     "is_nullable": ["NO", "NO"],
                 }
             ),
+            pl.DataFrame({"table_name": ["__polars_hist_db_xtdb_table_configs"]}),
             pl.DataFrame(
                 {
                     "primary_keys_json": ['["id"]'],
@@ -1309,6 +1335,7 @@ def test_xtdb_table_reflection_recovers_composite_primary_keys_from_metadata(
                     "is_nullable": ["NO", "NO", "NO", "YES"],
                 }
             ),
+            pl.DataFrame({"table_name": ["__polars_hist_db_xtdb_table_configs"]}),
             pl.DataFrame(
                 {
                     "primary_keys_json": ['["entity_id","record_id"]'],
@@ -1368,6 +1395,33 @@ def test_xtdb_physical_schema_rejects_heterogeneous_scalar_union():
 
     with pytest.raises(TypeError, match="physical schema"):
         _validate_xtdb_physical_types(metadata, table_config)
+
+
+def test_xtdb_physical_schema_accepts_nullable_type_shorthand():
+    table_config = TableConfig(
+        schema="test",
+        name="records",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "label", "VARCHAR(255)"),
+            TableColumnConfig("records", "seen_at", "DATETIME"),
+        ],
+    )
+    metadata = pl.DataFrame(
+        {
+            "column_name": ["_id", "id", "label", "seen_at"],
+            "data_type": [
+                ":i64",
+                ":i64",
+                "[:? :UTF8]",
+                '[:? [:timestamp-tz :micro "UTC"]]',
+            ],
+            "is_nullable": ["NO", "NO", "YES", "YES"],
+        }
+    )
+
+    _validate_xtdb_physical_types(metadata, table_config)
 
 
 def test_xtdb_declared_columns_quotes_non_identifier_column_names():

--- a/tests/backends/test_xtdb_live.py
+++ b/tests/backends/test_xtdb_live.py
@@ -129,6 +129,49 @@ def test_xtdb_live_create_append_read_roundtrip():
     }
 
 
+def test_xtdb_live_reflection_preserves_caller_transaction_without_metadata():
+    table_name = f"live_reflection_{int(time.time())}"
+    table_config = TableConfig(
+        schema="public",
+        name=table_name,
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig(table_name, "id", "BIGINT", nullable=False),
+            TableColumnConfig(table_name, "label", "VARCHAR(255)"),
+            TableColumnConfig(table_name, "seen_at", "DATETIME"),
+        ],
+    )
+
+    with _xtdb_engine() as engine:
+        backend = XtdbBackend()
+        with backend.connection_scope(engine) as connection:
+            backend.dataframes(connection).table_insert(
+                pl.DataFrame(
+                    {
+                        "id": [1],
+                        "label": ["Alpha"],
+                        "seen_at": [datetime(2026, 7, 18, tzinfo=timezone.utc)],
+                    }
+                ),
+                "public",
+                table_name,
+                table_config=table_config,
+            )
+
+        with engine.begin() as connection:
+            reflected = backend.table_configs(connection).from_table(
+                "public", table_name
+            )
+            assert connection.execute(text("SELECT 1")).scalar_one() == 1
+
+    assert {column.name: column.data_type for column in reflected.columns} == {
+        "_id": "BIGINT",
+        "id": "BIGINT",
+        "label": "VARCHAR(255)",
+        "seen_at": "TIMESTAMP WITH TIME ZONE",
+    }
+
+
 def test_xtdb_live_insert_non_public_table_with_reserved_column_name():
     table_config = TableConfig(
         schema="source_a",


### PR DESCRIPTION
## Summary
- unwrap XTDB nullable physical type notation before reflection and validation
- check config-metadata table existence before querying it
- stop swallowing missing-table SQL errors that invalidate caller transactions
- add unit and live XTDB regression coverage

## Verification
- 249 unit tests passed
- Ruff, formatting, and mypy passed
- regression test passed against XTDB 2.2.0-beta1