### PR TITLE
feat: enforce typed flattened input schemas

### DIFF
--- a/docs/configuration.qmd
+++ b/docs/configuration.qmd
@@ -145,6 +145,29 @@ The `search_paths` section defines where to find the data. The example above use
 
 The `pipeline` section contains a sequence of tasks that are run in order. The example above demonstrates two tasks:
 
+For flattened payloads, the pipeline is also the authoritative input schema.
+Every source column must be declared. Its input type is resolved from
+`ingestion_data_type`, falling back to `target_data_type` and then the target
+table column type. Declare `ingestion_data_type` only when the raw type differs
+from the target type. Undeclared columns, incompatible values, missing required
+columns, conflicting declarations, and nulls in non-nullable columns fail
+before payloads are combined or staged.
+
+Use `column_type: input_only` for a declared, typed source field that must be
+accepted but not staged or persisted:
+
+```yaml
+columns:
+- {source: record.id, target: id}
+- {source: record.measurement, target: measurement, ingestion_data_type: DOUBLE}
+- {source: record.unused_note, column_type: input_only, ingestion_data_type: VARCHAR(64)}
+```
+
+Transformation results and staging types continue to come from
+`target_data_type` or the target table schema, so a separate output schema is
+not required. The older `dsv_only` spelling remains supported for existing
+DSV configurations.
+
 **Task 1: Unit Info Table**
 
 This task populates the `unit_info` table:

--- a/polars_hist_db/config/dataset.py
+++ b/polars_hist_db/config/dataset.py
@@ -28,7 +28,13 @@ class DeltaConfig:
         return f"__{table_name}_tmp"
 
 
-PipelineColumnType = Literal["data", "computed", "dsv_only", "time_partition_only"]
+PipelineColumnType = Literal[
+    "data",
+    "computed",
+    "input_only",
+    "dsv_only",
+    "time_partition_only",
+]
 
 
 @dataclass(frozen=True)
@@ -199,7 +205,7 @@ class Pipeline:
     def build_ingestion_column_definitions(
         self, all_tables: TableConfigs
     ) -> List[IngestionColumnConfig]:
-        temporary_types = {"dsv_only", "time_partition_only"}
+        temporary_types = {"input_only", "dsv_only", "time_partition_only"}
         ordered_columns = [
             column for column in self.items if column.column_type not in temporary_types
         ] + [column for column in self.items if column.column_type in temporary_types]
@@ -248,6 +254,7 @@ class Pipeline:
                 if column.table != table.name or column.column_type not in {
                     "data",
                     "computed",
+                    "time_partition_only",
                 }:
                     continue
                 key = (column.table, column.source, column.target)

--- a/polars_hist_db/config/parser_config.py
+++ b/polars_hist_db/config/parser_config.py
@@ -12,7 +12,9 @@ LOGGER = logging.getLogger(__name__)
 
 @dataclass
 class IngestionColumnConfig:
-    column_type: Literal["data", "computed", "dsv_only", "time_partition_only"]
+    column_type: Literal[
+        "data", "computed", "input_only", "dsv_only", "time_partition_only"
+    ]
     schema: str
     table: Optional[str]
     ingestion_data_type: str

--- a/polars_hist_db/loaders/jetstream_input_source.py
+++ b/polars_hist_db/loaders/jetstream_input_source.py
@@ -20,7 +20,7 @@ from ..config.dataset import DatasetConfig
 from ..config.input.jetstream_config import JetStreamInputConfig
 from ..config.table import TableConfigs
 from .input_source import BatchFinalizer, InputSource
-from .transform import apply_transformations
+from .transform import apply_transformations, enforce_input_schema
 
 
 LOGGER = logging.getLogger(__name__)
@@ -53,9 +53,17 @@ class JetStreamInputSource(InputSource[JetStreamInputConfig]):
         all_dfs = []
         msg_audits = []
         for msg in msgs:
-            df = load_df_from_msg(msg, msg_ts, self.config.payload_ingest)
+            raw_df = load_df_from_msg(msg, msg_ts, self.config.payload_ingest)
             msg_audits.extend(
-                list(df.select("__path", "__created_at").unique().iter_rows())
+                list(raw_df.select("__path", "__created_at").unique().iter_rows())
+            )
+            metadata = raw_df.select("__path", "__created_at")
+            df = raw_df.drop("__path", "__created_at").pipe(
+                enforce_input_schema, self.column_definitions
+            )
+            df = df.with_columns(
+                metadata.get_column("__path"),
+                metadata.get_column("__created_at"),
             )
             all_dfs.append(df)
 

--- a/polars_hist_db/loaders/transform.py
+++ b/polars_hist_db/loaders/transform.py
@@ -9,8 +9,74 @@ from ..config.transform_fn_registry import TransformFnRegistry
 from ..config.parser_config import IngestionColumnConfig
 from ..core.dataframe import DataframeOps
 from ..types import PolarsType
+from ..utils.exceptions import NonRetryableException
 
 LOGGER = logging.getLogger(__name__)
