### PR TITLE
fix(types): validate complete XTDB type grammar

### DIFF
--- a/.github/workflows/bespoke_integration-tests.yaml
+++ b/.github/workflows/bespoke_integration-tests.yaml
@@ -41,6 +41,7 @@ jobs:
     env:
       MARIADB_PORT: "13307"
       NATS_PORT: "14222"
+      POLARS_HIST_DB_XTDB_LIVE: "1"
 
     steps:
       - uses: actions/checkout@v7

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -957,6 +957,22 @@ def _materialize_xtdb_missing_columns(
     return materialized.select([*configured_columns, *extra_columns])
 
 
+def _cast_xtdb_configured_columns(
+    df: pl.DataFrame,
+    table_config: TableConfig,
+    column_names: Iterable[str],
+) -> pl.DataFrame:
+    configured_types = {
+        column.name: PolarsType.from_sql(column.data_type)
+        for column in table_config.columns
+    }
+    return df.with_columns(
+        pl.col(column_name).cast(configured_types[column_name])
+        for column_name in column_names
+        if column_name in df.columns and column_name in configured_types
+    )
+
+
 def _dedupe_xtdb_staging_dataframe(
     df: pl.DataFrame, uniqueness_col_set: Iterable[str]
 ) -> pl.DataFrame:
@@ -1621,6 +1637,13 @@ class XtdbStagingOps:
                 table_config, value_targets, generated.schema
             )
             if _xtdb_is_integer_config_column(table_config, target_column):
+                target_dtype = PolarsType.from_sql(
+                    next(
+                        column.data_type
+                        for column in table_config.columns
+                        if column.name == target_column
+                    )
+                )
                 bits = (
                     63
                     if any(
@@ -1630,10 +1653,14 @@ class XtdbStagingOps:
                     )
                     else 31
                 )
-                generated_value = generated_payload.map_batches(
-                    partial(_xtdb_deduced_numeric_foreign_key_ids, bits=bits),
-                    return_dtype=pl.Int64,
-                ).alias(target_column)
+                generated_value = (
+                    generated_payload.map_batches(
+                        partial(_xtdb_deduced_numeric_foreign_key_ids, bits=bits),
+                        return_dtype=pl.Int64,
+                    )
+                    .cast(target_dtype)
+                    .alias(target_column)
+                )
             else:
                 generated_value = generated_payload.alias(target_column)
             if source_column not in candidates.columns:
@@ -1691,6 +1718,11 @@ class XtdbStagingOps:
             table_config,
             fk_targets,
         )
+        missing_parent_rows = _cast_xtdb_configured_columns(
+            missing_parent_rows,
+            table_config,
+            fk_targets,
+        )
         resolved_keys = missing_parent_rows.select(
             [*value_targets, *fk_targets]
         ).unique(maintain_order=True)
@@ -1706,6 +1738,7 @@ class XtdbStagingOps:
                 joined = joined.with_columns(
                     pl.coalesce(resolved_column, target_column).alias(target_column)
                 ).drop(resolved_column)
