### PR TITLE
fix: preserve timezone-aware timestamp types

### DIFF
--- a/polars_hist_db/types.py
+++ b/polars_hist_db/types.py
@@ -71,6 +71,16 @@ TYPE_PRIORITY_MAP: List[Tuple[str, pl.DataType, TypeEngine]] = [
     ("INT", pl.Int32(), sqlalchemy.types.INTEGER()),
     ("JSON", pl.Utf8(), sqlalchemy.types.JSON()),
     ("REAL", pl.Float64(), sqlalchemy.types.REAL()),
+    (
+        "TIMESTAMP WITH TIME ZONE",
+        pl.Datetime("us", "UTC"),
+        sqlalchemy.types.TIMESTAMP(timezone=True),
+    ),
+    (
+        "TIMESTAMPTZ",
+        pl.Datetime("us", "UTC"),
+        sqlalchemy.types.TIMESTAMP(timezone=True),
+    ),
     ("TIMESTAMP", pl.Datetime(), sqlalchemy.types.TIMESTAMP()),
     ("TIME", pl.Time(), sqlalchemy.types.TIME()),
     ("TINYINT(DISPLAY_WIDTH=1)", pl.Boolean(), sqlalchemy.types.BOOLEAN()),

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -2,8 +2,9 @@ from decimal import Decimal
 
 import polars as pl
 import pytest
+from sqlalchemy.types import TIMESTAMP
 
-from polars_hist_db.types import PolarsType
+from polars_hist_db.types import PolarsType, SQLAlchemyType, SQLType
 
 
 def test_apply_schema_casts_scaled_decimal() -> None:
@@ -22,3 +23,15 @@ def test_apply_schema_rejects_invalid_value_instead_of_leaving_wrong_type() -> N
             pl.DataFrame({"amount": ["not-a-number"]}),
             amount=pl.Decimal(precision=10, scale=4),
         )
+
+
+def test_timezone_aware_timestamp_type_roundtrip() -> None:
+    utc_timestamp = pl.Datetime("us", "UTC")
+
+    assert PolarsType.from_sql("TIMESTAMP WITH TIME ZONE") == utc_timestamp
+    assert PolarsType.from_sql("TIMESTAMPTZ") == utc_timestamp
+    assert SQLType.from_polars(utc_timestamp) == "TIMESTAMP WITH TIME ZONE"
+
+    sqlalchemy_type = SQLAlchemyType.from_sql("TIMESTAMP WITH TIME ZONE")
+    assert isinstance(sqlalchemy_type, TIMESTAMP)
+    assert sqlalchemy_type.timezone is True


### PR DESCRIPTION
## Summary
- distinguish timezone-aware SQL timestamps before the generic TIMESTAMP prefix
- preserve UTC-aware Polars and SQLAlchemy types for both standard and PostgreSQL spellings
- cover the conversion round trip

## Verification
- uv run pytest -q
- uv run pre-commit run --all-files