### PR TITLE
feat: scope document names by owning group

### DIFF
--- a/polars_hist_db/overrides/access.py
+++ b/polars_hist_db/overrides/access.py
@@ -116,7 +116,8 @@ class InMemoryDocumentAccessStore:
             (
                 doc
                 for doc in self._documents.values()
-                if doc.normalized_name == normalized_name
+                if doc.owning_group == owning_group
+                and doc.normalized_name == normalized_name
             ),
             None,
         )

--- a/polars_hist_db/overrides/config.py
+++ b/polars_hist_db/overrides/config.py
@@ -77,7 +77,7 @@ def build_document_access_table_configs(
                 "normalized_name",
                 "VARCHAR(255)",
                 nullable=False,
-                unique_constraint=["document_access_normalized_name"],
+                unique_constraint=["document_access_group_name"],
             ),
             TableColumnConfig(config.documents_table, "description", "MEDIUMTEXT"),
             TableColumnConfig(
@@ -92,7 +92,12 @@ def build_document_access_table_configs(
             TableColumnConfig(
                 config.documents_table, "created_at", "DATETIME(6)", nullable=False
             ),
-            TableColumnConfig(config.documents_table, "owning_group", "VARCHAR(255)"),
+            TableColumnConfig(
+                config.documents_table,
+                "owning_group",
+                "VARCHAR(255)",
+                unique_constraint=["document_access_group_name"],
+            ),
             TableColumnConfig(
                 config.documents_table,
                 "generation",

--- a/polars_hist_db/overrides/sql.py
+++ b/polars_hist_db/overrides/sql.py
@@ -520,7 +520,7 @@ class MariaDbDocumentAccessStore:
         _require_time(recorded_at)
         normalized_name = _normalized(name)
         if allow_existing:
-            existing = self._by_normalized_name(normalized_name)
+            existing = self._by_group_and_name(owning_group, normalized_name)
             if existing is not None:
                 return _existing_result(
                     existing,
@@ -552,7 +552,7 @@ class MariaDbDocumentAccessStore:
             duplicate = self._duplicate(idempotency_key, payload)
             if duplicate:
                 return duplicate
-            existing = self._by_normalized_name(normalized_name)
+            existing = self._by_group_and_name(owning_group, normalized_name)
             if existing is not None and allow_existing:
                 return _existing_result(
                     existing,
@@ -561,11 +561,19 @@ class MariaDbDocumentAccessStore:
                 )
             raise DocumentAccessError("document or grant already exists") from exc
 
-    def _by_normalized_name(self, normalized_name: str) -> AccessDocument | None:
+    def _by_group_and_name(
+        self, owning_group: str | None, normalized_name: str
+    ) -> AccessDocument | None:
+        group_match = (
+            self.documents.c.owning_group.is_(None)
+            if owning_group is None
+            else self.documents.c.owning_group == owning_group
+        )
         row = (
             self.connection.execute(
                 select(self.documents).where(
-                    self.documents.c.normalized_name == normalized_name
+                    group_match,
+                    self.documents.c.normalized_name == normalized_name,
                 )
             )
             .mappings()

--- a/polars_hist_db/overrides/xtdb.py
+++ b/polars_hist_db/overrides/xtdb.py
@@ -442,6 +442,12 @@ def _access_assertion_message(exc: Exception) -> str | None:
     )
 
 
+def _owning_group_predicate(owning_group: str | None) -> str:
+    if owning_group is None:
+        return "owning_group IS NULL"
+    return f"owning_group = {_literal(owning_group, 'VARCHAR(255)')}"
+
+
 class XtdbDocumentAccessStore:
     """XTDB implementation of the backend-neutral document access contract."""
 
@@ -551,7 +557,7 @@ class XtdbDocumentAccessStore:
         _require_time(recorded_at)
         normalized_name = _normalized(name)
         if allow_existing:
-            existing = self._by_normalized_name(normalized_name)
+            existing = self._by_group_and_name(owning_group, normalized_name)
             if existing is not None:
                 return _existing_result(
                     existing,
@@ -583,7 +589,7 @@ class XtdbDocumentAccessStore:
         statements = [
             self._command_assertion(idempotency_key),
             f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.documents)} WHERE _id = {_literal(document_id, 'VARCHAR(128)')}), 'document already exists'",
-            f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.documents)} WHERE normalized_name = {_literal(normalized_name, 'VARCHAR(255)')}), 'document name already exists'",
+            f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.documents)} WHERE {_owning_group_predicate(owning_group)} AND normalized_name = {_literal(normalized_name, 'VARCHAR(255)')}), 'document name already exists'",
             *(
                 f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.grants_table)} WHERE _id = {_literal(grant.grant_id, 'VARCHAR(128)')}), 'grant already exists'"
                 for grant in grants