+        joined = _cast_xtdb_configured_columns(joined, table_config, fk_targets)
 
         parent_rows_to_insert = missing_parent_rows.select(
             [*fk_targets, *value_targets]

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -1162,7 +1162,7 @@ class XtdbTableConfigOps:
         ]
         values_sql = ", ".join(_xtdb_sql_literal(value, "TEXT") for value in values)
         values_sql = (
-            f"{values_sql}, {_xtdb_sql_literal(table_config.is_temporal, 'BOOL')}"
+            f"{values_sql}, {_xtdb_sql_literal(table_config.is_temporal, 'BOOLEAN')}"
         )
         metadata_table = _xtdb_table_config_metadata_table(table_config.schema)
         _execute_xtdb_dml(

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -124,6 +124,91 @@ def _unwrap_xtdb_optional_type(data_type: str) -> str:
     return normalized
 
 
+_XTDB_PHYSICAL_TYPE_FAMILIES = {
+    ":NULL": "NULL",
+    ":NOTHING": "NOTHING",
+    ":BOOL": "BOOLEAN",
+    ":I8": "INTEGER",
+    ":I16": "INTEGER",
+    ":I32": "INTEGER",
+    ":I64": "BIGINT",
+    ":F32": "FLOAT",
+    ":F64": "DOUBLE PRECISION",
+    ":UTF8": "TEXT",
+    ":VARBINARY": "VARBINARY",
+    ":FIXED-SIZE-BINARY": "FIXED-SIZE-BINARY",
+    ":DECIMAL": "DECIMAL",
+    ":INSTANT": "TIMESTAMP WITH TIME ZONE",
+    ":TIMESTAMP-TZ": "TIMESTAMP WITH TIME ZONE",
+    ":TIMESTAMP-LOCAL": "TIMESTAMP",
+    ":DATE": "DATE",
+    ":TIME-LOCAL": "TIME",
+    ":DURATION": "DURATION",
+    ":INTERVAL": "INTERVAL",
+    ":TSTZ-RANGE": "TSTZ-RANGE",
+    ":KEYWORD": "KEYWORD",
+    ":OID": "OID",
+    ":REGCLASS": "REGCLASS",
+    ":REGPROC": "REGPROC",
+    ":UUID": "UUID",
+    ":URI": "URI",
+    ":TRANSIT": "TRANSIT",
+    ":LIST": "LIST",
+    ":FIXED-SIZE-LIST": "FIXED-SIZE-LIST",
+    ":SET": "SET",
+    ":MAP": "MAP",
+    ":STRUCT": "STRUCT",
+}
+
+
+def _xtdb_type_head(data_type: str) -> str:
+    match = re.match(r"^\[?\s*(:[A-Z0-9?-]+)", data_type)
+    if match is None:
+        raise ValueError(f"Unsupported XTDB column type: {data_type}")
+    return match.group(1)
+
+
+def _split_xtdb_set_members(data_type: str) -> list[str]:
+    body = data_type[2:-1].strip()
+    members: list[str] = []
+    start = 0
+    depth = 0
+    quoted = False
+    escaped = False
+    for idx, char in enumerate(body):
+        if quoted:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                quoted = False
+        elif char == '"':
+            quoted = True
+        elif char in "[{(":
+            depth += 1
+        elif char in "]})":
+            depth -= 1
+        elif char.isspace() and depth == 0:
+            if member := body[start:idx].strip():
+                members.append(member)
+            start = idx + 1
+    if member := body[start:].strip():
+        members.append(member)
+    return members
+
+
+def _xtdb_union_members(data_type: str) -> Optional[list[str]]:
+    if data_type.startswith("#{") and data_type.endswith("}"):
+        return _split_xtdb_set_members(data_type)
+    if _xtdb_type_head(data_type) not in {":UNION", ":SPARSE-UNION"}:
+        return None
+    start = data_type.find("#{")
+    if start < 0:
+        raise ValueError(f"Unsupported XTDB union type: {data_type}")
+    return _split_xtdb_set_members(data_type[start : data_type.rfind("}") + 1])
+
+
 def _xtdb_type_to_config_type(data_type: str) -> str:
     normalized = _unwrap_xtdb_optional_type(data_type)
     xtdb_types = {
@@ -136,51 +221,57 @@ def _xtdb_type_to_config_type(data_type: str) -> str:
         ":UTF8": "VARCHAR(255)",
         ":BOOL": "BOOLEAN",
         ":BOOLEAN": "BOOLEAN",
-        ":DATE": "DATE",
         ":TIMESTAMP": "TIMESTAMP",
     }
-    if normalized.startswith("[:TIMESTAMP-TZ"):
-        return "TIMESTAMP WITH TIME ZONE"
-    if normalized.startswith("[:TIMESTAMP-LOCAL"):
-        return "TIMESTAMP"
-    if normalized.startswith("[:DATE"):
-        return "DATE"
-    if normalized.startswith("[:TIME"):
-        return "TIME"
-    return xtdb_types.get(normalized, normalized)
+    if normalized in xtdb_types:
+        return xtdb_types[normalized]
+    if normalized.startswith(("DECIMAL", "NUMERIC")):
+        return normalized
+
+    family = _xtdb_physical_type_family(normalized)
+    if family == "DECIMAL":
+        precision_and_scale = re.search(r":DECIMAL\s+(\d+)\s+(-?\d+)", normalized)
+        if precision_and_scale:
+            return f"DECIMAL({precision_and_scale[1]},{precision_and_scale[2]})"
+    config_types = {
+        "TEXT": "VARCHAR(255)",
+        "BOOLEAN": "BOOLEAN",
+        "INTEGER": "INT",
+        "BIGINT": "BIGINT",
+        "FLOAT": "FLOAT",
+        "DOUBLE PRECISION": "DOUBLE",
+        "DATE": "DATE",
+        "TIME": "TIME",
+        "TIMESTAMP": "TIMESTAMP",
+        "TIMESTAMP WITH TIME ZONE": "TIMESTAMP WITH TIME ZONE",
+    }
+    if family in config_types:
+        return config_types[family]
+    raise ValueError(f"Unsupported XTDB column type: {data_type}")
 
 
 def _xtdb_physical_type_family(data_type: str) -> str:
     normalized = _unwrap_xtdb_optional_type(data_type)
-    if normalized.startswith("[:UNION"):
-        members = set(
-            re.findall(
-                r"\[:(?:DECIMAL|TIMESTAMP-TZ|TIMESTAMP-LOCAL|DATE|TIME)[^\]]*\]"
-                r"|:(?:I8|I16|I32|I64|F32|F64|UTF8|BOOL|BOOLEAN)\b",
-                normalized,
-            )
-        )
-        if not members and ":NULL" in normalized:
+    if (members := _xtdb_union_members(normalized)) is not None:
+        families = {
+            family
+            for member in members
+            if (family := _xtdb_physical_type_family(member)) != "NULL"
+        }
+        if not families:
             return "NULL"
-        if len(members) != 1:
+        if len(families) != 1:
             return "UNION"
-        normalized = members.pop()
-
-    if normalized == ":NULL":
-        return "NULL"
-    if normalized.startswith("[:DECIMAL") or normalized.startswith(
-        ("DECIMAL", "NUMERIC")
-    ):
+        return families.pop()
+    if normalized.startswith(("DECIMAL", "NUMERIC")):
         return "DECIMAL"
-    if normalized.startswith("[:TIMESTAMP-TZ"):
-        return "TIMESTAMP WITH TIME ZONE"
-    if normalized.startswith("[:TIMESTAMP-LOCAL"):
-        return "TIMESTAMP"
-    if normalized.startswith("[:DATE"):
-        return "DATE"
-    if normalized.startswith("[:TIME"):
-        return "TIME"
-    return _xtdb_cast_type(_xtdb_type_to_config_type(normalized))
+    if normalized[:1].isalpha():
+        return _xtdb_configured_type_family(normalized)
+    head = _xtdb_type_head(normalized)
+    try:
+        return _XTDB_PHYSICAL_TYPE_FAMILIES[head]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported XTDB column type: {data_type}") from exc
 
 
 def _xtdb_configured_type_family(data_type: str) -> str:
@@ -196,37 +287,49 @@ def _validate_xtdb_physical_types(
 ) -> None:
     physical_columns = _xtdb_physical_column_map(table_config)
     expected = {
-        physical_columns[column.name]: _xtdb_configured_type_family(column.data_type)
+        physical_columns[column.name]: (
+            _xtdb_configured_type_family(column.data_type),
+            column.nullable,
+        )
         for column in table_config.columns
         if column.name not in _XTDB_SYSTEM_COLUMNS
     }
     document_id_columns = _xtdb_document_id_columns(table_config)
     if document_id_columns != ["_id"]:
         expected["_id"] = (
-            "TEXT"
-            if len(document_id_columns) > 1
-            else _xtdb_configured_type_family(
-                next(
-                    column.data_type
-                    for column in table_config.columns
-                    if column.name == document_id_columns[0]
+            (
+                "TEXT"
+                if len(document_id_columns) > 1
+                else _xtdb_configured_type_family(
+                    next(
+                        column.data_type
+                        for column in table_config.columns
+                        if column.name == document_id_columns[0]
+                    )
                 )
-            )
+            ),
+            False,
         )
 
-    for row in metadata.iter_rows(named=True):
-        column = str(row["column_name"])
-        if column in _XTDB_SYSTEM_COLUMNS:
-            continue
-        expected_type = expected.get(column)
-        actual_type = _xtdb_physical_type_family(str(row["data_type"]))
-        if expected_type is not None and actual_type in {expected_type, "NULL"}:
+    actual = {
+        str(row["column_name"]): (
+            _xtdb_physical_type_family(str(row["data_type"])),
+            str(row["data_type"]),
+        )
+        for row in metadata.iter_rows(named=True)
+        if str(row["column_name"]) not in _XTDB_SYSTEM_COLUMNS
+    }
+    for column, (expected_type, nullable) in expected.items():
+        actual_type, physical_type = actual.get(column, ("MISSING", "MISSING"))
+        if actual_type == expected_type or (
+            nullable and actual_type in {"NULL", "MISSING"}
+        ):
             continue
 
         record_database_type_contract(
             backend="xtdb",
             operation="schema_reflection",
-            expected_type=expected_type or "DECLARED_COLUMN",
+            expected_type=expected_type,
             actual_type=actual_type,
             forced=False,
             outcome="rejected",
@@ -234,7 +337,7 @@ def _validate_xtdb_physical_types(
         message = (
             f"XTDB physical schema does not satisfy the configured type contract "
             f"for {table_config.schema}.{table_config.name}.{column}: expected "
-            f"{expected_type or 'a declared column'}, received {row['data_type']}"
+            f"{expected_type}, received {physical_type}"
         )
         LOGGER.error(message)
         raise TypeContractError(message)

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -928,8 +928,11 @@ def _fill_xtdb_staging_defaults(
     return _fill_xtdb_defaults(df, table_config)
 
 
-def _materialize_xtdb_missing_staging_columns(
-    df: pl.DataFrame, table_config: TableConfig
+def _materialize_xtdb_missing_columns(
+    df: pl.DataFrame,
+    table_config: TableConfig,
+    *,
+    use_defaults: bool,
 ) -> pl.DataFrame:
     missing_columns = [
         column for column in table_config.columns if column.name not in df.columns
@@ -937,12 +940,21 @@ def _materialize_xtdb_missing_staging_columns(
     if not missing_columns:
         return df
 
-    return df.with_columns(
-        pl.lit(_xtdb_default_value(column.default_value, column.data_type))
+    materialized = df.with_columns(
+        pl.lit(
+            _xtdb_default_value(column.default_value, column.data_type)
+            if use_defaults
+            else None
+        )
         .cast(PolarsType.from_sql(column.data_type))
         .alias(column.name)
         for column in missing_columns
     )
+    configured_columns = [column.name for column in table_config.columns]
+    extra_columns = [
+        column for column in materialized.columns if column not in configured_columns
+    ]
+    return materialized.select([*configured_columns, *extra_columns])
 
 
 def _dedupe_xtdb_staging_dataframe(
@@ -1370,7 +1382,11 @@ class XtdbStagingOps:
         if prefill_nulls_with_default:
             df = _fill_xtdb_staging_defaults(df, delta_table_config)
         df = _dedupe_xtdb_staging_dataframe(df, uniqueness_col_set)
-        df = _materialize_xtdb_missing_staging_columns(df, delta_table_config)
+        df = _materialize_xtdb_missing_columns(
+            df,
+            delta_table_config,
+            use_defaults=prefill_nulls_with_default,
+        )
         df = df.with_row_index(_XTDB_STAGE_ROW_INDEX_COLUMN).with_columns(
             pl.lit(stage_run_id).alias(_XTDB_STAGE_RUN_ID_COLUMN),
             pl.lit(partition_time).alias(_XTDB_STAGE_PARTITION_TIME_COLUMN),
@@ -1728,9 +1744,22 @@ class XtdbStagingOps:
                 **{target: source for source, target in fk_map.items()},
             }
         )
-        return stage_df.drop(
+        resolved_stage = stage_df.drop(
             [column for column in fk_sources if column in stage_df.columns]
         ).join(resolver, on=value_sources, how="left")
+        target_dtypes = {
+            source: PolarsType.from_sql(
+                next(
+                    column.data_type
+                    for column in table_config.columns
+                    if column.name == target
+                )
+            )
+            for source, target in fk_map.items()
+        }
+        return resolved_stage.with_columns(
+            pl.col(source).cast(dtype) for source, dtype in target_dtypes.items()
+        )
 
     def cleanup_run(self, stage_run_id: str) -> None:
         self._stage_run_cache.pop(stage_run_id, None)
@@ -1899,6 +1928,11 @@ class XtdbBackend:
                 )
             if table_config is None:
                 raise ValueError("XTDB delta upsert requires table_config")
+            df = _materialize_xtdb_missing_columns(
+                df,
+                table_config,
+                use_defaults=delta_config.prefill_nulls_with_default,
+            )
             if delta_config.prefill_nulls_with_default:
                 df = _fill_xtdb_defaults(df, table_config)
             df = _apply_xtdb_duplicate_policy(df, table_config, delta_config)

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -495,7 +495,12 @@ def _xtdb_table_config_from_metadata(
         columns=columns,
         foreign_keys=foreign_keys,
         primary_keys=primary_keys or [],
-        is_temporal=True,
+        is_temporal=(
+            bool(metadata[0, "is_temporal"])
+            if "is_temporal" in metadata.columns
+            and metadata[0, "is_temporal"] is not None
+            else True
+        ),
     )
 
 
@@ -1156,12 +1161,15 @@ class XtdbTableConfigOps:
             _xtdb_foreign_keys_json(table_config),
         ]
         values_sql = ", ".join(_xtdb_sql_literal(value, "TEXT") for value in values)
+        values_sql = (
+            f"{values_sql}, {_xtdb_sql_literal(table_config.is_temporal, 'BOOL')}"
+        )
         metadata_table = _xtdb_table_config_metadata_table(table_config.schema)
         _execute_xtdb_dml(
             self.connection,
             f"INSERT INTO {metadata_table} "
             "(_id, table_schema, table_name, primary_keys_json, "
-            "id_policy, columns_json, foreign_keys_json) "
+            "id_policy, columns_json, foreign_keys_json, is_temporal) "
             f"VALUES ({values_sql})",
         )
 
@@ -1181,11 +1189,6 @@ class XtdbTableConfigOps:
         """,
             self.connection,
         )
-        if metadata.is_empty():
-            raise ValueError(
-                f"XTDB table metadata not found for {table_schema}.{table_name}"
-            )
-
         config_metadata = _xtdb_table_config_metadata(
             self.connection,
             table_schema,
@@ -1197,8 +1200,14 @@ class XtdbTableConfigOps:
             table_name,
         )
         if configured_table is not None:
-            _validate_xtdb_physical_types(metadata, configured_table)
+            if not metadata.is_empty():
+                _validate_xtdb_physical_types(metadata, configured_table)
             return configured_table
+
+        if metadata.is_empty():
+            raise ValueError(
+                f"XTDB table metadata not found for {table_schema}.{table_name}"
+            )
 
         columns = []
         primary_keys = []

--- a/polars_hist_db/backends/xtdb_transport.py
+++ b/polars_hist_db/backends/xtdb_transport.py
@@ -10,7 +10,7 @@ from sqlalchemy import text
 
 from ..config import TableConfig
 from ..core import TimeHint
-from ..types import PolarsType
+from ..types import PolarsType, is_polars_type
 from .temporal import system_time_hint_clause
 
 
@@ -197,7 +197,7 @@ def _xtdb_cast_type(data_type: str) -> str:
 
 
 def _xtdb_cast_type_from_polars(dtype: pl.DataType) -> str:
-    if dtype in {pl.Int8, pl.Int16, pl.Int32}:
+    if is_polars_type(dtype, pl.Int8, pl.Int16, pl.Int32):
         return "INTEGER"
     if dtype == pl.Int64:
         return "BIGINT"
@@ -217,7 +217,7 @@ def _xtdb_cast_type_from_polars(dtype: pl.DataType) -> str:
         )
     if isinstance(dtype, pl.Decimal):
         return f"DECIMAL({dtype.precision},{dtype.scale})"
-    if dtype in {pl.String, pl.Utf8, pl.Categorical}:
+    if is_polars_type(dtype, pl.String, pl.Utf8, pl.Categorical):
         return "TEXT"
     raise ValueError(
         f"Unsupported XTDB Polars type {dtype}; provide a supported typed "

--- a/polars_hist_db/backends/xtdb_transport.py
+++ b/polars_hist_db/backends/xtdb_transport.py
@@ -175,8 +175,12 @@ def _xtdb_cast_type(data_type: str) -> str:
         return "TEXT"
     if normalized in {"DOUBLE", "DOUBLE PRECISION"}:
         return "DOUBLE PRECISION"
-    if normalized in {"FLOAT", "REAL"}:
+    if normalized == "FLOAT":
         return "FLOAT"
+    if normalized == "REAL":
+        # MariaDB REAL is DOUBLE PRECISION unless REAL_AS_FLOAT is enabled.
+        # The package contract likewise exposes REAL as Polars Float64.
+        return "DOUBLE PRECISION"
     if normalized in {"INT", "INTEGER"}:
         return "INTEGER"
     if normalized in {"BOOL", "BOOLEAN"}:

--- a/polars_hist_db/core/audit.py
+++ b/polars_hist_db/core/audit.py
@@ -115,7 +115,7 @@ class AuditOps:
     def _empty_xtdb_audit_df(self) -> pl.DataFrame:
         return pl.DataFrame(
             schema={
-                "audit_id": pl.Int64,
+                "audit_id": pl.Int32,
                 "table_name": pl.Utf8,
                 "data_source_type": pl.Utf8,
                 "data_source": pl.Utf8,
@@ -461,7 +461,9 @@ class AuditOps:
                 )
                 & 0x7FFFFFFF
             )
-            df = pl.DataFrame([new_item])
+            df = pl.DataFrame([new_item]).with_columns(
+                pl.col("audit_id").cast(pl.Int32)
+            )
             num_rows_changed = _xtdb_dataframe_ops(connection).table_insert(
                 df,
                 self.schema,

--- a/polars_hist_db/loaders/dsv/dsv_loader.py
+++ b/polars_hist_db/loaders/dsv/dsv_loader.py
@@ -8,7 +8,7 @@ import polars as pl
 
 from ...config.parser_config import IngestionColumnConfig
 from ..transform import header_configs
-from ...types import PolarsType
+from ...types import PolarsType, is_polars_type
 
 LOGGER = logging.getLogger(__name__)
 
@@ -67,7 +67,9 @@ def load_typed_dsv(
 
     def _is_forced_dtype(dtype: pl.DataType) -> bool:
         return (
-            dtype.is_temporal() or dtype.is_decimal() or dtype in {pl.String, pl.Utf8}
+            dtype.is_temporal()
+            or dtype.is_decimal()
+            or is_polars_type(dtype, pl.String, pl.Utf8)
         )
 
     headers_ingestion_schema: Mapping[str, pl.DataType] = {

--- a/polars_hist_db/types.py
+++ b/polars_hist_db/types.py
@@ -19,16 +19,25 @@ from sqlalchemy.types import TypeEngine
 from sqlalchemy.sql.sqltypes import NullType
 
 from .observability import record_database_type_contract
+from .utils.exceptions import NonRetryableException
 
 LOGGER = logging.getLogger(__name__)
 
 
-class TypeContractError(TypeError):
+class TypeContractError(TypeError, NonRetryableException):
     """A DataFrame does not satisfy a database table's declared types."""
 
 
+def is_polars_type(
+    dtype: pl.DataType,
+    *candidates: Union[pl.DataType, type[pl.DataType]],
+) -> bool:
+    """Compare Polars dtypes without relying on inconsistent dtype hashing."""
+    return any(dtype == candidate for candidate in candidates)
+
+
 def _polars_type_family(dtype: pl.DataType) -> str:
-    if dtype in {pl.String, pl.Utf8, pl.Categorical}:
+    if is_polars_type(dtype, pl.String, pl.Utf8, pl.Categorical):
         return "string"
     if dtype.is_integer():
         return "integer"
@@ -125,7 +134,7 @@ class SQLType:
         if isinstance(pl_dtype, pl.Decimal):
             return f"NUMERIC({pl_dtype.precision},{pl_dtype.scale})"
 
-        if pl_dtype in [pl.Utf8, pl.String, pl.Categorical]:
+        if is_polars_type(pl_dtype, pl.Utf8, pl.String, pl.Categorical):
             return f"VARCHAR({default_varchar_length})"
 
         raise ValueError(f"Unknown Polars data type: {pl_dtype}.")
@@ -271,16 +280,13 @@ class PolarsType:
     ) -> pl.DataFrame:
         """Fail closed on implicit database-boundary type conversions."""
         result = df
-        string_types = {pl.String, pl.Utf8, pl.Categorical}
         for column, expected in expected_schema.items():
             if column not in df.columns:
                 continue
             actual = df.schema[column]
-            if (
-                actual == expected
-                or actual in string_types
-                and expected in string_types
-            ):
+            actual_family = _polars_type_family(actual)
+            expected_family = _polars_type_family(expected)
+            if actual == expected or actual_family == expected_family == "string":
                 continue
             if actual == pl.Null:
                 result = result.with_columns(pl.col(column).cast(expected))
@@ -306,7 +312,7 @@ class PolarsType:
                 )
             LOGGER.warning("%s; applying explicit strict conversion", message)
             source = pl.col(column)
-            if actual == pl.Categorical and expected not in string_types:
+            if is_polars_type(actual, pl.Categorical) and expected_family != "string":
                 source = source.cast(pl.String)
             try:
                 result = result.with_columns(source.cast(expected, strict=True))

--- a/polars_hist_db/types.py
+++ b/polars_hist_db/types.py
@@ -233,21 +233,23 @@ class PolarsType:
         if df[col].dtype == target_type:
             return df
 
-        if target_type.is_integer():
-            df = df.with_columns(pl.col(col).cast(pl.Float64).cast(target_type))
-        elif target_type.is_decimal():
-            assert isinstance(target_type, pl.Decimal)
-            if target_type.scale == 0:
-                df = df.with_columns(
-                    pl.col(col).cast(pl.Float64).cast(pl.Int64).cast(target_type)
-                )
-        elif isinstance(target_type, pl.Datetime):
-            df = df.with_columns(pl.col(col).str.to_datetime())
-        elif isinstance(target_type, pl.Date):
-            df = df.with_columns(pl.col(col).str.to_date())
+        source = pl.col(col)
+        source_type = df.schema[col]
+        if isinstance(target_type, pl.Datetime) and is_polars_type(
+            source_type, pl.String
+        ):
+            source = source.str.to_datetime(
+                time_unit=target_type.time_unit,
+                time_zone=target_type.time_zone,
+                strict=True,
+            )
+        elif isinstance(target_type, pl.Date) and is_polars_type(
+            source_type, pl.String
+        ):
+            source = source.str.to_date(strict=True)
         else:
-            df = df.with_columns(pl.col(col).cast(target_type))
-        return df
+            source = source.cast(target_type, strict=True)
+        return df.with_columns(source)
 
     @staticmethod
     def apply_schema_to_dataframe(
@@ -259,13 +261,13 @@ class PolarsType:
                     continue
                 target_type = schema_overrides[col_name]
                 df = PolarsType.apply_dtype_to_column(df, col_name, target_type)
-            except Exception as e:
+            except Exception:
                 LOGGER.exception(
                     "Failed to type column %s with type %s",
                     col_name,
                     target_type,
-                    exc_info=e,
                 )
+                raise
         df = PolarsType.cast_str_to_cat(df)
         return df
 

--- a/tests/backends/test_xtdb_audit_ops.py
+++ b/tests/backends/test_xtdb_audit_ops.py
@@ -350,6 +350,7 @@ def test_xtdb_audit_add_entry_writes_via_backend_dataframe_ops(monkeypatch):
     assert table_name == "__audit_log"
     assert table_config.name == "__audit_log"
     assert "audit_id" in inserted_df.columns
+    assert inserted_df.schema["audit_id"] == pl.Int32
     assert inserted_df.select("table_name", "data_source").rows() == [
         ("trades", "trades.csv")
     ]

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -861,7 +861,7 @@ def test_xtdb_table_creation_maps_mysql_compatibility_types(monkeypatch):
         '"autoincrement":false,"nullable":true,"unique_constraint":[]},'
         '{"table":"compat_types","name":"time_col","data_type":"TIME",'
         '"default_value":null,"autoincrement":false,"nullable":true,'
-        "\"unique_constraint\":[]}]'::TEXT, '[]'::TEXT, FALSE::BOOL)",
+        "\"unique_constraint\":[]}]'::TEXT, '[]'::TEXT, FALSE::BOOLEAN)",
     ]
     assert _xtdb_declared_columns(table_config) == [
         "_id",
@@ -1053,7 +1053,7 @@ def test_xtdb_table_creation_records_configured_columns_without_ddl(monkeypatch)
         '"nullable":true,"unique_constraint":[]},{"table":"records",'
         '"name":"amount_value","data_type":"DECIMAL(20,6)","default_value":null,'
         '"autoincrement":false,"nullable":true,"unique_constraint":[]}]'
-        "'::TEXT, '[]'::TEXT, FALSE::BOOL)",
+        "'::TEXT, '[]'::TEXT, FALSE::BOOLEAN)",
     ]
 
 
@@ -1113,7 +1113,7 @@ def test_xtdb_table_creation_records_composite_primary_key_columns(monkeypatch):
         '"nullable":false,"unique_constraint":[]},{"table":"records",'
         '"name":"destination","data_type":"VARCHAR(255)","default_value":null,'
         '"autoincrement":false,"nullable":true,"unique_constraint":[]}]'
-        "'::TEXT, '[]'::TEXT, FALSE::BOOL)",
+        "'::TEXT, '[]'::TEXT, FALSE::BOOLEAN)",
     ]
 
 
@@ -1147,7 +1147,7 @@ def test_xtdb_table_creation_records_primary_key_metadata(monkeypatch):
         '"unique_constraint":[]},{"table":"records","name":"record_id",'
         '"data_type":"VARCHAR(255)","default_value":null,"autoincrement":false,'
         '"nullable":false,"unique_constraint":[]}]\'::TEXT, \'[]\'::TEXT, '
-        "FALSE::BOOL)",
+        "FALSE::BOOLEAN)",
     ]
 
 

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -16,6 +16,8 @@ from polars_hist_db.backends.xtdb import (
     _execute_xtdb_transaction,
     _xtdb_cast_type,
     _xtdb_declared_columns,
+    _xtdb_physical_type_family,
+    _xtdb_type_to_config_type,
     _validate_xtdb_physical_types,
 )
 from polars_hist_db.config import (
@@ -1240,9 +1242,9 @@ def test_xtdb_table_reflection_prefers_configured_column_metadata(monkeypatch):
         side_effect=[
             pl.DataFrame(
                 {
-                    "column_name": ["_id", "decimal_col", "real_col"],
-                    "data_type": [":i32", "[:DECIMAL 38 2]", ":f32"],
-                    "is_nullable": ["NO", "YES", "YES"],
+                    "column_name": ["_id", "id", "decimal_col", "real_col"],
+                    "data_type": [":i32", ":i32", "[:DECIMAL 38 2]", ":f32"],
+                    "is_nullable": ["NO", "NO", "YES", "YES"],
                 }
             ),
             pl.DataFrame({"table_name": ["__polars_hist_db_xtdb_table_configs"]}),
@@ -1290,9 +1292,9 @@ def test_xtdb_table_reflection_restores_foreign_key_metadata(monkeypatch):
         side_effect=[
             pl.DataFrame(
                 {
-                    "column_name": ["_id", "exchange_id"],
-                    "data_type": [":i32", ":i32"],
-                    "is_nullable": ["NO", "NO"],
+                    "column_name": ["_id", "id", "exchange_id"],
+                    "data_type": [":i32", ":i32", ":i32"],
+                    "is_nullable": ["NO", "NO", "NO"],
                 }
             ),
             pl.DataFrame({"table_name": ["__polars_hist_db_xtdb_table_configs"]}),
@@ -1422,6 +1424,117 @@ def test_xtdb_physical_schema_accepts_nullable_type_shorthand():
     )
 
     _validate_xtdb_physical_types(metadata, table_config)
+
+
+def test_xtdb_physical_schema_validates_configured_columns_not_unrelated_columns():
+    table_config = TableConfig(
+        schema="test",
+        name="records",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("records", "id", "BIGINT", nullable=False),
+            TableColumnConfig("records", "optional_note", "TEXT", nullable=True),
+        ],
+    )
+    metadata = pl.DataFrame(
+        {
+            "column_name": ["_id", "id", "legacy_event_time"],
+            "data_type": [":i64", ":i64", "[:? :instant]"],
+        }
+    )
+
+    _validate_xtdb_physical_types(metadata, table_config)
+
+
+def test_xtdb_physical_schema_rejects_missing_configured_column():
+    table_config = TableConfig(
+        schema="test",
+        name="records",
+        primary_keys=["id"],
+        columns=[TableColumnConfig("records", "id", "BIGINT", nullable=False)],
+    )
+
+    with pytest.raises(TypeError, match="expected BIGINT, received MISSING"):
+        _validate_xtdb_physical_types(
+            pl.DataFrame({"column_name": ["other"], "data_type": [":utf8"]}),
+            table_config,
+        )
+
+
+@pytest.mark.parametrize(
+    ("data_type", "family"),
+    [
+        (":null", "NULL"),
+        (":nothing", "NOTHING"),
+        (":bool", "BOOLEAN"),
+        (":i8", "INTEGER"),
+        (":i16", "INTEGER"),
+        (":i32", "INTEGER"),
+        (":i64", "BIGINT"),
+        (":f32", "FLOAT"),
+        (":f64", "DOUBLE PRECISION"),
+        (":utf8", "TEXT"),
+        (":varbinary", "VARBINARY"),
+        ("[:fixed-size-binary 16]", "FIXED-SIZE-BINARY"),
+        ("[:decimal 15 3 128]", "DECIMAL"),
+        (":instant", "TIMESTAMP WITH TIME ZONE"),
+        ('[:timestamp-tz :micro "GMT"]', "TIMESTAMP WITH TIME ZONE"),
+        ("[:timestamp-local :nano]", "TIMESTAMP"),
+        ("[:date :day]", "DATE"),
+        ("[:time-local :micro]", "TIME"),
+        ("[:duration :nano]", "DURATION"),
+        ("[:interval :month-day-nano]", "INTERVAL"),
+        (":tstz-range", "TSTZ-RANGE"),
+        (":keyword", "KEYWORD"),
+        (":oid", "OID"),
+        (":regclass", "REGCLASS"),
+        (":regproc", "REGPROC"),
+        (":uuid", "UUID"),
+        (":uri", "URI"),
+        (":transit", "TRANSIT"),
+        ("[:list :utf8]", "LIST"),
+        ("[:fixed-size-list 3 :utf8]", "FIXED-SIZE-LIST"),
+        ("[:set :utf8]", "SET"),
+        ("[:map {:sorted? false} [:struct {key :utf8 value :i64}]]", "MAP"),
+        ("[:struct {name :utf8}]", "STRUCT"),
+    ],
+)
+def test_xtdb_physical_type_family_covers_render_type_grammar(data_type, family):
+    assert _xtdb_physical_type_family(data_type) == family
+
+
+@pytest.mark.parametrize(
+    ("data_type", "family"),
+    [
+        ("[:? :utf8]", "TEXT"),
+        ("[:? :date :day]", "DATE"),
+        ("[:? :decimal 15 3 128]", "DECIMAL"),
+        ('[:? :timestamp-tz :micro "UTC"]', "TIMESTAMP WITH TIME ZONE"),
+        ("#{:null :i8 :i32}", "INTEGER"),
+        ('#{:null [:timestamp-tz :micro "UTC"]}', "TIMESTAMP WITH TIME ZONE"),
+        ("#{:null [:list :utf8]}", "LIST"),
+        ("#{:i64 :utf8}", "UNION"),
+    ],
+)
+def test_xtdb_physical_type_family_handles_nullable_and_polymorphic_types(
+    data_type, family
+):
+    assert _xtdb_physical_type_family(data_type) == family
+
+
+@pytest.mark.parametrize(
+    ("data_type", "config_type"),
+    [
+        ("[:? :date :day]", "DATE"),
+        ("[:? :decimal 15 3 128]", "DECIMAL(15,3)"),
+        (":instant", "TIMESTAMP WITH TIME ZONE"),
+        ('[:? :timestamp-tz :micro "GMT"]', "TIMESTAMP WITH TIME ZONE"),
+        ("[:timestamp-local :micro]", "TIMESTAMP"),
+        ("[:time-local :micro]", "TIME"),
+    ],
+)
+def test_xtdb_reflection_maps_parameterized_scalar_types(data_type, config_type):
+    assert _xtdb_type_to_config_type(data_type) == config_type
 
 
 def test_xtdb_declared_columns_quotes_non_identifier_column_names():

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -842,7 +842,7 @@ def test_xtdb_table_creation_maps_mysql_compatibility_types(monkeypatch):
     assert executed_sql == [
         "INSERT INTO test.__polars_hist_db_xtdb_table_configs "
         "(_id, table_schema, table_name, primary_keys_json, id_policy, "
-        "columns_json, foreign_keys_json) "
+        "columns_json, foreign_keys_json, is_temporal) "
         "VALUES ('test.compat_types'::TEXT, 'test'::TEXT, 'compat_types'::TEXT, "
         "'[\"id\"]'::TEXT, 'single-key'::TEXT, "
         '\'[{"table":"compat_types","name":"id","data_type":"INT",'
@@ -861,7 +861,7 @@ def test_xtdb_table_creation_maps_mysql_compatibility_types(monkeypatch):
         '"autoincrement":false,"nullable":true,"unique_constraint":[]},'
         '{"table":"compat_types","name":"time_col","data_type":"TIME",'
         '"default_value":null,"autoincrement":false,"nullable":true,'
-        "\"unique_constraint\":[]}]'::TEXT, '[]'::TEXT)",
+        "\"unique_constraint\":[]}]'::TEXT, '[]'::TEXT, FALSE::BOOL)",
     ]
     assert _xtdb_declared_columns(table_config) == [
         "_id",
@@ -1043,7 +1043,7 @@ def test_xtdb_table_creation_records_configured_columns_without_ddl(monkeypatch)
     assert executed_sql == [
         "INSERT INTO test.__polars_hist_db_xtdb_table_configs "
         "(_id, table_schema, table_name, primary_keys_json, id_policy, "
-        "columns_json, foreign_keys_json) "
+        "columns_json, foreign_keys_json, is_temporal) "
         "VALUES ('test.records'::TEXT, 'test'::TEXT, 'records'::TEXT, "
         "'[\"id\"]'::TEXT, 'single-key'::TEXT, "
         '\'[{"table":"records","name":"id","data_type":"BIGINT",'
@@ -1053,7 +1053,7 @@ def test_xtdb_table_creation_records_configured_columns_without_ddl(monkeypatch)
         '"nullable":true,"unique_constraint":[]},{"table":"records",'
         '"name":"amount_value","data_type":"DECIMAL(20,6)","default_value":null,'
         '"autoincrement":false,"nullable":true,"unique_constraint":[]}]'
-        "'::TEXT, '[]'::TEXT)",
+        "'::TEXT, '[]'::TEXT, FALSE::BOOL)",
     ]
 
 
@@ -1103,7 +1103,7 @@ def test_xtdb_table_creation_records_composite_primary_key_columns(monkeypatch):
     assert executed_sql == [
         "INSERT INTO test.__polars_hist_db_xtdb_table_configs "
         "(_id, table_schema, table_name, primary_keys_json, id_policy, "
-        "columns_json, foreign_keys_json) "
+        "columns_json, foreign_keys_json, is_temporal) "
         "VALUES ('test.records'::TEXT, 'test'::TEXT, 'records'::TEXT, "
         "'[\"entity_id\",\"record_id\"]'::TEXT, 'xtdb-pk-v1'::TEXT, "
         '\'[{"table":"records","name":"entity_id","data_type":"BIGINT",'
@@ -1113,7 +1113,7 @@ def test_xtdb_table_creation_records_composite_primary_key_columns(monkeypatch):
         '"nullable":false,"unique_constraint":[]},{"table":"records",'
         '"name":"destination","data_type":"VARCHAR(255)","default_value":null,'
         '"autoincrement":false,"nullable":true,"unique_constraint":[]}]'
-        "'::TEXT, '[]'::TEXT)",
+        "'::TEXT, '[]'::TEXT, FALSE::BOOL)",
     ]
 
 
@@ -1139,14 +1139,15 @@ def test_xtdb_table_creation_records_primary_key_metadata(monkeypatch):
     assert executed_sql == [
         "INSERT INTO test.__polars_hist_db_xtdb_table_configs "
         "(_id, table_schema, table_name, primary_keys_json, id_policy, "
-        "columns_json, foreign_keys_json) "
+        "columns_json, foreign_keys_json, is_temporal) "
         "VALUES ('test.records'::TEXT, 'test'::TEXT, 'records'::TEXT, "
         "'[\"entity_id\",\"record_id\"]'::TEXT, 'xtdb-pk-v1'::TEXT, "
         '\'[{"table":"records","name":"entity_id","data_type":"BIGINT",'
         '"default_value":null,"autoincrement":false,"nullable":false,'
         '"unique_constraint":[]},{"table":"records","name":"record_id",'
         '"data_type":"VARCHAR(255)","default_value":null,"autoincrement":false,'
-        '"nullable":false,"unique_constraint":[]}]\'::TEXT, \'[]\'::TEXT)',
+        '"nullable":false,"unique_constraint":[]}]\'::TEXT, \'[]\'::TEXT, '
+        "FALSE::BOOL)",
     ]
 
 
@@ -1253,6 +1254,7 @@ def test_xtdb_table_reflection_prefers_configured_column_metadata(monkeypatch):
                     "primary_keys_json": ['["id"]'],
                     "id_policy": ["single-key"],
                     "columns_json": [columns_json],
+                    "is_temporal": [False],
                 }
             ),
             pl.DataFrame(
@@ -1273,6 +1275,39 @@ def test_xtdb_table_reflection_prefers_configured_column_metadata(monkeypatch):
         ("id", "INT"),
         ("decimal_col", "DECIMAL(10,2)"),
         ("real_col", "REAL"),
+    ]
+    assert table_config.is_temporal is False
+
+
+def test_xtdb_table_reflection_returns_recorded_config_before_physical_rows(
+    monkeypatch,
+):
+    columns_json = (
+        '[{"table":"records","name":"id","data_type":"INT",'
+        '"default_value":null,"autoincrement":false,"nullable":false,'
+        '"unique_constraint":[]}]'
+    )
+    read_database = Mock(
+        side_effect=[
+            pl.DataFrame(),
+            pl.DataFrame({"table_name": ["__polars_hist_db_xtdb_table_configs"]}),
+            pl.DataFrame(
+                {
+                    "primary_keys_json": ['["id"]'],
+                    "columns_json": [columns_json],
+                    "is_temporal": [False],
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(pl, "read_database", read_database)
+
+    table_config = XtdbTableConfigOps(object()).from_table("test", "records")
+
+    assert table_config.primary_keys == ["id"]
+    assert table_config.is_temporal is False
+    assert [(column.name, column.data_type) for column in table_config.columns] == [
+        ("id", "INT")
     ]
 
 

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -656,6 +656,52 @@ def test_xtdb_temporal_upsert_prefills_configured_defaults_before_insert():
     }
 
 
+def test_xtdb_temporal_upsert_materializes_missing_configured_columns():
+    backend = XtdbBackend()
+    ops = Mock()
+    ops.table_insert.return_value = 1
+    table_config = TableConfig(
+        schema="test",
+        name="records",
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig("records", "id", "INT", nullable=False),
+            TableColumnConfig("records", "description", "VARCHAR(255)"),
+            TableColumnConfig("records", "amount", "DECIMAL(10,2)"),
+            TableColumnConfig("records", "observed_at", "DATETIME"),
+        ],
+    )
+
+    result = backend.temporal_upsert(
+        pl.DataFrame({"id": pl.Series([1], dtype=pl.Int32)}),
+        "test",
+        "records",
+        dataframe_ops=ops,
+        table_config=table_config,
+        delta_config=DeltaConfig(prefill_nulls_with_default=False),
+    )
+
+    assert result == 1
+    written_df = ops.table_insert.call_args.args[0]
+    assert written_df.columns == [
+        "id",
+        "description",
+        "amount",
+        "observed_at",
+        "_valid_from",
+    ]
+    assert written_df.schema == {
+        "id": pl.Int32,
+        "description": pl.String,
+        "amount": pl.Decimal(10, 2),
+        "observed_at": pl.Datetime("us"),
+        "_valid_from": pl.Datetime("us", "UTC"),
+    }
+    assert written_df.select("description", "amount", "observed_at").null_count().row(
+        0
+    ) == (1, 1, 1)
+
+
 def test_xtdb_temporal_upsert_treats_null_to_value_as_changed():
     backend = XtdbBackend()
     ops = Mock()
@@ -1244,7 +1290,7 @@ def test_xtdb_table_reflection_prefers_configured_column_metadata(monkeypatch):
             pl.DataFrame(
                 {
                     "column_name": ["_id", "id", "decimal_col", "real_col"],
-                    "data_type": [":i32", ":i32", "[:DECIMAL 38 2]", ":f32"],
+                    "data_type": [":i32", ":i32", "[:DECIMAL 38 2]", ":f64"],
                     "is_nullable": ["NO", "NO", "YES", "YES"],
                 }
             ),

--- a/tests/backends/test_xtdb_dataframe_ops.py
+++ b/tests/backends/test_xtdb_dataframe_ops.py
@@ -614,6 +614,7 @@ def test_xtdb_dataframe_ops_uses_native_casts_for_mysql_compatibility_types():
             TableColumnConfig("compat_types", "tinyint_col", "TINYINT"),
             TableColumnConfig("compat_types", "smallint_col", "SMALLINT"),
             TableColumnConfig("compat_types", "mediumint_col", "MEDIUMINT"),
+            TableColumnConfig("compat_types", "real_col", "REAL"),
             TableColumnConfig("compat_types", "datetime_col", "DATETIME"),
             TableColumnConfig("compat_types", "time_col", "TIME"),
         ],
@@ -628,6 +629,7 @@ def test_xtdb_dataframe_ops_uses_native_casts_for_mysql_compatibility_types():
                 "tinyint_col": [2],
                 "smallint_col": [738221],
                 "mediumint_col": [4],
+                "real_col": [78.9],
                 "datetime_col": [datetime(2030, 1, 1, 12, 0)],
                 "time_col": [datetime(2030, 1, 1, 12, 30).time()],
             }
@@ -643,6 +645,7 @@ def test_xtdb_dataframe_ops_uses_native_casts_for_mysql_compatibility_types():
     assert "INSERT INTO test.compat_types" in insert_sql
     assert "%s::BOOLEAN" in insert_sql
     assert insert_sql.count("%s::INTEGER") == 6
+    assert "%s::DOUBLE PRECISION" in insert_sql
     assert "%s::TIMESTAMP WITH TIME ZONE" in insert_sql
     assert "%s::TIME" in insert_sql
     assert insert_call.args[1] == [
@@ -654,6 +657,7 @@ def test_xtdb_dataframe_ops_uses_native_casts_for_mysql_compatibility_types():
             2,
             738221,
             4,
+            78.9,
             datetime(2030, 1, 1, 12, 0, tzinfo=timezone.utc),
             datetime(2030, 1, 1, 12, 30).time(),
         )

--- a/tests/backends/test_xtdb_live.py
+++ b/tests/backends/test_xtdb_live.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import date, datetime, time as datetime_time, timezone
 from decimal import Decimal
 import os
 import subprocess
@@ -170,6 +170,57 @@ def test_xtdb_live_reflection_preserves_caller_transaction_without_metadata():
         "label": "VARCHAR(255)",
         "seen_at": "TIMESTAMP WITH TIME ZONE",
     }
+
+
+def test_xtdb_live_validates_supported_physical_type_families():
+    table_name = f"live_types_{int(time.time())}"
+    table_config = TableConfig(
+        schema="public",
+        name=table_name,
+        primary_keys=["id"],
+        columns=[
+            TableColumnConfig(table_name, "id", "BIGINT", nullable=False),
+            TableColumnConfig(table_name, "enabled", "BOOL", nullable=False),
+            TableColumnConfig(table_name, "count", "INT", nullable=False),
+            TableColumnConfig(table_name, "ratio", "FLOAT", nullable=False),
+            TableColumnConfig(table_name, "measurement", "DOUBLE", nullable=False),
+            TableColumnConfig(table_name, "label", "VARCHAR(64)", nullable=False),
+            TableColumnConfig(table_name, "amount", "DECIMAL(15,3)", nullable=False),
+            TableColumnConfig(table_name, "event_date", "DATE", nullable=False),
+            TableColumnConfig(table_name, "event_time", "TIME", nullable=False),
+            TableColumnConfig(table_name, "seen_at_local", "TIMESTAMP", nullable=False),
+            TableColumnConfig(table_name, "seen_at_utc", "DATETIME", nullable=False),
+        ],
+    )
+    data = pl.DataFrame(
+        {
+            "id": [1],
+            "enabled": [True],
+            "count": pl.Series([2], dtype=pl.Int32),
+            "ratio": pl.Series([1.5], dtype=pl.Float32),
+            "measurement": [2.5],
+            "label": ["value"],
+            "amount": pl.Series([Decimal("3.125")], dtype=pl.Decimal(15, 3)),
+            "event_date": [date(2026, 7, 18)],
+            "event_time": [datetime_time(12, 34, 56)],
+            "seen_at_local": [datetime(2026, 7, 18, 12, 34, 56)],
+            "seen_at_utc": [datetime(2026, 7, 18, 12, 34, 56, tzinfo=timezone.utc)],
+        }
+    )
+
+    with _xtdb_engine() as engine:
+        backend = XtdbBackend()
+        with backend.connection_scope(engine) as connection:
+            backend.table_configs(connection).create(table_config)
+            backend.dataframes(connection).table_insert(
+                data,
+                table_config.schema,
+                table_config.name,
+                table_config=table_config,
+            )
+            assert (
+                backend.table_configs(connection).create(table_config) == table_config
+            )
 
 
 def test_xtdb_live_insert_non_public_table_with_reserved_column_name():

--- a/tests/backends/test_xtdb_live.py
+++ b/tests/backends/test_xtdb_live.py
@@ -243,7 +243,7 @@ def test_xtdb_live_insert_non_public_table_with_reserved_column_name():
             backend.dataframes(connection).table_insert(
                 pl.DataFrame(
                     {
-                        "entity_id": [311038700],
+                        "entity_id": pl.Series([311038700], dtype=pl.Int32),
                         "name": ["ALPHA"],
                         "flag": ["BS"],
                     }
@@ -286,8 +286,10 @@ def test_xtdb_live_insert_column_with_slash_roundtrip():
             backend.dataframes(connection).table_insert(
                 pl.DataFrame(
                     {
-                        "entity_id": [1],
-                        "capacity/bcm": ["4.080"],
+                        "entity_id": pl.Series([1], dtype=pl.Int32),
+                        "capacity/bcm": pl.Series(
+                            [Decimal("4.080")], dtype=pl.Decimal(15, 3)
+                        ),
                     }
                 ),
                 table_config.schema,
@@ -370,8 +372,8 @@ def test_xtdb_live_normalizes_foreign_keys_end_to_end():
     )
     upload = pl.DataFrame(
         {
-            "trade_id": [1, 2, 3],
-            "country_id": pl.Series([None, None, None], dtype=pl.Int64),
+            "trade_id": pl.Series([1, 2, 3], dtype=pl.Int32),
+            "country_id": pl.Series([None, None, None], dtype=pl.Int32),
             "country_name": ["Japan", "Korea", "Korea"],
         }
     )
@@ -382,7 +384,12 @@ def test_xtdb_live_normalizes_foreign_keys_end_to_end():
         _create_config_tables(engine, tables, backend)
         with engine.connect() as connection:
             backend.dataframes(connection).table_insert(
-                pl.DataFrame({"country_id": [7], "name": ["Japan"]}),
+                pl.DataFrame(
+                    {
+                        "country_id": pl.Series([7], dtype=pl.Int32),
+                        "name": ["Japan"],
+                    }
+                ),
                 "public",
                 "live_countries",
                 table_config=tables["live_countries"],
@@ -817,7 +824,7 @@ def test_xtdb_live_delta_upsert_dropout_closes_missing_rows_at_valid_time():
                     {
                         "id": [1, 2],
                         "destination": ["Alpha", "Beta"],
-                        "_valid_from": [datetime(1985, 1, 1)] * 2,
+                        "_valid_from": [datetime(1985, 1, 1, tzinfo=timezone.utc)] * 2,
                     }
                 ),
                 table_config.schema,
@@ -831,7 +838,7 @@ def test_xtdb_live_delta_upsert_dropout_closes_missing_rows_at_valid_time():
                     {
                         "id": [1],
                         "destination": ["Alpha"],
-                        "_valid_from": [datetime(1986, 1, 1)],
+                        "_valid_from": [datetime(1986, 1, 1, tzinfo=timezone.utc)],
                     }
                 ),
                 table_config.schema,

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -1090,6 +1090,8 @@ def test_xtdb_staging_reuses_deduced_foreign_key_for_later_primary_item(
     )
 
     generated_id = location_df[0, "id"]
+    assert location_df.schema["id"] == pl.Int32
+    assert trades_df.schema["destination_location_id"] == pl.Int32
     assert trades_df.to_dict(as_series=False) == {
         "id": [308327],
         "destination_location_id": [generated_id],

--- a/tests/core/test_correctness_regressions.py
+++ b/tests/core/test_correctness_regressions.py
@@ -13,6 +13,7 @@ from polars_hist_db.core.delta_table import (
     _prevalidate_upsert_from_table,
 )
 from polars_hist_db.loaders.dsv.dsv_loader import _validate_expected_columns
+from polars_hist_db.types import PolarsType
 
 
 def test_boolean_string_defaults_are_parsed():
@@ -49,6 +50,22 @@ def test_missing_dsv_columns_are_added_to_rows():
 
     assert result.schema == {"missing": pl.String}
     assert result["missing"].to_list() == [None, None]
+
+
+@pytest.mark.parametrize("expected", [pl.String, pl.Utf8, pl.Categorical])
+def test_database_contract_accepts_all_string_encodings(expected):
+    categorical = pl.DataFrame({"value": ["one", "two"]}).with_columns(
+        pl.col("value").cast(pl.Categorical)
+    )
+
+    result = PolarsType.enforce_database_schema(
+        categorical,
+        {"value": expected},
+        backend="test",
+        operation="table_insert",
+    )
+
+    assert result.schema["value"] == pl.Categorical
 
 
 def test_last_delta_column_type_mismatch_raises():

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -1,0 +1,24 @@
+from decimal import Decimal
+
+import polars as pl
+import pytest
+
+from polars_hist_db.types import PolarsType
+
+
+def test_apply_schema_casts_scaled_decimal() -> None:
+    result = PolarsType.apply_schema_to_dataframe(
+        pl.DataFrame({"amount": [1.2345]}),
+        amount=pl.Decimal(precision=10, scale=4),
+    )
+
+    assert result.schema["amount"] == pl.Decimal(precision=10, scale=4)
+    assert result[0, "amount"] == Decimal("1.2345")
+
+
+def test_apply_schema_rejects_invalid_value_instead_of_leaving_wrong_type() -> None:
+    with pytest.raises(Exception, match="conversion"):
+        PolarsType.apply_schema_to_dataframe(
+            pl.DataFrame({"amount": ["not-a-number"]}),
+            amount=pl.Decimal(precision=10, scale=4),
+        )

--- a/tests/dataset/test_scrape_transactions.py
+++ b/tests/dataset/test_scrape_transactions.py
@@ -4,6 +4,7 @@ import pytest
 
 from polars_hist_db.loaders.input_source import BatchFinalizer
 from polars_hist_db.dataset.scrape import try_run_pipeline_as_transaction
+from polars_hist_db.types import TypeContractError
 
 
 @pytest.mark.asyncio
@@ -55,3 +56,29 @@ async def test_pipeline_raises_final_retry_error(monkeypatch):
         )
 
     assert attempts == 3
+
+
+@pytest.mark.asyncio
+async def test_pipeline_does_not_retry_type_contract_errors(monkeypatch):
+    attempts = 0
+
+    def fail(*args):
+        nonlocal attempts
+        attempts += 1
+        raise TypeContractError("invalid schema")
+
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.scrape._run_pipeline_as_transaction", fail
+    )
+
+    with pytest.raises(TypeContractError, match="invalid schema"):
+        await try_run_pipeline_as_transaction(
+            [],
+            SimpleNamespace(),
+            object(),
+            object(),
+            BatchFinalizer(),
+            num_retries=3,
+        )
+
+    assert attempts == 1

--- a/tests/sql/test_dataframe_join.py
+++ b/tests/sql/test_dataframe_join.py
@@ -15,6 +15,7 @@ from ..utils.dsv_helper import (
     setup_fixture_dataset,
     connection_context_for_engine,
     dataframe_ops_for_engine,
+    normalise_query_result_for_backend,
 )
 
 pytestmark = pytest.mark.integration
@@ -69,6 +70,7 @@ def test_time_hints(temp_table):
                 query_df,
                 column_selection=None,
             )
+            .pipe(normalise_query_result_for_backend, engine, table_config)
             .sort("id")
         )
 
@@ -87,6 +89,7 @@ def test_time_hints(temp_table):
                 column_selection=None,
                 time_hint=TimeHint(mode="asof", asof_utc=asof_utc),
             )
