### PR TITLE
fix(xtdb): encode unsupported document IDs

### DIFF
--- a/polars_hist_db/backends/xtdb_arrow.py
+++ b/polars_hist_db/backends/xtdb_arrow.py
@@ -100,6 +100,50 @@ def _xtdb_document_id_columns(table_config: TableConfig) -> list[str]:
     )
 
 
+_XTDB_NATIVE_ID_CAST_TYPES = {"TEXT", "INTEGER", "BIGINT"}
+
+
+def _xtdb_document_id_cast_type(table_config: TableConfig) -> str:
+    document_id_columns = _xtdb_document_id_columns(table_config)
+    if len(document_id_columns) > 1:
+        return "TEXT"
+    source_key = document_id_columns[0]
+    source_type = next(
+        column.data_type for column in table_config.columns if column.name == source_key
+    )
+    cast_type = _xtdb_cast_type(source_type)
+    if document_id_columns == ["_id"] and cast_type not in _XTDB_NATIVE_ID_CAST_TYPES:
+        raise ValueError(
+            "XTDB explicit _id columns must be string or integer typed; "
+            f"received {source_type}"
+        )
+    return cast_type if cast_type in _XTDB_NATIVE_ID_CAST_TYPES else "TEXT"
+
+
+def _xtdb_document_id_is_encoded(table_config: TableConfig) -> bool:
+    document_id_columns = _xtdb_document_id_columns(table_config)
+    if document_id_columns == ["_id"]:
+        return False
+    if len(document_id_columns) > 1:
+        return True
+    source_type = next(
+        column.data_type
+        for column in table_config.columns
+        if column.name == document_id_columns[0]
+    )
+    return _xtdb_cast_type(source_type) not in _XTDB_NATIVE_ID_CAST_TYPES
+
+
+def _xtdb_document_id_value(table_config: TableConfig, row: Mapping[str, Any]) -> Any:
+    document_id_columns = _xtdb_document_id_columns(table_config)
+    if not _xtdb_document_id_is_encoded(table_config):
+        return row[document_id_columns[0]]
+    return _xtdb_composite_document_id(
+        document_id_columns,
+        tuple(row[column] for column in document_id_columns),
+    )
+
+
 def _xtdb_json_safe_key_value(value: Any) -> Any:
     if isinstance(value, bytes):
         return {"binary_hex": value.hex()}