@@ -603,7 +609,7 @@ class XtdbDocumentAccessStore:
             )
         except DocumentAccessError as exc:
             if allow_existing and str(exc) == "document name already exists":
-                existing = self._by_normalized_name(normalized_name)
+                existing = self._by_group_and_name(owning_group, normalized_name)
                 if existing is not None:
                     return _existing_result(
                         existing,
@@ -613,10 +619,13 @@ class XtdbDocumentAccessStore:
             raise
         return result if duplicate is None else duplicate
 
-    def _by_normalized_name(self, normalized_name: str) -> AccessDocument | None:
+    def _by_group_and_name(
+        self, owning_group: str | None, normalized_name: str
+    ) -> AccessDocument | None:
         rows = self._rows(
             f"SELECT {_access_document_columns()} FROM {_table_name(self.documents)} "
-            f"WHERE normalized_name = {_literal(normalized_name, 'VARCHAR(255)')}"
+            f"WHERE {_owning_group_predicate(owning_group)} AND "
+            f"normalized_name = {_literal(normalized_name, 'VARCHAR(255)')}"
         )
         return _access_document_from_row(rows[0]) if rows else None
 

--- a/tests/backends/test_xtdb_live.py
+++ b/tests/backends/test_xtdb_live.py
@@ -172,12 +172,27 @@ def test_xtdb_live_document_access_create():
                 owning_group="group-1",
                 allow_existing=True,
             )
+            other_group = store.create(
+                "document-3",
+                "Shared layer",
+                None,
+                "user-2",
+                datetime.now(timezone.utc),
+                initial_grants=(AccessGrantInput("grant-3", "group-2", "manager"),),
+                idempotency_key="command-3",
+                owning_group="group-2",
+                allow_existing=True,
+            )
             documents = store.list_all()
 
     assert result.accepted is True
     assert existing.document.document_id == "document-1"
     assert existing.duplicate is True
-    assert [document.document_id for document in documents] == ["document-1"]
+    assert other_group.document.document_id == "document-3"
+    assert {document.document_id for document in documents} == {
+        "document-1",
+        "document-3",
+    }
 
 
 def test_xtdb_live_reflection_preserves_caller_transaction_without_metadata():

--- a/tests/overrides/test_crdt_table_config.py
+++ b/tests/overrides/test_crdt_table_config.py
@@ -4,8 +4,10 @@ from sqlalchemy.dialects import mysql
 
 from polars_hist_db.overrides import (
     CrdtDocumentStoreConfig,
+    DocumentAccessStoreConfig,
     build_crdt_document_table_config,
     build_crdt_update_table_config,
+    build_document_access_table_configs,
 )
 
 
@@ -68,3 +70,14 @@ def test_crdt_document_tables_compile_mediumtext_for_mariadb():
     ddl = str(CreateTable(table).compile(dialect=mysql.dialect()))
 
     assert "MEDIUMTEXT" in ddl
+
+
+def test_document_names_are_unique_within_the_owning_group():
+    documents, _, _ = build_document_access_table_configs(DocumentAccessStoreConfig())
+    constrained = {
+        column.name
+        for column in documents.columns
+        if "document_access_group_name" in column.unique_constraint
+    }
+
+    assert constrained == {"normalized_name", "owning_group"}