+            .pipe(normalise_query_result_for_backend, engine, table_config)
             .sort("id")
         )
 
@@ -107,6 +110,7 @@ def test_time_hints(temp_table):
                     mode="span", asof_utc=asof_utc, history_span=timedelta(days=0)
                 ),
             )
+            .pipe(normalise_query_result_for_backend, engine, table_config)
             .sort("id")
         )
 
@@ -127,6 +131,7 @@ def test_time_hints(temp_table):
                     mode="span", asof_utc=asof_utc, history_span=timedelta(days=2)
                 ),
             )
+            .pipe(normalise_query_result_for_backend, engine, table_config)
             .sort("__valid_from")
         )
 

--- a/tests/utils/dsv_helper.py
+++ b/tests/utils/dsv_helper.py
@@ -90,7 +90,7 @@ def _published_port(container_id: str) -> int:
     return int(first_binding.rsplit(":", 1)[1])
 
 
-def xtdb_engine_test() -> tuple[Engine, str]:
+def xtdb_engine_test() -> tuple[Engine, str, DbEngineConfig]:
     container_id = _docker(
         ["run", "--rm", "-d", "-p", "5432", "ghcr.io/xtdb/xtdb:nightly"]
     )
@@ -113,7 +113,7 @@ def xtdb_engine_test() -> tuple[Engine, str]:
                 raise
             time.sleep(1)
 
