### PR TITLE
perf(xtdb): upload key relations for joins

### DIFF
--- a/benchmarks/xtdb_delta.py
+++ b/benchmarks/xtdb_delta.py
@@ -43,6 +43,16 @@ from polars_hist_db.overrides import (
 class CurrentRows:
     frame: pl.DataFrame
 
+    @property
+    def connection(self) -> "CurrentRows":
+        return self
+
+    def table_insert(self, df: pl.DataFrame, *_args: Any, **_kwargs: Any) -> int:
+        return len(df)
+
+    def execute(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
     def from_raw_sql(self, sql: str, *_args: Any) -> pl.DataFrame:
         if "__xtdb_minimum_id" in sql:
             return pl.DataFrame(

--- a/polars_hist_db/backends/xtdb_dataframe.py
+++ b/polars_hist_db/backends/xtdb_dataframe.py
@@ -1,5 +1,8 @@
+from contextlib import contextmanager
 from datetime import datetime
-from typing import Any, Mapping, Optional, cast
+import logging
+from typing import Any, Iterator, Mapping, Optional, cast
+from uuid import uuid4
 
 import polars as pl
 
@@ -19,6 +22,7 @@ from .xtdb_transport import (
 
 
 _XTDB_QUERY_ROWS_PER_CHUNK = 10_000
+LOGGER = logging.getLogger(__name__)
 
 
 def _table_config_ops(connection: Any) -> Any:
@@ -107,7 +111,6 @@ class XtdbDataframeOps:
             _xtdb_table_query_target_column,
             _xtdb_temporal_basis_clause,
             _xtdb_valid_time_clause,
-            _xtdb_values_cte,
         )
 
         if table_config is None:
@@ -171,30 +174,25 @@ class XtdbDataframeOps:
         chunk_size = self.max_rows_per_insert or _XTDB_QUERY_ROWS_PER_CHUNK
         chunks = []
         for query_chunk in query_df.iter_slices(chunk_size):
-            values_cte, parameters = _xtdb_values_cte("query_df", query_chunk)
             join_clause = " AND ".join(
                 "t."
                 f"{_xtdb_table_query_target_column(column, table_config)} = "
                 f"q.{_xtdb_column_identifier(column)}"
                 for column in query_chunk.columns
             )
-            query = (
-                f"WITH {values_cte} "
-                f"SELECT {select_sql} "
-                "FROM ("
-                "SELECT *, _valid_from, _valid_to "
-                f"FROM {table_sql}{valid_time_clause}"
-                ") AS t "
-                "JOIN query_df AS q "
-                f"ON {join_clause}"
-            )
-            chunks.append(
-                self.from_raw_sql(
-                    query,
-                    schema_overrides,
-                    {"parameters": parameters},
+            with _uploaded_xtdb_relation(
+                self, query_chunk, table_schema
+            ) as query_table:
+                query = (
+                    f"SELECT {select_sql} "
+                    "FROM ("
+                    "SELECT *, _valid_from, _valid_to "
+                    f"FROM {table_sql}{valid_time_clause}"
+                    ") AS t "
+                    f"JOIN {query_table} AS q "
+                    f"ON {join_clause}"
                 )
-            )
+                chunks.append(self.from_raw_sql(query, schema_overrides))
         df = pl.concat(chunks, how="vertical_relaxed")
         for temporal_column in ["__valid_from", "__valid_to"]:
             if (
@@ -387,3 +385,53 @@ class XtdbAdbcDataframeOps:
                     db_schema_name=table_schema,
                 )
         return df.height
+
+
+@contextmanager
+def _uploaded_xtdb_relation(
+    dataframe_ops: XtdbDataframeOps | XtdbAdbcDataframeOps,
+    df: pl.DataFrame,
+    table_schema: str,
+) -> Iterator[str]:
+    from .xtdb_arrow import _xtdb_physical_column_name
+    from .xtdb_transport import _is_xtdb_table_not_found_error
+
+    table_name = f"__polars_hist_db_keys_{uuid4().hex}"
+    table_sql = _qualified_table_name(table_schema, table_name)
+    physical_columns = {
+        column: _xtdb_physical_column_name(column)
+        for column in df.columns
+        if column != _xtdb_physical_column_name(column)
+    }
+    upload_df = df.rename(physical_columns)
+    if "_id" not in upload_df.columns:
+        upload_df = upload_df.with_row_index("_id")
+
+    failed = False
+    try:
+        dataframe_ops.table_insert(upload_df, table_schema, table_name)
+        yield table_sql
+    except BaseException:
+        failed = True
+        raise
+    finally:
+        try:
+            if isinstance(dataframe_ops, XtdbAdbcDataframeOps):
+                with dataframe_ops.connection.cursor() as cursor:
+                    cursor.execute(f"ERASE FROM {table_sql}")
+            else:
+                _execute_xtdb_dml(
+                    dataframe_ops.connection,
+                    f"ERASE FROM {table_sql}",
+                )
+        except Exception as exc:
+            if _is_xtdb_table_not_found_error(exc):
+                pass
+            elif failed:
+                LOGGER.warning(
+                    "Failed to erase XTDB uploaded key relation %s",
+                    table_sql,
+                    exc_info=True,
+                )
+            else:
+                raise

--- a/polars_hist_db/backends/xtdb_dataframe.py
+++ b/polars_hist_db/backends/xtdb_dataframe.py
@@ -189,7 +189,8 @@ class XtdbDataframeOps:
                     "SELECT *, _valid_from, _valid_to "
                     f"FROM {table_sql}{valid_time_clause}"
                     ") AS t "
-                    f"JOIN {query_table} AS q "
+                    f"JOIN {query_table} "
+                    "FOR VALID_TIME ALL FOR SYSTEM_TIME ALL AS q "
                     f"ON {join_clause}"
                 )
                 chunks.append(self.from_raw_sql(query, schema_overrides))
@@ -405,7 +406,9 @@ def _uploaded_xtdb_relation(
     }
     upload_df = df.rename(physical_columns)
     if "_id" not in upload_df.columns:
-        upload_df = upload_df.with_row_index("_id")
+        upload_df = upload_df.with_row_index("_id").with_columns(
+            pl.col("_id").cast(pl.Int64)
+        )
 
     failed = False
     try:

--- a/polars_hist_db/backends/xtdb_delta.py
+++ b/polars_hist_db/backends/xtdb_delta.py
@@ -8,11 +8,14 @@ from ..config import DeltaConfig, TableConfig, ValidTimeConfig
 from ..types import PolarsType
 from .xtdb_arrow import (
     _prepare_xtdb_insert_dataframe,
-    _xtdb_cast_type,
     _xtdb_document_id_columns,
 )
 from .xtdb_query import _xtdb_temporal_basis_clause
-from .xtdb_dataframe import XtdbAdbcDataframeOps, XtdbDataframeOps
+from .xtdb_dataframe import (
+    _uploaded_xtdb_relation,
+    XtdbAdbcDataframeOps,
+    XtdbDataframeOps,
+)
 from .xtdb_staging import _fill_xtdb_defaults, _materialize_xtdb_missing_columns
 from .xtdb_transport import (
     _execute_xtdb_dml,
@@ -20,7 +23,6 @@ from .xtdb_transport import (
     _is_xtdb_table_not_found_error,
     _qualified_table_name,
     _rollback_xtdb_connection,
-    _xtdb_sql_literal,
     _xtdb_timestamp_literal,
 )
 
@@ -167,17 +169,6 @@ def _apply_xtdb_duplicate_policy(
     return indexed_df.join(selected_rows, on=row_index, how="inner").drop(row_index)
 
 
-def _xtdb_document_id_cast_type(table_config: TableConfig) -> str:
-    document_id_columns = _xtdb_document_id_columns(table_config)
-    if len(document_id_columns) > 1:
-        return "TEXT"
-    source_key = document_id_columns[0]
-    for column in table_config.columns:
-        if column.name == source_key:
-            return _xtdb_cast_type(column.data_type)
-    return "TEXT"
-
-
 def _delete_xtdb_missing_rows(
     df: pl.DataFrame,
     table_schema: str,
@@ -192,41 +183,49 @@ def _delete_xtdb_missing_rows(
         df.select(document_id_columns).unique(maintain_order=True),
         table_config,
     ).get_column("_id")
-    id_cast_type = _xtdb_document_id_cast_type(table_config)
-    ids_sql = ", ".join(
-        _xtdb_sql_literal(value, id_cast_type) for value in incoming_ids
-    )
-    missing_predicate = f"_id NOT IN ({ids_sql})" if ids_sql else "TRUE"
     table_sql = _qualified_table_name(table_schema, table_name)
-    try:
-        missing_count = int(
-            dataframe_ops.from_raw_sql(
-                "SELECT COUNT(*) AS missing_count FROM "
-                f"{table_sql}{_xtdb_temporal_basis_clause(update_time)} "
-                f"WHERE {missing_predicate}"
-            ).item()
-        )
-    except Exception as exc:
-        if _is_xtdb_table_not_found_error(exc):
-            _rollback_xtdb_connection(dataframe_ops.connection)
+
+    def delete_missing(missing_predicate: str) -> int:
+        try:
+            missing_count = int(
+                dataframe_ops.from_raw_sql(
+                    "SELECT COUNT(*) AS missing_count FROM "
+                    f"{table_sql}{_xtdb_temporal_basis_clause(update_time)} "
+                    f"WHERE {missing_predicate}"
+                ).item()
+            )
+        except Exception as exc:
+            if _is_xtdb_table_not_found_error(exc):
+                _rollback_xtdb_connection(dataframe_ops.connection)
+                return 0
+            raise
+        if missing_count == 0:
             return 0
-        raise
-    if missing_count == 0:
-        return 0
-    valid_time_clause = ""
-    close_time = _xtdb_dropout_close_time(df, dropout_close_time, update_time)
-    if close_time is not None:
-        valid_time_clause = (
-            " FOR PORTION OF VALID_TIME FROM "
-            f"{_xtdb_timestamp_literal(close_time)} TO NULL"
+        valid_time_clause = ""
+        close_time = _xtdb_dropout_close_time(df, dropout_close_time, update_time)
+        if close_time is not None:
+            valid_time_clause = (
+                " FOR PORTION OF VALID_TIME FROM "
+                f"{_xtdb_timestamp_literal(close_time)} TO NULL"
+            )
+        delete_sql = (
+            f"DELETE FROM {table_sql}{valid_time_clause} WHERE {missing_predicate}"
         )
-    delete_sql = f"DELETE FROM {table_sql}{valid_time_clause} WHERE {missing_predicate}"
-    _execute_xtdb_dml(
-        dataframe_ops.connection,
-        delete_sql,
-        system_time=update_time,
-    )
-    return missing_count
+        _execute_xtdb_dml(
+            dataframe_ops.connection,
+            delete_sql,
+            system_time=update_time,
+        )
+        return missing_count
+
+    if incoming_ids.is_empty():
+        return delete_missing("TRUE")
+    with _uploaded_xtdb_relation(
+        dataframe_ops,
+        pl.DataFrame({"_id": incoming_ids}),
+        table_schema,
+    ) as key_table:
+        return delete_missing(f"_id NOT IN (SELECT _id FROM {key_table})")
 
 
 def _xtdb_dropout_close_time(

--- a/polars_hist_db/backends/xtdb_delta.py
+++ b/polars_hist_db/backends/xtdb_delta.py
@@ -225,7 +225,10 @@ def _delete_xtdb_missing_rows(
         pl.DataFrame({"_id": incoming_ids}),
         table_schema,
     ) as key_table:
-        return delete_missing(f"_id NOT IN (SELECT _id FROM {key_table})")
+        return delete_missing(
+            "_id NOT IN (SELECT _id FROM "
+            f"{key_table} FOR VALID_TIME ALL FOR SYSTEM_TIME ALL)"
+        )
 
 
 def _xtdb_dropout_close_time(

--- a/polars_hist_db/backends/xtdb_query.py
+++ b/polars_hist_db/backends/xtdb_query.py
@@ -1,15 +1,10 @@
 from datetime import datetime
-from typing import Any, Optional
-
-import polars as pl
+from typing import Optional
 
 from ..config import TableConfig
 from ..core import TimeHint
-from .xtdb_arrow import _xtdb_cast_type_from_polars
 from .xtdb_transport import (
-    _validate_identifier,
     _xtdb_column_identifier,
-    _xtdb_parameter_value,
     _xtdb_timestamp_literal,
 )
 
@@ -97,27 +92,3 @@ def _xtdb_table_query_target_column(column: str, table_config: TableConfig) -> s
     if _xtdb_single_primary_key_alias(table_config) == column:
         return "_id"
     return _xtdb_column_identifier(column)
-
-
-def _xtdb_values_cte(name: str, df: pl.DataFrame) -> tuple[str, dict[str, Any]]:
-    if df.is_empty():
-        raise ValueError("XTDB table_query requires at least one query row")
-
-    cte_name = _validate_identifier(name)
-    columns = [_xtdb_column_identifier(column) for column in df.columns]
-    casts = [_xtdb_cast_type_from_polars(dtype) for dtype in df.schema.values()]
-    parameters = {}
-    row_queries = []
-    for row_index, row in enumerate(df.rows()):
-        projections = []
-        for column_index, (value, cast_type) in enumerate(zip(row, casts, strict=True)):
-            parameter = f"q_{row_index}_{column_index}"
-            parameters[parameter] = _xtdb_parameter_value(value, cast_type)
-            projections.append(
-                f"CAST(:{parameter} AS {cast_type}) AS {columns[column_index]}"
-            )
-        row_queries.append(f"SELECT {', '.join(projections)}")
-    return (
-        f"{cte_name} AS ({' UNION ALL '.join(row_queries)})",
-        parameters,
-    )

--- a/polars_hist_db/backends/xtdb_staging.py
+++ b/polars_hist_db/backends/xtdb_staging.py
@@ -531,7 +531,8 @@ class XtdbStagingOps:
                 existing = dataframe_ops.from_raw_sql(
                     "WITH occupied AS ("
                     f"SELECT t.{physical_target} AS {target_column} "
-                    f"FROM {table_name} AS t JOIN {candidate_table} AS q "
+                    f"FROM {table_name} AS t JOIN {candidate_table} "
+                    "FOR VALID_TIME ALL FOR SYSTEM_TIME ALL AS q "
                     f"ON t.{physical_target} = q.{target_column}"
                     "), bounds AS ("
                     f"SELECT MIN(t.{physical_target}) AS {minimum_column} "

--- a/polars_hist_db/backends/xtdb_staging.py
+++ b/polars_hist_db/backends/xtdb_staging.py
@@ -16,8 +16,12 @@ from ..config import (
 from ..pipeline_projection import project_staged_pipeline_item_dataframe
 from ..types import PolarsType
 from .xtdb_arrow import _xtdb_json_safe_key_value
-from .xtdb_query import _xtdb_table_query_target_column, _xtdb_values_cte
-from .xtdb_dataframe import XtdbAdbcDataframeOps, XtdbDataframeOps
+from .xtdb_query import _xtdb_table_query_target_column
+from .xtdb_dataframe import (
+    _uploaded_xtdb_relation,
+    XtdbAdbcDataframeOps,
+    XtdbDataframeOps,
+)
 from .xtdb_transport import (
     _is_xtdb_adbc_ingest_unavailable,
     _normalize_xtdb_timestamp_columns,
@@ -516,29 +520,30 @@ class XtdbStagingOps:
                 continue
 
             candidates = resolved.select(target).unique(maintain_order=True)
-            values_cte, parameters = _xtdb_values_cte("candidate_keys", candidates)
             target_column = _xtdb_column_identifier(target)
             physical_target = _xtdb_table_query_target_column(target, table_config)
             table_name = _qualified_table_name(table_config.schema, table_config.name)
             minimum_column = "__xtdb_minimum_id"
-            existing = self._dataframes().from_raw_sql(
-                f"WITH {values_cte}, "
-                "occupied AS ("
-                f"SELECT t.{physical_target} AS {target_column} "
-                f"FROM {table_name} AS t JOIN candidate_keys AS q "
-                f"ON t.{physical_target} = q.{target_column}"
-                "), bounds AS ("
-                f"SELECT MIN(t.{physical_target}) AS {minimum_column} "
-                f"FROM {table_name} AS t"
-                ") "
-                f"SELECT occupied.{target_column}, bounds.{minimum_column} "
-                "FROM bounds LEFT JOIN occupied ON TRUE",
-                {
-                    target: resolved.schema[target],
-                    minimum_column: resolved.schema[target],
-                },
-                {"parameters": parameters},
-            )
+            dataframe_ops = self._dataframes()
+            with _uploaded_xtdb_relation(
+                dataframe_ops, candidates, table_config.schema
+            ) as candidate_table:
+                existing = dataframe_ops.from_raw_sql(
+                    "WITH occupied AS ("
+                    f"SELECT t.{physical_target} AS {target_column} "
+                    f"FROM {table_name} AS t JOIN {candidate_table} AS q "
+                    f"ON t.{physical_target} = q.{target_column}"
+                    "), bounds AS ("
+                    f"SELECT MIN(t.{physical_target}) AS {minimum_column} "
+                    f"FROM {table_name} AS t"
+                    ") "
+                    f"SELECT occupied.{target_column}, bounds.{minimum_column} "
+                    "FROM bounds LEFT JOIN occupied ON TRUE",
+                    {
+                        target: resolved.schema[target],
+                        minimum_column: resolved.schema[target],
+                    },
+                )
             occupied = set(existing.get_column(target).drop_nulls().to_list())
             minimum_values = existing.get_column(minimum_column).drop_nulls()
             database_minimum = (

--- a/polars_hist_db/core/table.py
+++ b/polars_hist_db/core/table.py
@@ -20,6 +20,7 @@ from .db import DbOps
 
 
 LOGGER = logging.getLogger(__name__)
+_TABLE_METADATA_CACHE_ATTR = "_polars_hist_db_table_metadata_cache"
 
 
 class TableOps:
@@ -27,6 +28,20 @@ class TableOps:
         self.connection = connection
         self.table_schema = table_schema
         self.table_name = table_name
+
+    @staticmethod
+    def invalidate_metadata(
+        connection: Connection,
+        table_schema: str | None = None,
+        table_name: str | None = None,
+    ) -> None:
+        cache = getattr(connection, _TABLE_METADATA_CACHE_ATTR, None)
+        if not isinstance(cache, dict):
+            return
+        if table_schema is None or table_name is None:
+            cache.clear()
+            return
+        cache.pop((table_schema, table_name), None)
 
     def enable_system_versioning(
         self,
@@ -46,6 +61,7 @@ class TableOps:
         result = DbOps(self.connection).execute_sqlalchemy(
             "sql.op.enable_system_versioning", text(sql)
         )
+        self.invalidate_metadata(self.connection, self.table_schema, self.table_name)
         LOGGER.debug("enabled system versioning %s", result)
 
     def get_table_metadata(
@@ -56,6 +72,15 @@ class TableOps:
         if not autoload_metadata:
             return Table(self.table_name, metadata)
 
+        cache = getattr(self.connection, _TABLE_METADATA_CACHE_ATTR, None)
+        if not isinstance(cache, dict):
+            cache = {}
+            setattr(self.connection, _TABLE_METADATA_CACHE_ATTR, cache)
+        cache_key = (self.table_schema, self.table_name)
+        cached = cache.get(cache_key)
+        if isinstance(cached, Table):
+            return cached
+
         with warnings.catch_warnings():
             # skip this annoying SQLAlchemy warning:
             # SAWarning: Unknown schema content: '  PERIOD FOR SYSTEM_TIME (`__valid_from`, `__valid_to`),'
@@ -64,6 +89,7 @@ class TableOps:
 
             tbl = Table(self.table_name, metadata, autoload_with=self.connection)
 
+        cache[cache_key] = tbl
         return tbl
 
     def row_count(self) -> int:

--- a/polars_hist_db/core/table_config.py
+++ b/polars_hist_db/core/table_config.py
@@ -139,6 +139,7 @@ class TableConfigOps:
         if tbo.table_exists():
             tbl = tbo.get_table_metadata()
             tbl.drop(self.connection, checkfirst=True)
+            TableOps.invalidate_metadata(self.connection, table_schema, table_name)
             LOGGER.info("dropped table %s", table_name)
 
     def _create_temporal(
@@ -179,6 +180,9 @@ class TableConfigOps:
                     f"ALTER TABLE {tbo.table_schema}.{tbo.table_name} "
                     f"ADD COLUMN {column_sql}"
                 ),
+            )
+            TableOps.invalidate_metadata(
+                self.connection, tbo.table_schema, tbo.table_name
             )
 
     def _create_nontemporal(
@@ -252,6 +256,7 @@ class TableConfigOps:
         DbOps(self.connection).execute_sqlalchemy(
             f"sql.base.table_create.{table_name}", create_stmt
         )
+        TableOps.invalidate_metadata(self.connection, tbo.table_schema, tbo.table_name)
 
         LOGGER.debug("created table %s.%s", tbo.table_schema, tbo.table_name)
 

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from unittest.mock import Mock
 from datetime import date, datetime, time, timezone
 from decimal import Decimal
@@ -29,6 +30,11 @@ from polars_hist_db.config import (
 from polars_hist_db.overrides import CrdtDocumentStoreConfig, OverrideLedgerConfig
 
 _NON_TEMPORAL_VALID_FROM = _XTDB_NON_TEMPORAL_VALID_FROM
+
+
+@contextmanager
+def _uploaded_keys(dataframe_ops, df, table_schema):
+    yield f"{table_schema}.__uploaded_keys"
 
 
 def test_xtdb_casts_mediumtext_as_text():
@@ -187,7 +193,10 @@ def test_xtdb_temporal_upsert_rejects_manual_finality():
         )
 
 
-def test_xtdb_temporal_upsert_dropout_deletes_missing_current_keys():
+def test_xtdb_temporal_upsert_dropout_deletes_missing_current_keys(monkeypatch):
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb_delta._uploaded_xtdb_relation", _uploaded_keys
+    )
     backend = XtdbBackend()
     driver_connection = Mock()
     connection = Mock()
@@ -217,13 +226,13 @@ def test_xtdb_temporal_upsert_dropout_deletes_missing_current_keys():
     assert result == 2
     assert ops.from_raw_sql.call_args.args[0] == (
         "SELECT COUNT(*) AS missing_count FROM test.records "
-        "WHERE _id NOT IN (1::BIGINT)"
+        "WHERE _id NOT IN (SELECT _id FROM test.__uploaded_keys)"
     )
     executed_sql = [call.args[0] for call in driver_connection.execute.call_args_list]
     assert executed_sql[1] == (
         "DELETE FROM test.records FOR PORTION OF VALID_TIME FROM "
         "TIMESTAMP WITH TIME ZONE '1970-01-01T00:00:00+00:00' TO NULL "
-        "WHERE _id NOT IN (1::BIGINT)"
+        "WHERE _id NOT IN (SELECT _id FROM test.__uploaded_keys)"
     )
     insert_call = driver_connection.cursor.return_value.executemany.call_args
     assert insert_call.args[0] == (
@@ -234,7 +243,10 @@ def test_xtdb_temporal_upsert_dropout_deletes_missing_current_keys():
     assert insert_call.args[1] == [(1, 1, "Alpha", _NON_TEMPORAL_VALID_FROM)]
 
 
-def test_xtdb_temporal_upsert_dropout_closes_missing_keys_at_valid_time():
+def test_xtdb_temporal_upsert_dropout_closes_missing_keys_at_valid_time(monkeypatch):
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb_delta._uploaded_xtdb_relation", _uploaded_keys
+    )
     backend = XtdbBackend()
     driver_connection = Mock()
     connection = Mock()
@@ -272,7 +284,7 @@ def test_xtdb_temporal_upsert_dropout_closes_missing_keys_at_valid_time():
     assert executed_sql[1] == (
         "DELETE FROM test.records FOR PORTION OF VALID_TIME FROM "
         "TIMESTAMP WITH TIME ZONE '2030-01-02T00:00:00+00:00' TO NULL "
-        "WHERE _id NOT IN (1::BIGINT)"
+        "WHERE _id NOT IN (SELECT _id FROM test.__uploaded_keys)"
     )
 
 

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -226,13 +226,15 @@ def test_xtdb_temporal_upsert_dropout_deletes_missing_current_keys(monkeypatch):
     assert result == 2
     assert ops.from_raw_sql.call_args.args[0] == (
         "SELECT COUNT(*) AS missing_count FROM test.records "
-        "WHERE _id NOT IN (SELECT _id FROM test.__uploaded_keys)"
+        "WHERE _id NOT IN (SELECT _id FROM test.__uploaded_keys "
+        "FOR VALID_TIME ALL FOR SYSTEM_TIME ALL)"
     )
     executed_sql = [call.args[0] for call in driver_connection.execute.call_args_list]
     assert executed_sql[1] == (
         "DELETE FROM test.records FOR PORTION OF VALID_TIME FROM "
         "TIMESTAMP WITH TIME ZONE '1970-01-01T00:00:00+00:00' TO NULL "
-        "WHERE _id NOT IN (SELECT _id FROM test.__uploaded_keys)"
+        "WHERE _id NOT IN (SELECT _id FROM test.__uploaded_keys "
+        "FOR VALID_TIME ALL FOR SYSTEM_TIME ALL)"
     )
     insert_call = driver_connection.cursor.return_value.executemany.call_args
     assert insert_call.args[0] == (
@@ -284,7 +286,8 @@ def test_xtdb_temporal_upsert_dropout_closes_missing_keys_at_valid_time(monkeypa
     assert executed_sql[1] == (
         "DELETE FROM test.records FOR PORTION OF VALID_TIME FROM "
         "TIMESTAMP WITH TIME ZONE '2030-01-02T00:00:00+00:00' TO NULL "
-        "WHERE _id NOT IN (SELECT _id FROM test.__uploaded_keys)"
+        "WHERE _id NOT IN (SELECT _id FROM test.__uploaded_keys "
+        "FOR VALID_TIME ALL FOR SYSTEM_TIME ALL)"
     )
 
 

--- a/tests/backends/test_xtdb_dataframe_ops.py
+++ b/tests/backends/test_xtdb_dataframe_ops.py
@@ -418,7 +418,8 @@ def test_xtdb_dataframe_ops_chunks_table_query(monkeypatch):
         "UNION ALL" not in call.args[0] for call in ops.from_raw_sql.call_args_list
     )
     assert all(
-        f"JOIN test.__uploaded_keys_{index} AS q" in call.args[0]
+        f"JOIN test.__uploaded_keys_{index} "
+        "FOR VALID_TIME ALL FOR SYSTEM_TIME ALL AS q" in call.args[0]
         for index, call in enumerate(ops.from_raw_sql.call_args_list, 1)
     )
 
@@ -441,6 +442,7 @@ def test_uploaded_xtdb_relation_adds_document_ids_and_erases_on_failure(monkeypa
 
     uploaded = ops.table_insert.call_args.args[0]
     assert uploaded.to_dict(as_series=False) == {"_id": [0, 1], "id": [10, 20]}
+    assert uploaded.schema["_id"] == pl.Int64
     erase.assert_called_once_with(connection, f"ERASE FROM {table_sql}")
 
 

--- a/tests/backends/test_xtdb_dataframe_ops.py
+++ b/tests/backends/test_xtdb_dataframe_ops.py
@@ -1,4 +1,5 @@
 import builtins
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from decimal import Decimal
 from types import SimpleNamespace
@@ -9,11 +10,13 @@ import pyarrow as pa
 import pytest
 
 from polars_hist_db.backends.xtdb import (
+    XtdbAdbcDataframeOps,
     XtdbDataframeOps,
     XtdbTableConfigOps,
     _execute_xtdb_dml,
     _execute_xtdb_arrow_copy,
 )
+from polars_hist_db.backends.xtdb_dataframe import _uploaded_xtdb_relation
 from polars_hist_db.config import TableColumnConfig, TableConfig
 from polars_hist_db.core import TimeHint
 from polars_hist_db.types import TypeContractError
@@ -389,6 +392,17 @@ def test_xtdb_dataframe_ops_chunks_table_query(monkeypatch):
             pl.DataFrame({"id": [5]}),
         ]
     )
+    uploaded = []
+
+    @contextmanager
+    def uploaded_relation(dataframe_ops, df, table_schema):
+        uploaded.append(df)
+        yield f"{table_schema}.__uploaded_keys_{len(uploaded)}"
+
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb_dataframe._uploaded_xtdb_relation",
+        uploaded_relation,
+    )
 
     result = ops.table_query(
         "test",
@@ -399,13 +413,48 @@ def test_xtdb_dataframe_ops_chunks_table_query(monkeypatch):
 
     assert result.to_dict(as_series=False) == {"id": [1, 2, 3, 4, 5]}
     assert ops.from_raw_sql.call_count == 3
+    assert [chunk.height for chunk in uploaded] == [2, 2, 1]
     assert all(
-        "UNION ALL" in call.args[0] for call in ops.from_raw_sql.call_args_list[:2]
+        "UNION ALL" not in call.args[0] for call in ops.from_raw_sql.call_args_list
     )
-    assert "UNION ALL" not in ops.from_raw_sql.call_args_list[2].args[0]
-    assert ops.from_raw_sql.call_args_list[0].args[2] == {
-        "parameters": {"q_0_0": 1, "q_1_0": 2}
-    }
+    assert all(
+        f"JOIN test.__uploaded_keys_{index} AS q" in call.args[0]
+        for index, call in enumerate(ops.from_raw_sql.call_args_list, 1)
+    )
+
+
+def test_uploaded_xtdb_relation_adds_document_ids_and_erases_on_failure(monkeypatch):
+    connection = Mock()
+    ops = XtdbDataframeOps(connection)
+    ops.table_insert = Mock(return_value=2)  # type: ignore[method-assign]
+    erase = Mock()
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb_dataframe._execute_xtdb_dml", erase
+    )
+
+    with pytest.raises(RuntimeError, match="query failed"):
+        with _uploaded_xtdb_relation(
+            ops, pl.DataFrame({"id": [10, 20]}), "test"
+        ) as table_sql:
+            assert table_sql.startswith("test.__polars_hist_db_keys_")
+            raise RuntimeError("query failed")
+
+    uploaded = ops.table_insert.call_args.args[0]
+    assert uploaded.to_dict(as_series=False) == {"_id": [0, 1], "id": [10, 20]}
+    erase.assert_called_once_with(connection, f"ERASE FROM {table_sql}")
+
+
+def test_uploaded_xtdb_relation_uses_adbc_for_upload_and_cleanup():
+    connection = MagicMock()
+    ops = XtdbAdbcDataframeOps(connection)
+    ops.table_insert = Mock(return_value=1)  # type: ignore[method-assign]
+
+    with _uploaded_xtdb_relation(ops, pl.DataFrame({"_id": [10]}), "test") as table_sql:
+        assert table_sql.startswith("test.__polars_hist_db_keys_")
+
+    connection.cursor.return_value.__enter__.return_value.execute.assert_called_once_with(
+        f"ERASE FROM {table_sql}"
+    )
 
 
 def test_xtdb_arrow_copy_writes_one_arrow_stream_transaction():

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from datetime import date, datetime, timezone
 from decimal import Decimal
 from unittest.mock import Mock
@@ -28,6 +29,19 @@ def _empty_numeric_key_occupancy():
     return pl.DataFrame(
         {"id": [None], "__xtdb_minimum_id": [None]},
         schema={"id": pl.Int64, "__xtdb_minimum_id": pl.Int64},
+    )
+
+
+@contextmanager
+def _uploaded_keys(dataframe_ops, df, table_schema):
+    yield f"{table_schema}.__uploaded_keys"
+
+
+@pytest.fixture(autouse=True)
+def _mock_uploaded_keys(monkeypatch):
+    monkeypatch.setattr(
+        "polars_hist_db.backends.xtdb_staging._uploaded_xtdb_relation",
+        _uploaded_keys,
     )
 
 

--- a/tests/core/test_table_metadata_cache.py
+++ b/tests/core/test_table_metadata_cache.py
@@ -1,0 +1,45 @@
+from sqlalchemy import Column, create_engine, Integer, MetaData, Table, text
+
+from polars_hist_db.config.table import TableColumnConfig, TableConfig
+from polars_hist_db.core.table import TableOps
+from polars_hist_db.core.table_config import TableConfigOps
+
+
+def test_table_metadata_is_cached_per_connection_and_can_be_invalidated():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.connect() as connection:
+        Table("items", MetaData(), Column("id", Integer)).create(connection)
+        ops = TableOps("main", "items", connection)
+
+        first = ops.get_table_metadata()
+        assert ops.get_table_metadata() is first
+
+        connection.execute(text("ALTER TABLE items ADD COLUMN value INTEGER"))
+        assert "value" not in ops.get_table_metadata().columns
+
+        TableOps.invalidate_metadata(connection, "main", "items")
+        refreshed = ops.get_table_metadata()
+        assert refreshed is not first
+        assert "value" in refreshed.columns
+
+
+def test_table_config_ddl_invalidates_cached_metadata():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.connect() as connection:
+        Table("items", MetaData(), Column("id", Integer)).create(connection)
+        ops = TableOps("main", "items", connection)
+        cached = ops.get_table_metadata()
+        config = TableConfig(
+            "items",
+            "main",
+            [
+                TableColumnConfig("items", "id", "INTEGER"),
+                TableColumnConfig("items", "value", "INTEGER"),
+            ],
+        )
+
+        TableConfigOps(connection)._add_missing_columns(ops, config)
+
+        refreshed = ops.get_table_metadata()
+        assert refreshed is not cached
+        assert "value" in refreshed.columns


### PR DESCRIPTION
## Summary
- replace literal `UNION ALL` lookup CTEs with uploaded XTDB key relations
- perform dropout detection with a server-side anti-join
- reuse uploaded relations for numeric foreign-key collision checks
- erase transient relations after both successful and failed operations

## Validation
- `uv run pytest -m "not integration" -q` (338 passed, 1 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy .`

Integration tests are left to CI.