### PR TITLE
feat: support idempotent document access creation

### DIFF
--- a/polars_hist_db/overrides/access.py
+++ b/polars_hist_db/overrides/access.py
@@ -96,20 +96,39 @@ class InMemoryDocumentAccessStore:
         initial_grants: Iterable[AccessGrantInput] = (),
         idempotency_key: str,
         owning_group: str | None = None,
+        allow_existing: bool = False,
     ) -> AccessMutationResult:
         grants = tuple(initial_grants)
-        payload = _payload(
-            "create", document_id, name, description, actor_id, grants, owning_group
+        payload = _create_payload(
+            document_id,
+            name,
+            description,
+            actor_id,
+            grants,
+            owning_group,
+            allow_existing,
         )
         duplicate = self._duplicate(idempotency_key, payload)
         if duplicate is not None:
             return duplicate
+        normalized_name = _normalized(name)
+        existing = next(
+            (
+                doc
+                for doc in self._documents.values()
+                if doc.normalized_name == normalized_name
+            ),
+            None,
+        )
+        if existing is not None and allow_existing:
+            return _existing_result(
+                existing,
+                self.grants(existing.document_id),
+                owning_group,
+            )
         if document_id in self._documents:
             raise DocumentAccessError("document already exists")
-        normalized_name = _normalized(name)
-        if any(
-            doc.normalized_name == normalized_name for doc in self._documents.values()
-        ):
+        if existing is not None:
             raise DocumentAccessError("document name already exists")
         _require_time(recorded_at)
         document = AccessDocument(
@@ -332,6 +351,52 @@ def _normalized(value: str) -> str:
     if not normalized:
         raise DocumentAccessError("name is required")
     return normalized
+
+
+def _create_payload(
+    document_id: str,
+    name: str,
+    description: str | None,
+    actor_id: str,
+    grants: Iterable[AccessGrantInput],
+    owning_group: str | None,
+    allow_existing: bool,
+) -> str:
+    grants = tuple(grants)
+    if allow_existing:
+        return _payload(
+            "create",
+            name,
+            description,
+            actor_id,
+            tuple((grant.group_name, grant.role) for grant in grants),
+            owning_group,
+            "allow_existing",
+        )
+    values: list[object] = [
+        document_id,
+        name,
+        description,
+        actor_id,
+        grants,
+        owning_group,
+    ]
+    return _payload("create", *values)
+
+
+def _existing_result(
+    document: AccessDocument,
+    grants: Iterable[AccessGrant],
+    owning_group: str | None,
+) -> AccessMutationResult:
+    if document.status != "active" or document.owning_group != owning_group:
+        raise DocumentAccessError("document name already exists")
+    return AccessMutationResult(
+        document,
+        tuple(grants),
+        accepted=False,
+        duplicate=True,
+    )
 
 
 def _require_time(value: datetime) -> None:

--- a/polars_hist_db/overrides/sql.py
+++ b/polars_hist_db/overrides/sql.py
@@ -22,6 +22,8 @@ from .access import (
     DocumentNotFound,
     DocumentRevisionConflict,
     IdempotencyConflict,
+    _create_payload,
+    _existing_result,
     _normalized,
     _payload,
     _require_time,
@@ -501,24 +503,34 @@ class MariaDbDocumentAccessStore:
         initial_grants: Sequence[AccessGrantInput] = (),
         idempotency_key: str,
         owning_group: str | None = None,
+        allow_existing: bool = False,
     ) -> AccessMutationResult:
-        payload = _payload(
-            "create",
+        payload = _create_payload(
             document_id,
             name,
             description,
             actor_id,
             initial_grants,
             owning_group,
+            allow_existing,
         )
         duplicate = self._duplicate(idempotency_key, payload)
         if duplicate:
             return duplicate
         _require_time(recorded_at)
+        normalized_name = _normalized(name)
+        if allow_existing:
+            existing = self._by_normalized_name(normalized_name)
+            if existing is not None:
+                return _existing_result(
+                    existing,
+                    self.grants(existing.document_id),
+                    owning_group,
+                )
         document = AccessDocument(
             document_id,
             name,
-            _normalized(name),
+            normalized_name,
             description,
             "active",
             1,
@@ -540,7 +552,26 @@ class MariaDbDocumentAccessStore:
             duplicate = self._duplicate(idempotency_key, payload)
             if duplicate:
                 return duplicate
+            existing = self._by_normalized_name(normalized_name)
+            if existing is not None and allow_existing:
+                return _existing_result(
+                    existing,
+                    self.grants(existing.document_id),
+                    owning_group,
+                )
             raise DocumentAccessError("document or grant already exists") from exc
+
+    def _by_normalized_name(self, normalized_name: str) -> AccessDocument | None:
+        row = (
+            self.connection.execute(
+                select(self.documents).where(
+                    self.documents.c.normalized_name == normalized_name
+                )
+            )
+            .mappings()
+            .first()
+        )
+        return _access_document(row) if row else None
 
     def grant(
         self,

--- a/polars_hist_db/overrides/xtdb.py
+++ b/polars_hist_db/overrides/xtdb.py
@@ -33,6 +33,8 @@ from .access import (
     DocumentNotFound,
     DocumentRevisionConflict,
     IdempotencyConflict,
+    _create_payload,
+    _existing_result,
     _normalized,
     _payload,
     _require_time,
@@ -422,6 +424,24 @@ class XtdbCrdtDocumentStore:
             return []
 
 
+_ACCESS_ASSERTION_MESSAGES = (
+    "idempotency key already exists",
+    "document already exists",
+    "document name already exists",
+    "grant already exists",
+    "group already has an active grant",
+    "document revision changed",
+    "active group grant not found",
+)
+
+
+def _access_assertion_message(exc: Exception) -> str | None:
+    error = str(exc)
+    return next(
+        (message for message in _ACCESS_ASSERTION_MESSAGES if message in error), None
+    )
+
+
 class XtdbDocumentAccessStore:
     """XTDB implementation of the backend-neutral document access contract."""
 
@@ -513,16 +533,31 @@ class XtdbDocumentAccessStore:
         initial_grants: Sequence[AccessGrantInput] = (),
         idempotency_key: str,
         owning_group: str | None = None,
+        allow_existing: bool = False,
     ) -> AccessMutationResult:
         grants = tuple(initial_grants)
-        payload = _payload(
-            "create", document_id, name, description, actor_id, grants, owning_group
+        payload = _create_payload(
+            document_id,
+            name,
+            description,
+            actor_id,
+            grants,
+            owning_group,
+            allow_existing,
         )
         duplicate = self._duplicate(idempotency_key, payload)
         if duplicate:
             return duplicate
         _require_time(recorded_at)
         normalized_name = _normalized(name)
+        if allow_existing:
+            existing = self._by_normalized_name(normalized_name)
+            if existing is not None:
+                return _existing_result(
+                    existing,
+                    self.grants(existing.document_id),
+                    owning_group,
+                )
         if len({grant.grant_id for grant in grants}) != len(grants) or len(
             {grant.group_name.casefold() for grant in grants}
         ) != len(grants):
@@ -562,8 +597,28 @@ class XtdbDocumentAccessStore:
                 idempotency_key, payload, "create", result, recorded_at
             ),
         ]
-        duplicate = self._run(statements, idempotency_key, payload, document_id, None)
+        try:
+            duplicate = self._run(
+                statements, idempotency_key, payload, document_id, None
+            )
+        except DocumentAccessError as exc:
+            if allow_existing and str(exc) == "document name already exists":
+                existing = self._by_normalized_name(normalized_name)
+                if existing is not None:
+                    return _existing_result(
+                        existing,
+                        self.grants(existing.document_id),
+                        owning_group,
+                    )
+            raise
         return result if duplicate is None else duplicate
+
+    def _by_normalized_name(self, normalized_name: str) -> AccessDocument | None:
+        rows = self._rows(
+            f"SELECT {_access_document_columns()} FROM {_table_name(self.documents)} "
+            f"WHERE normalized_name = {_literal(normalized_name, 'VARCHAR(255)')}"
+        )
+        return _access_document_from_row(rows[0]) if rows else None
 
     def grant(
         self,
@@ -778,13 +833,16 @@ class XtdbDocumentAccessStore:
         self._ensure_tables()
         try:
             _execute_xtdb_transaction(self.connection, statements)
-        except Exception:
+        except Exception as exc:
             duplicate = self._duplicate(key, payload)
             if duplicate:
                 return duplicate
             if revision is not None:
                 self._active(document_id, revision)
-            raise DocumentAccessError("access command conflicts") from None
+            conflict = _access_assertion_message(exc)
+            if conflict is not None:
+                raise DocumentAccessError(conflict) from exc
+            raise
         return None
 
     def _ensure_tables(self) -> None:
@@ -801,10 +859,12 @@ class XtdbDocumentAccessStore:
             }
             bootstrap_id = _document_id(config, bootstrap_row)
             _execute_xtdb_transaction(
+                self.connection, [_insert_statement(config, bootstrap_row)]
+            )
+            _execute_xtdb_transaction(
                 self.connection,
                 [
-                    _insert_statement(config, bootstrap_row),
-                    f"ERASE FROM {_table_name(config)} WHERE _id = {_literal(bootstrap_id, 'TEXT')}",
+                    f"ERASE FROM {_table_name(config)} WHERE _id = {_literal(bootstrap_id, 'TEXT')}"
                 ],
             )
 

--- a/tests/backends/test_xtdb_live.py
+++ b/tests/backends/test_xtdb_live.py
@@ -24,6 +24,12 @@ from polars_hist_db.dataset.entrypoint import (
 )
 from polars_hist_db.dataset.scrape import _run_pipeline_as_transaction
 from polars_hist_db.loaders.input_source import BatchFinalizer
+from polars_hist_db.overrides import (
+    AccessGrantInput,
+    DocumentAccessStoreConfig,
+    XtdbDocumentAccessStore,
+    build_document_access_table_configs,
+)
 
 
 pytestmark = [
@@ -127,6 +133,51 @@ def test_xtdb_live_create_append_read_roundtrip():
         "destination": ["Alpha", "Beta"],
         "amount_value": [10.5, 20.25],
     }
+
+
+def test_xtdb_live_document_access_create():
+    suffix = int(time.time())
+    config = DocumentAccessStoreConfig(
+        schema="public",
+        documents_table=f"access_documents_{suffix}",
+        grants_table=f"access_grants_{suffix}",
+        commands_table=f"access_commands_{suffix}",
+    )
+
+    with _xtdb_engine() as engine:
+        backend = XtdbBackend()
+        with backend.connection_scope(engine) as connection:
+            tables = backend.table_configs(connection)
+            for table_config in build_document_access_table_configs(config):
+                tables.create(table_config)
+            store = XtdbDocumentAccessStore(connection, config)
+            result = store.create(
+                "document-1",
+                "Shared layer",
+                None,
+                "user-1",
+                datetime.now(timezone.utc),
+                initial_grants=(AccessGrantInput("grant-1", "group-1", "manager"),),
+                idempotency_key="command-1",
+                owning_group="group-1",
+            )
+            existing = store.create(
+                "document-2",
+                " shared layer ",
+                None,
+                "user-1",
+                datetime.now(timezone.utc),
+                initial_grants=(AccessGrantInput("grant-2", "group-1", "manager"),),
+                idempotency_key="command-2",
+                owning_group="group-1",
+                allow_existing=True,
+            )
+            documents = store.list_all()
+
+    assert result.accepted is True
+    assert existing.document.document_id == "document-1"
+    assert existing.duplicate is True
+    assert [document.document_id for document in documents] == ["document-1"]
 
 
 def test_xtdb_live_reflection_preserves_caller_transaction_without_metadata():

--- a/tests/overrides/test_document_access_store.py
+++ b/tests/overrides/test_document_access_store.py
@@ -4,6 +4,7 @@ import pytest
 
 from polars_hist_db.overrides import (
     AccessGrantInput,
+    DocumentAccessError,
     DocumentArchived,
     DocumentRevisionConflict,
     IdempotencyConflict,
@@ -79,3 +80,89 @@ def test_guard_matches_the_portable_active_revision_contract():
 
     assert guard.key_values == {"document_id": "doc-1"}
     assert guard.expected_values == {"status": "active", "revision": 4}
+
+
+def test_create_can_ensure_an_existing_active_document_for_the_same_owner():
+    store = InMemoryDocumentAccessStore()
+    created = store.create(
+        "doc-1",
+        "Analysts",
+        None,
+        "admin",
+        TIME,
+        initial_grants=[AccessGrantInput("grant-1", "analysts", "manager")],
+        idempotency_key="create-1",
+        owning_group="analysts",
+    )
+
+    existing = store.create(
+        "doc-1",
+        " analysts ",
+        None,
+        "admin",
+        TIME,
+        initial_grants=[AccessGrantInput("grant-2", "analysts", "manager")],
+        idempotency_key="create-2",
+        owning_group="analysts",
+        allow_existing=True,
+    )
+
+    assert existing.document == created.document
+    assert existing.grants == created.grants
+    assert existing.accepted is False
+    assert existing.duplicate is True
+
+
+def test_allow_existing_does_not_cross_ownership_boundaries():
+    store = InMemoryDocumentAccessStore()
+    store.create(
+        "doc-1",
+        "Analysts",
+        None,
+        "admin",
+        TIME,
+        idempotency_key="create-1",
+        owning_group="analysts",
+    )
+
+    with pytest.raises(DocumentAccessError, match="document name already exists"):
+        store.create(
+            "doc-2",
+            "Analysts",
+            None,
+            "admin",
+            TIME,
+            idempotency_key="create-2",
+            owning_group="reviewers",
+            allow_existing=True,
+        )
+
+
+def test_allow_existing_idempotency_ignores_generated_identifiers():
+    store = InMemoryDocumentAccessStore()
+    created = store.create(
+        "generated-doc-1",
+        "Analysts",
+        None,
+        "admin",
+        TIME,
+        initial_grants=[AccessGrantInput("generated-grant-1", "analysts", "manager")],
+        idempotency_key="create-1",
+        owning_group="analysts",
+        allow_existing=True,
+    )
+
+    retried = store.create(
+        "generated-doc-2",
+        "Analysts",
+        None,
+        "admin",
+        TIME,
+        initial_grants=[AccessGrantInput("generated-grant-2", "analysts", "manager")],
+        idempotency_key="create-1",
+        owning_group="analysts",
+        allow_existing=True,
+    )
+
+    assert retried.document == created.document
+    assert retried.duplicate is True

--- a/tests/overrides/test_xtdb_document_access_store.py
+++ b/tests/overrides/test_xtdb_document_access_store.py
@@ -1,7 +1,10 @@
 from datetime import datetime, timezone
 
+import pytest
+
 from polars_hist_db.overrides import (
     AccessGrantInput,
+    DocumentAccessError,
     DocumentAccessStoreConfig,
     XtdbDocumentAccessStore,
 )
@@ -46,3 +49,77 @@ def test_xtdb_access_guard_uses_active_revision():
 
     assert guard.key_values == {"document_id": "document-1"}
     assert guard.expected_values == {"status": "active", "revision": 3}
+
+
+def test_xtdb_access_create_reports_the_assertion_that_conflicted(monkeypatch):
+    store = XtdbDocumentAccessStore(object(), DocumentAccessStoreConfig())
+    monkeypatch.setattr(store, "_duplicate", lambda *_: None)
+    monkeypatch.setattr(store, "_ensure_tables", lambda: None)
+
+    def reject(*_):
+        raise RuntimeError("document name already exists\nDETAIL: assertion failed")
+
+    monkeypatch.setattr(
+        "polars_hist_db.overrides.xtdb._execute_xtdb_transaction", reject
+    )
+
+    with pytest.raises(DocumentAccessError, match="^document name already exists$"):
+        store.create(
+            "document-1",
+            "Shared corrections",
+            None,
+            "user-1",
+            datetime(2026, 7, 12, 11, tzinfo=timezone.utc),
+            idempotency_key="command-1",
+        )
+
+
+def test_xtdb_access_create_does_not_mask_unexpected_database_errors(monkeypatch):
+    store = XtdbDocumentAccessStore(object(), DocumentAccessStoreConfig())
+    monkeypatch.setattr(store, "_duplicate", lambda *_: None)
+    monkeypatch.setattr(store, "_ensure_tables", lambda: None)
+    database_error = RuntimeError("connection closed")
+
+    def reject(*_):
+        raise database_error
+
+    monkeypatch.setattr(
+        "polars_hist_db.overrides.xtdb._execute_xtdb_transaction", reject
+    )
+
+    with pytest.raises(RuntimeError, match="connection closed") as error:
+        store.create(
+            "document-1",
+            "Shared corrections",
+            None,
+            "user-1",
+            datetime(2026, 7, 12, 11, tzinfo=timezone.utc),
+            idempotency_key="command-1",
+        )
+
+    assert error.value is database_error
+
+
+def test_xtdb_access_bootstrap_erases_rows_in_a_followup_transaction(monkeypatch):
+    transactions: list[list[str]] = []
+    store = XtdbDocumentAccessStore(object(), DocumentAccessStoreConfig())
+    monkeypatch.setattr(store, "_rows", lambda *_: [])
+    monkeypatch.setattr(
+        "polars_hist_db.overrides.xtdb._execute_xtdb_transaction",
+        lambda _, statements: transactions.append(list(statements)),
+    )
+
+    store._ensure_tables()
+
+    assert len(transactions) == 6
+    assert all(len(transaction) == 1 for transaction in transactions)
+    assert [
+        transaction[0].lstrip().split(maxsplit=1)[0] for transaction in transactions
+    ] == [
+        "INSERT",
+        "ERASE",
+        "INSERT",
+        "ERASE",
+        "INSERT",
+        "ERASE",
+    ]

--- a/tests/sql/test_document_access_store.py
+++ b/tests/sql/test_document_access_store.py
@@ -53,6 +53,16 @@ def test_mariadb_access_store_persists_lifecycle_and_idempotency():
                 initial_grants=(AccessGrantInput("grant-1", "operators", "editor"),),
                 idempotency_key="command-1",
             )
+            existing = store.create(
+                "document-2",
+                " shared corrections ",
+                None,
+                "user-1",
+                now,
+                initial_grants=(AccessGrantInput("grant-2", "operators", "editor"),),
+                idempotency_key="command-ensure",
+                allow_existing=True,
+            )
             revoked = store.revoke(
                 "document-1",
                 "operators",
@@ -68,6 +78,8 @@ def test_mariadb_access_store_persists_lifecycle_and_idempotency():
             assert created.document.revision == 1
             assert duplicate.duplicate is True
             assert duplicate.document.created_at == now
+            assert existing.document.document_id == "document-1"
+            assert existing.duplicate is True
             assert revoked.grants[0].active is False
             assert archived.document.status == "archived"
             with pytest.raises(DocumentArchived):


### PR DESCRIPTION
## Summary
- add an opt-in allow_existing document-access create contract across in-memory, MariaDB, and XTDB stores
- preserve semantic idempotency when callers regenerate storage identifiers
- report known XTDB assertion conflicts precisely and preserve unexpected database errors
- erase XTDB bootstrap sentinels in a follow-up transaction

## Verification
- 313 non-integration tests passed
- ruff and mypy passed
- added MariaDB and XTDB live coverage for ensure semantics and sentinel cleanup