-    return engine, container_id
+    return engine, container_id, config
 
 
 def _backend_from_engine(engine: Engine):
@@ -250,8 +250,7 @@ def setup_fixture_dataset(test_file: str, backend_name: str = "mariadb"):
         backend_config = DbEngineConfig(backend="mariadb")
         backend = backend_from_config(backend_config)
     elif backend_name == "xtdb":
-        engine, container_id = xtdb_engine_test()
-        backend_config = DbEngineConfig(backend="xtdb")
+        engine, container_id, backend_config = xtdb_engine_test()
         backend = backend_from_config(backend_config)
     else:
         raise ValueError(f"unsupported test backend {backend_name!r}")
@@ -458,6 +457,20 @@ def connection_context_for_engine(engine: Engine):
 
 def dataframe_ops_for_engine(engine: Engine, connection):
     return _backend_from_engine(engine).dataframes(connection)
+
+
+def normalise_query_result_for_backend(
+    df: pl.DataFrame,
+    engine: Engine,
+    table_config: TableConfig,
+) -> pl.DataFrame:
+    if _backend_from_engine(engine).name != "xtdb":
+        return df
+    return _normalise_xtdb_dataframe(
+        df,
+        table_config,
+        include_temporal_columns=table_config.is_temporal,
+    )
 
 
 def table_config_ops_for_engine(engine: Engine, connection):

