### PR TITLE
fix: preserve native XTDB document identifiers

### DIFF
--- a/polars_hist_db/overrides/xtdb.py
+++ b/polars_hist_db/overrides/xtdb.py
@@ -152,7 +152,7 @@ class XtdbCrdtDocumentStore:
         document_id_sql = _literal(document_id, "VARCHAR(128)")
         head = self._rows(
             f"SELECT document_id, revision FROM {_table_name(self.documents)} "
-            f"WHERE _id = {document_id_sql}"
+            f"WHERE document_id = {document_id_sql}"
         )
         if not head:
             return None
@@ -190,7 +190,7 @@ class XtdbCrdtDocumentStore:
             [
                 f"ERASE FROM {_table_name(self.projection)} WHERE crdt_document_id = {value}",
                 f"ERASE FROM {_table_name(self.updates)} WHERE document_id = {value}",
-                f"ERASE FROM {_table_name(self.documents)} WHERE _id = {value}",
+                f"ERASE FROM {_table_name(self.documents)} WHERE document_id = {value}",
             ],
         )
 
@@ -312,11 +312,11 @@ class XtdbCrdtDocumentStore:
     def _revision_assertion(self, prepared: PreparedCrdtCommit) -> str:
         document_id = _literal(prepared.document_id, "VARCHAR(128)")
         if prepared.base_revision == 0:
-            predicate = f"NOT EXISTS (SELECT 1 FROM {_table_name(self.documents)} WHERE _id = {document_id})"
+            predicate = f"NOT EXISTS (SELECT 1 FROM {_table_name(self.documents)} WHERE document_id = {document_id})"
         else:
             predicate = (
                 "EXISTS (SELECT 1 FROM "
-                f"{_table_name(self.documents)} WHERE _id = {document_id} "
+                f"{_table_name(self.documents)} WHERE document_id = {document_id} "
                 f"AND revision = {prepared.base_revision}::BIGINT)"
             )
         return f"ASSERT {predicate}, 'CRDT document revision changed'"
@@ -405,12 +405,11 @@ class XtdbCrdtDocumentStore:
                 column.name: _bootstrap_value(column.data_type)
                 for column in config.columns
             }
-            bootstrap_id = _document_id(config, bootstrap_row)
             _execute_xtdb_transaction(
                 self.connection,
                 [
                     _insert_statement(config, bootstrap_row),
-                    f"ERASE FROM {table_name} WHERE _id = {_literal(bootstrap_id, 'TEXT')}",
+                    f"ERASE FROM {table_name} WHERE {_where(config, {key: bootstrap_row[key] for key in config.primary_keys})}",
                 ],
             )
 
@@ -460,7 +459,7 @@ class XtdbDocumentAccessStore:
     def get(self, document_id: str) -> AccessDocument | None:
         rows = self._rows(
             f"SELECT {_access_document_columns()} FROM {_table_name(self.documents)} "
-            f"WHERE _id = {_literal(document_id, 'VARCHAR(128)')}"
+            f"WHERE document_id = {_literal(document_id, 'VARCHAR(128)')}"
         )
         return _access_document_from_row(rows[0]) if rows else None
 
@@ -522,7 +521,7 @@ class XtdbDocumentAccessStore:
         _execute_xtdb_transaction(
             self.connection,
             [
-                f"ASSERT EXISTS (SELECT 1 FROM {_table_name(self.documents)} WHERE _id = {_literal(document_id, 'VARCHAR(128)')} AND generation = {expected_generation}::BIGINT), 'document generation changed'",
+                f"ASSERT EXISTS (SELECT 1 FROM {_table_name(self.documents)} WHERE document_id = {_literal(document_id, 'VARCHAR(128)')} AND generation = {expected_generation}::BIGINT), 'document generation changed'",
                 _access_update(self.documents, document_id, {"status": "purging"}),
             ],
         )
