### PR TITLE
perf: cache reflected table metadata

### DIFF
--- a/polars_hist_db/core/table.py
+++ b/polars_hist_db/core/table.py
@@ -20,6 +20,7 @@ from .db import DbOps
 
 
 LOGGER = logging.getLogger(__name__)
+_TABLE_METADATA_CACHE_ATTR = "_polars_hist_db_table_metadata_cache"
 
 
 class TableOps:
@@ -27,6 +28,20 @@ class TableOps:
         self.connection = connection
         self.table_schema = table_schema
         self.table_name = table_name
+
+    @staticmethod
+    def invalidate_metadata(
+        connection: Connection,
+        table_schema: str | None = None,
+        table_name: str | None = None,
+    ) -> None:
+        cache = getattr(connection, _TABLE_METADATA_CACHE_ATTR, None)
+        if not isinstance(cache, dict):
+            return
+        if table_schema is None or table_name is None:
+            cache.clear()
+            return
+        cache.pop((table_schema, table_name), None)
 
     def enable_system_versioning(
         self,
@@ -46,6 +61,7 @@ class TableOps:
         result = DbOps(self.connection).execute_sqlalchemy(
             "sql.op.enable_system_versioning", text(sql)
         )
+        self.invalidate_metadata(self.connection, self.table_schema, self.table_name)
         LOGGER.debug("enabled system versioning %s", result)
 
     def get_table_metadata(
@@ -56,6 +72,15 @@ class TableOps:
         if not autoload_metadata:
             return Table(self.table_name, metadata)
 
+        cache = getattr(self.connection, _TABLE_METADATA_CACHE_ATTR, None)
+        if not isinstance(cache, dict):
+            cache = {}
+            setattr(self.connection, _TABLE_METADATA_CACHE_ATTR, cache)
+        cache_key = (self.table_schema, self.table_name)
+        cached = cache.get(cache_key)
+        if isinstance(cached, Table):
+            return cached
+
         with warnings.catch_warnings():
             # skip this annoying SQLAlchemy warning:
             # SAWarning: Unknown schema content: '  PERIOD FOR SYSTEM_TIME (`__valid_from`, `__valid_to`),'
@@ -64,6 +89,7 @@ class TableOps:
 
             tbl = Table(self.table_name, metadata, autoload_with=self.connection)
 
+        cache[cache_key] = tbl
         return tbl
 
     def row_count(self) -> int:

--- a/polars_hist_db/core/table_config.py
+++ b/polars_hist_db/core/table_config.py
@@ -139,6 +139,7 @@ class TableConfigOps:
         if tbo.table_exists():
             tbl = tbo.get_table_metadata()
             tbl.drop(self.connection, checkfirst=True)
+            TableOps.invalidate_metadata(self.connection, table_schema, table_name)
             LOGGER.info("dropped table %s", table_name)
 
     def _create_temporal(
@@ -179,6 +180,9 @@ class TableConfigOps:
                     f"ALTER TABLE {tbo.table_schema}.{tbo.table_name} "
                     f"ADD COLUMN {column_sql}"
                 ),
+            )
+            TableOps.invalidate_metadata(
+                self.connection, tbo.table_schema, tbo.table_name
             )
 
     def _create_nontemporal(
@@ -252,6 +256,7 @@ class TableConfigOps:
         DbOps(self.connection).execute_sqlalchemy(
             f"sql.base.table_create.{table_name}", create_stmt
         )
+        TableOps.invalidate_metadata(self.connection, tbo.table_schema, tbo.table_name)
 
         LOGGER.debug("created table %s.%s", tbo.table_schema, tbo.table_name)
 

--- a/tests/core/test_table_metadata_cache.py
+++ b/tests/core/test_table_metadata_cache.py
@@ -1,0 +1,45 @@
+from sqlalchemy import Column, create_engine, Integer, MetaData, Table, text
+
+from polars_hist_db.config.table import TableColumnConfig, TableConfig
+from polars_hist_db.core.table import TableOps
+from polars_hist_db.core.table_config import TableConfigOps
+
+
+def test_table_metadata_is_cached_per_connection_and_can_be_invalidated():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.connect() as connection:
+        Table("items", MetaData(), Column("id", Integer)).create(connection)
+        ops = TableOps("main", "items", connection)
+
+        first = ops.get_table_metadata()
+        assert ops.get_table_metadata() is first
+
+        connection.execute(text("ALTER TABLE items ADD COLUMN value INTEGER"))
+        assert "value" not in ops.get_table_metadata().columns
+
+        TableOps.invalidate_metadata(connection, "main", "items")
+        refreshed = ops.get_table_metadata()
+        assert refreshed is not first
+        assert "value" in refreshed.columns
+
+
+def test_table_config_ddl_invalidates_cached_metadata():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.connect() as connection:
+        Table("items", MetaData(), Column("id", Integer)).create(connection)
+        ops = TableOps("main", "items", connection)
+        cached = ops.get_table_metadata()
+        config = TableConfig(
+            "items",
+            "main",
+            [
+                TableColumnConfig("items", "id", "INTEGER"),
+                TableColumnConfig("items", "value", "INTEGER"),
+            ],
+        )
+
+        TableConfigOps(connection)._add_missing_columns(ops, config)
+
+        refreshed = ops.get_table_metadata()
+        assert refreshed is not cached
+        assert "value" in refreshed.columns


### PR DESCRIPTION
## Summary

- cache reflected SQLAlchemy table metadata on the active connection
- reuse metadata across operations within the same connection/run
- invalidate cached entries after table creation, deletion, column additions, and temporal schema changes
- cover cache reuse, explicit refresh, and automatic DDL invalidation

## Validation

- 336 non-integration tests passed, 1 skipped, 19 deselected
- mypy passed for 168 source files
- Ruff check and format passed