--- a/tests/utils/dsv_helper.py
+++ b/tests/utils/dsv_helper.py
@@ -84,20 +84,30 @@ def _docker(args: list[str]) -> str:
     return subprocess.check_output(["docker", *args], text=True).strip()
 
 
-def _published_port(container_id: str) -> int:
-    output = _docker(["port", container_id, "5432/tcp"])
+def _published_port(container_id: str, container_port: str) -> int:
+    output = _docker(["port", container_id, container_port])
     first_binding = output.splitlines()[0]
     return int(first_binding.rsplit(":", 1)[1])
 
 
 def xtdb_engine_test() -> tuple[Engine, str, DbEngineConfig]:
     container_id = _docker(
-        ["run", "--rm", "-d", "-p", "5432", "ghcr.io/xtdb/xtdb:nightly"]
+        [
+            "run",
+            "--rm",
+            "-d",
+            "-p",
+            "5432",
+            "-p",
+            "9832",
+            "ghcr.io/xtdb/xtdb:nightly",
+        ]
     )
     config = DbEngineConfig(
         backend="xtdb",
         hostname="127.0.0.1",
-        port=_published_port(container_id),
+        port=_published_port(container_id, "5432/tcp"),
+        adbc_port=_published_port(container_id, "9832/tcp"),
     )
     engine = XtdbBackend().create_engine(config)
     deadline = time.monotonic() + 60