@@ -588,10 +587,10 @@ class XtdbDocumentAccessStore:
         )
         statements = [
             self._command_assertion(idempotency_key),
-            f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.documents)} WHERE _id = {_literal(document_id, 'VARCHAR(128)')}), 'document already exists'",
+            f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.documents)} WHERE document_id = {_literal(document_id, 'VARCHAR(128)')}), 'document already exists'",
             f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.documents)} WHERE {_owning_group_predicate(owning_group)} AND normalized_name = {_literal(normalized_name, 'VARCHAR(255)')}), 'document name already exists'",
             *(
-                f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.grants_table)} WHERE _id = {_literal(grant.grant_id, 'VARCHAR(128)')}), 'grant already exists'"
+                f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.grants_table)} WHERE grant_id = {_literal(grant.grant_id, 'VARCHAR(128)')}), 'grant already exists'"
                 for grant in grants
             ),
             _insert_statement(self.documents, _document_row(document)),
@@ -653,7 +652,7 @@ class XtdbDocumentAccessStore:
         statements = [
             self._command_assertion(idempotency_key),
             self._active_assertion(document_id, expected_revision),
-            f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.grants_table)} WHERE _id = {_literal(grant.grant_id, 'VARCHAR(128)')}), 'grant already exists'",
+            f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.grants_table)} WHERE grant_id = {_literal(grant.grant_id, 'VARCHAR(128)')}), 'grant already exists'",
             f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.grants_table)} WHERE active_group_key = {_literal(_active_group_key(document_id, grant.group_name), 'VARCHAR(512)')}), 'group already has an active grant'",
             _access_update(self.documents, document_id, {"revision": updated.revision}),
             _insert_statement(self.grants_table, _grant_row(new_grant)),
@@ -707,7 +706,7 @@ class XtdbDocumentAccessStore:
         statements = [
             self._command_assertion(idempotency_key),
             self._active_assertion(document_id, expected_revision),
-            f"ASSERT EXISTS (SELECT 1 FROM {_table_name(self.grants_table)} WHERE _id = {_literal(active_grant.grant_id, 'VARCHAR(128)')} AND revoked_at IS NULL), 'active group grant not found'",
+            f"ASSERT EXISTS (SELECT 1 FROM {_table_name(self.grants_table)} WHERE grant_id = {_literal(active_grant.grant_id, 'VARCHAR(128)')} AND revoked_at IS NULL), 'active group grant not found'",
             _access_update(self.documents, document_id, {"revision": updated.revision}),
             _access_update(
                 self.grants_table,
@@ -792,7 +791,7 @@ class XtdbDocumentAccessStore:
     def _duplicate(self, key: str, payload: str) -> AccessMutationResult | None:
         rows = self._rows(
             f"SELECT payload_hash, result_json FROM {_table_name(self.commands)} "
-            f"WHERE _id = {_literal(key, 'VARCHAR(128)')}"
+            f"WHERE idempotency_key = {_literal(key, 'VARCHAR(128)')}"
         )
         if not rows:
             return None
@@ -803,12 +802,12 @@ class XtdbDocumentAccessStore:
         return _access_result_from_json(rows[0]["result_json"], duplicate=True)
 
     def _command_assertion(self, key: str) -> str:
-        return f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.commands)} WHERE _id = {_literal(key, 'VARCHAR(128)')}), 'idempotency key already exists'"
+        return f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.commands)} WHERE idempotency_key = {_literal(key, 'VARCHAR(128)')}), 'idempotency key already exists'"
 
     def _active_assertion(self, document_id: str, revision: int) -> str:
         return (
             f"ASSERT EXISTS (SELECT 1 FROM {_table_name(self.documents)} WHERE "
-            f"_id = {_literal(document_id, 'VARCHAR(128)')} AND status = 'active' "
+            f"document_id = {_literal(document_id, 'VARCHAR(128)')} AND status = 'active' "
             f"AND revision = {revision}::BIGINT), 'document revision changed'"
         )
 
@@ -866,14 +865,13 @@ class XtdbDocumentAccessStore:
                 column.name: _bootstrap_value(column.data_type)
                 for column in config.columns
             }