+
+
+class InputSchemaError(TypeError, NonRetryableException):
+    """An input DataFrame does not satisfy its resolved pipeline schema."""
+
+
+def enforce_input_schema(
+    df: pl.DataFrame, column_configs: Sequence[IngestionColumnConfig]
+) -> pl.DataFrame:
+    sources: dict[str, tuple[pl.DataType, bool, bool]] = {}
+    generated: dict[str, pl.DataType] = {}
+    for config in column_configs:
+        if config.source is None:
+            if config.target is not None and config.column_type == "computed":
+                generated[config.target] = PolarsType.from_sql(config.target_data_type)
+            continue
+
+        dtype = PolarsType.from_sql(config.ingestion_data_type)
+        required = config.required
+        nullable = True if config.nullable is None else config.nullable
+        previous = sources.get(config.source)
+        if previous is not None and previous[0] != dtype:
+            raise InputSchemaError(
+                f"conflicting ingestion types for {config.source!r}: "
+                f"{previous[0]} and {dtype}"
+            )
+        sources[config.source] = (
+            dtype,
+            required or (previous[1] if previous else False),
+            nullable and (previous[2] if previous else True),
+        )
+
+    accepted = set(sources).union(generated)
+    unknown = sorted(set(df.columns).difference(accepted))
+    if unknown:
+        raise InputSchemaError("undeclared input columns: " + ", ".join(unknown))
+
+    result = df
+    for name, (dtype, required, nullable) in sources.items():
+        if name not in result.columns:
+            if required or not nullable:
+                raise InputSchemaError(f"missing required input column: {name}")
+            result = result.with_columns(pl.lit(None).cast(dtype).alias(name))
+        else:
+            try:
+                result = PolarsType.apply_dtype_to_column(result, name, dtype)
+            except Exception as exc:
+                raise InputSchemaError(
+                    f"input column {name!r} cannot be converted to {dtype}"
+                ) from exc
+        if not nullable and result[name].null_count() > 0:
+            raise InputSchemaError(f"nulls in required input column: {name}")
+
+    for name, dtype in generated.items():
+        if name in result.columns:
+            try:
+                result = PolarsType.apply_dtype_to_column(result, name, dtype)
+            except Exception as exc:
+                raise InputSchemaError(
+                    f"computed input column {name!r} cannot be converted to {dtype}"
+                ) from exc
+
+    return result.select(
+        [*sources, *(name for name in generated if name in result.columns)]
+    )
 
 
 def header_configs(
@@ -19,7 +85,7 @@ def header_configs(
     return [
         cfg
         for cfg in column_configs
-        if cfg.source and cfg.column_type in ["data", "dsv_only"]
+        if cfg.source and cfg.column_type in ["data", "input_only", "dsv_only"]
     ]
 
 
@@ -43,7 +109,8 @@ def apply_transformations(
         [
             col_cfg.source
             for col_cfg in column_configs
-            if col_cfg.column_type == "dsv_only" and col_cfg.source in dsv_df.columns
+            if col_cfg.column_type in {"input_only", "dsv_only"}
+            and col_cfg.source in dsv_df.columns
         ]
     )
 

--- a/tests/_data/config/foodprices.yaml
+++ b/tests/_data/config/foodprices.yaml
@@ -105,6 +105,7 @@ datasets:
           - { source: Price, target: price }
           - { source: Month, ingestion_data_type: VARCHAR(2) }
           - { source: Year, ingestion_data_type: INT }
+          - { source: Place, column_type: input_only, ingestion_data_type: VARCHAR(64) }
           - { source: Placex, ingestion_data_type: VARCHAR(64) }
           - { target: price_usd, transforms: { try_to_usd: ['Price', 'Year'] } }
           - { target: time, column_type: time_partition_only, target_data_type: DATETIME, transforms: { combine_columns: ['${Year}', '-', '${Month}', '-01' ], apply_type_casts: [Utf8, Date] } }

--- a/tests/config/test_pipeline_config.py
+++ b/tests/config/test_pipeline_config.py
@@ -69,6 +69,11 @@ def test_pipeline_builds_normalized_table_metadata_without_dataframes():
                 "columns": [
                     {"source": "id", "target": "id", "required": True},
                     {"source": "country_id", "target": "country_id"},
+                    {
+                        "source": "unused_payload_field",
+                        "column_type": "input_only",
+                        "ingestion_data_type": "VARCHAR(16)",
+                    },
                     {"source": "raw_date", "ingestion_data_type": "VARCHAR(10)"},
                     {
                         "target": "event_date",
@@ -112,6 +117,7 @@ def test_pipeline_builds_normalized_table_metadata_without_dataframes():
     assert definitions[("ref", "country_id")].deduce_foreign_key is True
     assert definitions[("ref", "country")].target_data_type == "VARCHAR(64)"
     assert definitions[("sample", "id")].required is True
+    assert definitions[("sample", "unused_payload_field")].column_type == "input_only"
     assert definitions[("sample", "raw_date")].column_type == "dsv_only"
     assert definitions[("sample", "raw_date")].table is None
     assert definitions[("sample", "event_date")].transforms == {"parse_date": []}
@@ -120,4 +126,5 @@ def test_pipeline_builds_normalized_table_metadata_without_dataframes():
         ("country", "VARCHAR(64)"),
         ("id", "INT"),
         ("country_id", "INT"),
+        ("event_date", "DATE"),
     ]

--- a/tests/dataset/test_turkey_jetstream.py
+++ b/tests/dataset/test_turkey_jetstream.py
@@ -95,12 +95,12 @@ async def test_turkey_stream(nats_js, fixture_with_config):
     diff_df, missing_cols = compare_dataframes(
         uploaded_df,
         test_data,
-        on=["UmId", "ProductId", "Price", "Place"],
+        on=["UmId", "ProductId", "Price"],
     )
     assert len(diff_df) == 0
-    assert len(missing_cols) == 4
     assert missing_cols == [
         "missing:Month_lhs",
+        "missing:Place_lhs",
         "missing:Year_lhs",
         "missing:price_usd_rhs",
         "missing:time_rhs",
@@ -134,7 +134,6 @@ async def test_turkey_stream(nats_js, fixture_with_config):
 
     assert len(diff_df) == 0
     assert missing_cols == [
-        "missing:Place_lhs",
         "missing:ProductName_lhs",
         "missing:UmName_lhs",
         "missing:time_lhs",

--- a/tests/loaders/test_input_schema.py
+++ b/tests/loaders/test_input_schema.py
@@ -1,0 +1,79 @@
+import polars as pl
+import pytest
+from typing import Literal
+
+from polars_hist_db.config.parser_config import IngestionColumnConfig
+from polars_hist_db.loaders.transform import (
+    InputSchemaError,
+    apply_transformations,
+    enforce_input_schema,
+)
+
+
+def _column(
+    source: str,
+    data_type: str,
+    *,
+    column_type: Literal["data", "input_only"] = "data",
+    nullable: bool = True,
+) -> IngestionColumnConfig:
+    return IngestionColumnConfig(
+        column_type=column_type,
+        schema="sample",
+        table="items" if column_type == "data" else None,
+        ingestion_data_type=data_type,
+        target_data_type=data_type,
+        source=source,
+        target=source if column_type == "data" else None,
+        nullable=nullable,
+    )
+
+
+def test_input_schema_types_nulls_and_drops_declared_input_only_columns() -> None:
+    columns = [
+        _column("id", "INT", nullable=False),
+        _column("note", "VARCHAR(32)"),
+        _column("unused", "VARCHAR(32)", column_type="input_only"),
+    ]
+    first_raw = pl.DataFrame(
+        {"id": [1], "unused": [None]},
+        schema={"id": pl.Int64, "unused": pl.Null},
+    )
+    second_raw = pl.DataFrame({"id": [2], "note": ["ready"], "unused": ["x"]})
+
+    typed = pl.concat(
+        [
+            enforce_input_schema(first_raw, columns),
+            enforce_input_schema(second_raw, columns),
+        ]
+    )
+    transformed = apply_transformations(typed, columns)
+
+    assert typed.schema == {
+        "id": pl.Int32,
+        "note": pl.String,
+        "unused": pl.String,
+    }
+    assert typed.get_column("note").to_list() == [None, "ready"]
+    assert transformed.columns == ["id", "note"]
+
+
+def test_input_schema_rejects_unknown_missing_null_and_conflicting_columns() -> None:
+    required = _column("id", "INT", nullable=False)
+
+    with pytest.raises(InputSchemaError, match="undeclared input columns: surprise"):
+        enforce_input_schema(pl.DataFrame({"id": [1], "surprise": [2]}), [required])
+
+    with pytest.raises(InputSchemaError, match="missing required input column: id"):
+        enforce_input_schema(pl.DataFrame(), [required])
+
+    with pytest.raises(InputSchemaError, match="nulls in required input column: id"):
+        enforce_input_schema(
+            pl.DataFrame({"id": [None]}, schema={"id": pl.Null}), [required]
+        )
+
+    with pytest.raises(InputSchemaError, match="conflicting ingestion types"):
+        enforce_input_schema(
+            pl.DataFrame({"id": [1]}),
+            [required, _column("id", "VARCHAR(8)")],
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1409,7 +1409,7 @@ wheels = [
 
 [[package]]
 name = "polars-hist-db"
-version = "0.12.62"
+version = "0.12.63"
 source = { editable = "." }
 dependencies = [
     { name = "nats-py" },


### PR DESCRIPTION
## Summary
- treat pipeline column metadata as the single authoritative contract for flattened payload input and staged output
- materialize and strictly type each message before batch concatenation, rejecting unknown, missing required, conflicting, incompatible, and invalid-null fields
- add `input_only` fields and derive time-partition staging types without duplicating schemas

## Verification
- `uv run pytest -q` (308 passed, 17 integration tests deselected)
- `uv run pre-commit run --all-files`
- `uv lock --check`