--- a/tests/utils/dsv_helper.py
+++ b/tests/utils/dsv_helper.py
@@ -247,12 +247,15 @@ def setup_fixture_dataset(test_file: str, backend_name: str = "mariadb"):
     container_id = None
     if backend_name == "mariadb":
         engine = mariadb_engine_test()
-        backend = backend_from_config(DbEngineConfig(backend="mariadb"))
+        backend_config = DbEngineConfig(backend="mariadb")
+        backend = backend_from_config(backend_config)
     elif backend_name == "xtdb":
         engine, container_id = xtdb_engine_test()
-        backend = backend_from_config(DbEngineConfig(backend="xtdb"))
+        backend_config = DbEngineConfig(backend="xtdb")
+        backend = backend_from_config(backend_config)
     else:
         raise ValueError(f"unsupported test backend {backend_name!r}")
+    config.db_config = backend_config
     engine._polars_hist_db_backend = backend  # type: ignore[attr-defined]
 
     table_schema = config.tables.schemas()[0]
@@ -478,6 +481,26 @@ def modify_and_read(
     return_view: bool = False,
 ) -> Tuple[pl.DataFrame, Optional[pl.DataFrame]]:
     backend = _backend_from_engine(engine)
+    schema = {
+        column.name: PolarsType.from_sql(column.data_type)
+        for column in table_config.columns
+        if column.name in df.columns
+    }
+    df = PolarsType.apply_schema_to_dataframe(df, **schema)
+    if backend.name == "xtdb":
+        datetime_columns = [
+            column.name
+            for column in table_config.columns
+            if column.name in df.columns
+            and isinstance(df.schema[column.name], pl.Datetime)
+            and getattr(df.schema[column.name], "time_zone", None) is None
+            and column.data_type.upper() in {"DATETIME", "TIMESTAMPTZ"}
+        ]
+        if datetime_columns:
+            df = df.with_columns(
+                pl.col(column).dt.replace_time_zone("UTC")
+                for column in datetime_columns
+            )
     connection_context = engine.connect if backend.name == "xtdb" else engine.begin
     with connection_context() as connection:
         # config = (