@@ -200,13 +244,8 @@ def _xtdb_insert_casts(
     configured_types = {}
     if table_config is not None:
         document_id_columns = _xtdb_document_id_columns(table_config)
-        if len(document_id_columns) > 1:
-            configured_types["_id"] = "TEXT"
-        elif document_id_columns != ["_id"]:
-            for column in table_config.columns:
-                if column.name == document_id_columns[0]:
-                    configured_types["_id"] = _xtdb_cast_type(column.data_type)
-                    break
+        if document_id_columns != ["_id"]:
+            configured_types["_id"] = _xtdb_document_id_cast_type(table_config)
         for column in table_config.columns:
             configured_types[column.name] = _xtdb_cast_type(column.data_type)
 
@@ -243,11 +282,11 @@ def _xtdb_configured_column_dtypes(
         if dtype is None:
             continue
         dtypes[column.name] = dtype
-        if document_id_columns != ["_id"] and document_id_columns == [column.name]:
-            dtypes["_id"] = dtype
-
-    if len(document_id_columns) > 1:
-        dtypes["_id"] = pl.String()
+    if document_id_columns != ["_id"]:
+        dtypes["_id"] = (
+            _xtdb_polars_type_or_none(_xtdb_document_id_cast_type(table_config))
+            or pl.String()
+        )
     dtypes["_valid_from"] = pl.Datetime("us", "UTC")
     dtypes["_valid_to"] = pl.Datetime("us", "UTC")
     return dtypes
@@ -315,7 +354,7 @@ def _prepare_xtdb_insert_dataframe(
             f"{missing_keys!r}"
         )
 
-    if len(document_id_columns) == 1:
+    if not _xtdb_document_id_is_encoded(table_config):
         return df.with_columns(pl.col(document_id_columns[0]).alias("_id")).select(
             ["_id", *df.columns]
         )

--- a/polars_hist_db/backends/xtdb_dataframe.py
+++ b/polars_hist_db/backends/xtdb_dataframe.py
@@ -101,7 +101,7 @@ class XtdbDataframeOps:
         basis_time: datetime | None = None,
     ) -> pl.DataFrame:
         from .xtdb_arrow import (
-            _xtdb_document_id_columns,
+            _xtdb_document_id_cast_type,
             _xtdb_polars_type_or_none,
         )
         from .xtdb_query import (
@@ -130,22 +130,10 @@ class XtdbDataframeOps:
             if dtype is not None:
                 schema_overrides[column.name] = dtype
         if "_id" in output_columns:
-            document_id_columns = _xtdb_document_id_columns(table_config)
-            if len(document_id_columns) > 1:
-                schema_overrides["_id"] = pl.String()
-            else:
-                id_config = next(
-                    (
-                        column
-                        for column in table_config.columns
-                        if column.name == document_id_columns[0]
-                    ),
-                    None,
-                )
-                if id_config is not None:
-                    schema_overrides["_id"] = (
-                        _xtdb_polars_type_or_none(id_config.data_type) or pl.String()
-                    )
+            schema_overrides["_id"] = (
+                _xtdb_polars_type_or_none(_xtdb_document_id_cast_type(table_config))
+                or pl.String()
+            )
         for temporal_column in ["__valid_from", "__valid_to"]:
             if temporal_column in output_columns:
                 schema_overrides[temporal_column] = pl.Datetime("us")

--- a/polars_hist_db/backends/xtdb_delta.py
+++ b/polars_hist_db/backends/xtdb_delta.py
@@ -8,7 +8,9 @@ from ..config import DeltaConfig, TableConfig, ValidTimeConfig
 from ..types import PolarsType
 from .xtdb_arrow import (
     _prepare_xtdb_insert_dataframe,
+    _xtdb_document_id_cast_type,
     _xtdb_document_id_columns,
+    _xtdb_document_id_is_encoded,
 )
 from .xtdb_query import _xtdb_temporal_basis_clause
 from .xtdb_dataframe import (
@@ -260,7 +262,9 @@ def _xtdb_dropout_close_time(
 
 def _xtdb_value_compare_dtypes(table_config: TableConfig) -> dict[str, pl.DataType]:
     document_id_columns = _xtdb_document_id_columns(table_config)
-    uses_single_source_key = len(document_id_columns) == 1
+    uses_single_source_key = len(
+        document_id_columns
+    ) == 1 and not _xtdb_document_id_is_encoded(table_config)
     dtypes = {}
     for column in table_config.columns:
         target_name = (
@@ -269,6 +273,8 @@ def _xtdb_value_compare_dtypes(table_config: TableConfig) -> dict[str, pl.DataTy
             else column.name
         )
         dtypes[target_name] = PolarsType.from_sql(column.data_type)
+    if uses_single_source_key and document_id_columns != ["_id"]:
+        dtypes["_id"] = PolarsType.from_sql(_xtdb_document_id_cast_type(table_config))
     return dtypes
 
 

--- a/polars_hist_db/backends/xtdb_query.py
+++ b/polars_hist_db/backends/xtdb_query.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from ..config import TableConfig
 from ..core import TimeHint
+from .xtdb_arrow import _xtdb_document_id_is_encoded
 from .xtdb_transport import (
     _xtdb_column_identifier,
     _xtdb_timestamp_literal,
@@ -47,6 +48,8 @@ def _xtdb_valid_time_clause(time_hint: Optional[TimeHint]) -> str:
 
 
 def _xtdb_single_primary_key_alias(table_config: TableConfig) -> str | None:
+    if _xtdb_document_id_is_encoded(table_config):
+        return None
     primary_keys = list(table_config.primary_keys)
     if len(primary_keys) != 1:
         return None

--- a/polars_hist_db/backends/xtdb_schema.py
+++ b/polars_hist_db/backends/xtdb_schema.py
@@ -10,7 +10,9 @@ from ..observability import record_database_type_contract
 from ..types import TypeContractError
 from .xtdb_arrow import (
     _xtdb_cast_type,
+    _xtdb_document_id_cast_type,
     _xtdb_document_id_columns,
+    _xtdb_document_id_is_encoded,
     _xtdb_physical_column_map,
 )
 from .xtdb_transport import (
@@ -208,17 +210,7 @@ def _validate_xtdb_physical_types(
     document_id_columns = _xtdb_document_id_columns(table_config)
     if document_id_columns != ["_id"]:
         expected["_id"] = (
-            (
-                "TEXT"
-                if len(document_id_columns) > 1
-                else _xtdb_configured_type_family(
-                    next(
-                        column.data_type
-                        for column in table_config.columns
-                        if column.name == document_id_columns[0]
-                    )
-                )
-            ),
+            _xtdb_configured_type_family(_xtdb_document_id_cast_type(table_config)),
             False,
         )
 
@@ -425,7 +417,7 @@ def _xtdb_id_policy(table_config: TableConfig) -> str:
     document_id_columns = _xtdb_document_id_columns(table_config)
     if document_id_columns == ["_id"]:
         return "explicit-id"
-    if len(document_id_columns) == 1:
+    if len(document_id_columns) == 1 and not _xtdb_document_id_is_encoded(table_config):
         return "single-key"
     return "xtdb-pk-v1"
 

--- a/polars_hist_db/overrides/xtdb.py
+++ b/polars_hist_db/overrides/xtdb.py
@@ -11,7 +11,8 @@ from sqlalchemy import text
 
 from polars_hist_db.backends.xtdb_arrow import (
     _xtdb_cast_type,
-    _xtdb_composite_document_id,
+    _xtdb_document_id_cast_type,
+    _xtdb_document_id_value,
 )
 from polars_hist_db.backends.xtdb_transport import (
     _execute_xtdb_transaction,
@@ -1088,9 +1089,7 @@ def _insert_statement(
     document_id = _document_id(config, row)
     values = {"_id": document_id, **row}
     types = {
-        "_id": (
-            columns[primary_keys[0]].data_type if len(primary_keys) == 1 else "TEXT"
-        ),
+        "_id": _xtdb_document_id_cast_type(config),
         **{name: column.data_type for name, column in columns.items()},
     }
     if valid_from is not None:
@@ -1122,10 +1121,7 @@ def _update_statement(update: AtomicUpdate) -> str:
 
 
 def _document_id(config: TableConfig, row: Mapping[str, object]) -> object:
-    keys = list(config.primary_keys)
-    if len(keys) == 1:
-        return row[keys[0]]
-    return _xtdb_composite_document_id(keys, tuple(row[key] for key in keys))
+    return _xtdb_document_id_value(config, row)
 
 
 def _where(config: TableConfig, values: Mapping[str, object]) -> str:

--- a/polars_hist_db/overrides/xtdb.py
+++ b/polars_hist_db/overrides/xtdb.py
@@ -1081,13 +1081,16 @@ def _insert_statement(
     valid_to: object | None = None,
 ) -> str:
     columns = {column.name: column for column in config.columns}
-    missing_keys = [key for key in config.primary_keys if key not in row]
+    primary_keys = tuple(config.primary_keys)
+    missing_keys = [key for key in primary_keys if key not in row]
     if missing_keys:
         raise ValueError("atomic rows require every configured primary key")
     document_id = _document_id(config, row)
     values = {"_id": document_id, **row}
     types = {
-        "_id": "TEXT",
+        "_id": (
+            columns[primary_keys[0]].data_type if len(primary_keys) == 1 else "TEXT"
+        ),
         **{name: column.data_type for name, column in columns.items()},
     }
     if valid_from is not None:

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -21,6 +21,11 @@ from polars_hist_db.backends.xtdb import (
     _xtdb_type_to_config_type,
     _validate_xtdb_physical_types,
 )
+from polars_hist_db.backends.xtdb_arrow import (
+    _prepare_xtdb_insert_dataframe,
+    _xtdb_insert_casts,
+)
+from polars_hist_db.backends.xtdb_query import _xtdb_single_primary_key_alias
 from polars_hist_db.config import (
     DeltaConfig,
     TableColumnConfig,
@@ -44,6 +49,23 @@ def test_xtdb_casts_mediumtext_as_text():
 def test_xtdb_rejects_unknown_configured_column_type():
     with pytest.raises(ValueError, match="Unsupported XTDB column type: UUID"):
         _xtdb_cast_type("UUID")
+
+
+def test_xtdb_encodes_binary_primary_keys_as_valid_text_document_ids():
+    table = TableConfig(
+        name="records",
+        schema="test",
+        primary_keys=("id",),
+        columns=[TableColumnConfig("records", "id", "BINARY(16)")],
+    )
+
+    prepared = _prepare_xtdb_insert_dataframe(
+        pl.DataFrame({"id": [b"\x01" * 16]}, schema={"id": pl.Binary}), table
+    )
+
+    assert prepared["_id"].item().startswith("xtdb-pk-v1:")
+    assert _xtdb_insert_casts(prepared, table)[0] == "TEXT"
+    assert _xtdb_single_primary_key_alias(table) is None
 
 
 def test_xtdb_backend_builds_crdt_document_store(monkeypatch):

--- a/tests/overrides/test_xtdb_arrow_override_store.py
+++ b/tests/overrides/test_xtdb_arrow_override_store.py
@@ -107,4 +107,6 @@ def test_xtdb_schema_on_write_does_not_query_a_missing_table(monkeypatch) -> Non
     assert len(transactions[0]) == 1
     assert transactions[0][0].startswith("INSERT")
     assert "(_id, layer_id" in transactions[0][0]
+    assert "xtdb-pk-v1" in transactions[0][0]
+    assert "::TEXT" in transactions[0][0]
     assert "::VARBINARY" in transactions[0][0]

--- a/tests/overrides/test_xtdb_arrow_override_store.py
+++ b/tests/overrides/test_xtdb_arrow_override_store.py
@@ -106,3 +106,5 @@ def test_xtdb_schema_on_write_does_not_query_a_missing_table(monkeypatch) -> Non
 
     assert len(transactions[0]) == 1
     assert transactions[0][0].startswith("INSERT")
+    assert "(_id, layer_id" in transactions[0][0]
+    assert "::VARBINARY" in transactions[0][0]


### PR DESCRIPTION
## Summary
- preserve native XTDB document IDs for supported string and integer keys
- canonically encode binary and other unsupported primary-key types as text IDs while retaining their typed logical columns
- apply the same ID rule to atomic SQL, DataFrame ingest, schema validation, queries, and delta comparison

## Verification
- `uv run pytest tests/backends/test_xtdb_backend.py tests/overrides -q` (173 passed)
- Ruff and mypy pass
- live XTDB integration coverage runs in CI