--- a/tests/overrides/test_document_access_store.py
+++ b/tests/overrides/test_document_access_store.py
@@ -4,7 +4,6 @@ import pytest
 
 from polars_hist_db.overrides import (
     AccessGrantInput,
-    DocumentAccessError,
     DocumentArchived,
     DocumentRevisionConflict,
     IdempotencyConflict,
@@ -113,7 +112,7 @@ def test_create_can_ensure_an_existing_active_document_for_the_same_owner():
     assert existing.duplicate is True
 
 
-def test_allow_existing_does_not_cross_ownership_boundaries():
+def test_same_name_can_exist_in_different_ownership_scopes():
     store = InMemoryDocumentAccessStore()
     store.create(
         "doc-1",
@@ -125,17 +124,20 @@ def test_allow_existing_does_not_cross_ownership_boundaries():
         owning_group="analysts",
     )
 
-    with pytest.raises(DocumentAccessError, match="document name already exists"):
-        store.create(
-            "doc-2",
-            "Analysts",
-            None,
-            "admin",
-            TIME,
-            idempotency_key="create-2",
-            owning_group="reviewers",
-            allow_existing=True,
-        )
+    created = store.create(
+        "doc-2",
+        "Analysts",
+        None,
+        "admin",
+        TIME,
+        idempotency_key="create-2",
+        owning_group="reviewers",
+        allow_existing=True,
+    )
+
+    assert created.document.document_id == "doc-2"
+    assert created.document.owning_group == "reviewers"
+    assert created.accepted is True
 
 
 def test_allow_existing_idempotency_ignores_generated_identifiers():

--- a/tests/overrides/test_xtdb_document_access_store.py
+++ b/tests/overrides/test_xtdb_document_access_store.py
@@ -28,11 +28,17 @@ def test_xtdb_access_create_submits_one_asserted_transaction(monkeypatch):
         datetime(2026, 7, 12, 11, tzinfo=timezone.utc),
         initial_grants=(AccessGrantInput("grant-1", "operators", "editor"),),
         idempotency_key="command-1",
+        owning_group="operators",
     )
 
     assert result.accepted is True
     assert result.document.revision == 1
     assert statements[0].startswith("ASSERT NOT EXISTS")
+    name_assertion = next(
+        statement for statement in statements if "normalized_name" in statement
+    )
+    assert "owning_group = 'operators'" in name_assertion
+    assert "normalized_name = 'shared corrections'" in name_assertion
     assert any("INSERT INTO overrides.document_access" in item for item in statements)
     assert any(
         "INSERT INTO overrides.document_access_grants" in item for item in statements

--- a/tests/sql/test_document_access_store.py
+++ b/tests/sql/test_document_access_store.py
@@ -43,6 +43,7 @@ def test_mariadb_access_store_persists_lifecycle_and_idempotency():
                 now,
                 initial_grants=(AccessGrantInput("grant-1", "operators", "editor"),),
                 idempotency_key="command-1",
+                owning_group="operators",
             )
             duplicate = store.create(
                 "document-1",
@@ -52,6 +53,7 @@ def test_mariadb_access_store_persists_lifecycle_and_idempotency():
                 now,
                 initial_grants=(AccessGrantInput("grant-1", "operators", "editor"),),
                 idempotency_key="command-1",
+                owning_group="operators",
             )
             existing = store.create(
                 "document-2",
@@ -61,6 +63,18 @@ def test_mariadb_access_store_persists_lifecycle_and_idempotency():
                 now,
                 initial_grants=(AccessGrantInput("grant-2", "operators", "editor"),),
                 idempotency_key="command-ensure",
+                owning_group="operators",
+                allow_existing=True,
+            )
+            other_group = store.create(
+                "document-3",
+                "Shared corrections",
+                None,
+                "user-2",
+                now,
+                initial_grants=(AccessGrantInput("grant-3", "reviewers", "editor"),),
+                idempotency_key="command-other-group",
+                owning_group="reviewers",
                 allow_existing=True,
             )
             revoked = store.revoke(
@@ -80,6 +94,7 @@ def test_mariadb_access_store_persists_lifecycle_and_idempotency():
             assert duplicate.document.created_at == now
             assert existing.document.document_id == "document-1"
             assert existing.duplicate is True
+            assert other_group.document.document_id == "document-3"
             assert revoked.grants[0].active is False
             assert archived.document.status == "archived"
             with pytest.raises(DocumentArchived):


### PR DESCRIPTION
## Summary
- enforce document-name uniqueness within each owning group
- preserve idempotent create semantics within a group
- cover in-memory, MariaDB, and XTDB implementations

## Verification
- unit tests for access stores and table configuration
- backend live tests updated for same-name documents across groups
- ruff and mypy pre-commit checks pass