@@ -490,7 +513,7 @@ def modify_and_read(
             assert dataset.delta_config is not None
             if app_time is not None and "_valid_from" not in df.columns:
                 df = df.with_columns(
-                    pl.lit(app_time.replace(tzinfo=None)).alias("_valid_from")
+                    pl.lit(app_time.astimezone(timezone.utc)).alias("_valid_from")
                 )
             backend.temporal_upsert(
                 df,
@@ -501,7 +524,7 @@ def modify_and_read(
                 delta_config=dataset.delta_config,
                 valid_time=dataset.valid_time_for_table(table_schema, config.name),
                 dropout_close_time=(
-                    app_time.replace(tzinfo=None) if app_time is not None else None
+                    app_time.astimezone(timezone.utc) if app_time is not None else None
                 ),
             )
         elif operation == "delete":


### PR DESCRIPTION
## Summary

- parse the complete type grammar emitted by XTDB information-schema reflection, including parameterized, nullable, polymorphic, temporal, decimal, extension, and nested container types
- validate configured columns as the schema contract while allowing unrelated schema-on-read columns
- require non-nullable configured columns and fail closed for unknown or incompatible physical types
- preserve native timestamp, date, time, numeric, boolean, and string type families without text fallback
- compare Polars dtype classes and instances without relying on their inconsistent hashes
- treat string and categorical encodings as the same semantic database type
- stop retrying deterministic type-contract failures
- run the live XTDB integration suite in CI instead of silently skipping it

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy polars_hist_db`
- `uv run pytest -q -m "not integration"` (301 passed)
- exhaustive grammar cases derived from XTDB `render-type`
- live XTDB scalar contract validation