-            bootstrap_id = _document_id(config, bootstrap_row)
             _execute_xtdb_transaction(
                 self.connection, [_insert_statement(config, bootstrap_row)]
             )
             _execute_xtdb_transaction(
                 self.connection,
                 [
-                    f"ERASE FROM {_table_name(config)} WHERE _id = {_literal(bootstrap_id, 'TEXT')}"
+                    f"ERASE FROM {_table_name(config)} WHERE {_where(config, {key: bootstrap_row[key] for key in config.primary_keys})}"
                 ],
             )
 
@@ -1041,7 +1039,7 @@ def _access_update(
     )
     return (
         f"UPDATE {_table_name(config)} SET {assignments} WHERE "
-        f"_id = {_literal(document_id, 'VARCHAR(128)')}"
+        f"{_where(config, {next(iter(config.primary_keys)): document_id})}"
     )
 
 

--- a/tests/backends/test_xtdb_live.py
+++ b/tests/backends/test_xtdb_live.py
@@ -137,6 +137,7 @@ def test_xtdb_live_create_append_read_roundtrip():
 
 def test_xtdb_live_document_access_create():
     suffix = int(time.time())
+    document_id = "e9ca81c9-6116-4247-b951-185e82033440"
     config = DocumentAccessStoreConfig(
         schema="public",
         documents_table=f"access_documents_{suffix}",
@@ -152,7 +153,7 @@ def test_xtdb_live_document_access_create():
                 tables.create(table_config)
             store = XtdbDocumentAccessStore(connection, config)
             result = store.create(
-                "document-1",
+                document_id,
                 "Shared layer",
                 None,
                 "user-1",
@@ -184,15 +185,17 @@ def test_xtdb_live_document_access_create():
                 allow_existing=True,
             )
             documents = store.list_all()
+            loaded = store.get(document_id)
 
     assert result.accepted is True
-    assert existing.document.document_id == "document-1"
+    assert existing.document.document_id == document_id
     assert existing.duplicate is True
     assert other_group.document.document_id == "document-3"
     assert {document.document_id for document in documents} == {
-        "document-1",
+        document_id,
         "document-3",
     }
+    assert loaded == result.document
 
 
 def test_xtdb_live_reflection_preserves_caller_transaction_without_metadata():

--- a/tests/overrides/test_xtdb_document_access_store.py
+++ b/tests/overrides/test_xtdb_document_access_store.py
@@ -57,6 +57,17 @@ def test_xtdb_access_guard_uses_active_revision():
     assert guard.expected_values == {"status": "active", "revision": 3}
 
 
+def test_xtdb_access_get_uses_logical_key_not_native_id(monkeypatch):
+    queries: list[str] = []
+    store = XtdbDocumentAccessStore(object(), DocumentAccessStoreConfig())
+    monkeypatch.setattr(store, "_rows", lambda sql: queries.append(sql) or [])
+
+    store.get("e9ca81c9-6116-4247-b951-185e82033440")
+
+    assert "WHERE document_id =" in queries[0]
+    assert "WHERE _id =" not in queries[0]
+
+
 def test_xtdb_access_create_reports_the_assertion_that_conflicted(monkeypatch):
     store = XtdbDocumentAccessStore(object(), DocumentAccessStoreConfig())
     monkeypatch.setattr(store, "_duplicate", lambda *_: None)

--- a/uv.lock
+++ b/uv.lock
@@ -1370,7 +1370,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1409,7 +1409,7 @@ wheels = [
 
 [[package]]
 name = "polars-hist-db"
-version = "0.12.65"
+version = "0.12.66"
 source = { editable = "." }
 dependencies = [
     { name = "nats-py" },


### PR DESCRIPTION
## Summary
- query configured logical primary-key columns instead of casting the native XTDB identifier
- apply the same rule to CRDT lookup, access lifecycle assertions, updates, erasure, and idempotency checks
- cover UUID-shaped identifiers in the live XTDB access test

## Verification
- override tests: 51 passed
- Ruff passed
- pre-commit hooks, including mypy, passed