### PR TITLE
perf(xtdb): remove duplicate parent resolution joins

### DIFF
--- a/polars_hist_db/backends/xtdb_staging.py
+++ b/polars_hist_db/backends/xtdb_staging.py
@@ -703,6 +703,8 @@ class XtdbStagingOps:
             generated,
             [*fk_targets, *value_targets],
         )
+        parent_exists = "__xtdb_parent_exists"
+        parent_lookup = parent_lookup.with_columns(pl.lit(True).alias(parent_exists))
 
         joined = generated.join(
             parent_lookup,
@@ -711,7 +713,12 @@ class XtdbStagingOps:
             suffix="__existing",
         )
         first_fk = fk_targets[0]
-        has_existing_fk = f"{first_fk}__existing" in joined.columns
+        missing_parent = "__xtdb_missing_parent"
+        joined = joined.with_columns(
+            (pl.col(parent_exists).is_null() & pl.col(first_fk).is_not_null()).alias(
+                missing_parent
+            )
+        )
         for target_column in fk_targets:
             existing_column = f"{target_column}__existing"
             if existing_column in joined.columns:
@@ -719,17 +726,8 @@ class XtdbStagingOps:
                     pl.coalesce(existing_column, target_column).alias(target_column)
                 ).drop(existing_column)
 
-        if has_existing_fk:
-            missing_parent_rows = joined.filter(pl.col(first_fk).is_not_null())
-            if not parent_lookup.is_empty():
-                existing_keys = parent_lookup.select(value_targets).unique()
-                missing_parent_rows = missing_parent_rows.join(
-                    existing_keys,
-                    on=value_targets,
-                    how="anti",
-                )
-        else:
-            missing_parent_rows = joined
+        missing_parent_rows = joined.filter(missing_parent)
+        retained_rows = joined.filter(~pl.col(missing_parent))
 
         missing_parent_rows = self._resolve_numeric_foreign_key_collisions(
             missing_parent_rows,
@@ -741,21 +739,8 @@ class XtdbStagingOps:
             table_config,
             fk_targets,
         )
-        resolved_keys = missing_parent_rows.select(
-            [*value_targets, *fk_targets]
-        ).unique(maintain_order=True)
-        joined = joined.join(
-            resolved_keys,
-            on=value_targets,
-            how="left",
-            suffix="__resolved",
-        )
-        for target_column in fk_targets:
-            resolved_column = f"{target_column}__resolved"
-            if resolved_column in joined.columns:
-                joined = joined.with_columns(
-                    pl.coalesce(resolved_column, target_column).alias(target_column)
-                ).drop(resolved_column)
+        joined = pl.concat([retained_rows, missing_parent_rows], how="vertical_relaxed")
+        joined = joined.drop([missing_parent, parent_exists])
         joined = _cast_xtdb_configured_columns(joined, table_config, fk_targets)
 
         parent_rows_to_insert = missing_parent_rows.select(

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -1237,13 +1237,13 @@ def test_xtdb_staging_does_not_insert_same_generated_parent_twice(
     assert destination_df.is_empty()
 
 
-def test_xtdb_staging_deduces_existing_foreign_key_without_insert(monkeypatch):
+def test_xtdb_staging_deduces_existing_and_missing_foreign_keys(monkeypatch):
     stage_df = pl.DataFrame(
         {
-            "stage_run_id": ["stage-1"],
-            "stage_row_index": [0],
-            "country_id": [None],
-            "country_name": ["Japan"],
+            "stage_run_id": ["stage-1", "stage-1"],
+            "stage_row_index": [0, 1],
+            "country_id": [None, None],
+            "country_name": ["Japan", "Korea"],
         },
         schema={
             "stage_run_id": pl.String,
@@ -1266,7 +1266,7 @@ def test_xtdb_staging_deduces_existing_foreign_key_without_insert(monkeypatch):
         "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_query",
         Mock(return_value=parent_df),
     )
-    table_insert = Mock(return_value=0)
+    table_insert = Mock(return_value=1)
     monkeypatch.setattr(
         "polars_hist_db.backends.xtdb.XtdbDataframeOps.table_insert",
         table_insert,
@@ -1309,10 +1309,15 @@ def test_xtdb_staging_deduces_existing_foreign_key_without_insert(monkeypatch):
         valid_time=None,
     )
 
-    table_insert.assert_not_called()
+    inserted = table_insert.call_args.args[0]
+    generated_id = 'xtdb-fk-v1:ref.countries:[["name","Korea"]]'
+    assert inserted.to_dict(as_series=False) == {
+        "country_id": [generated_id],
+        "name": ["Korea"],
+    }
     assert result.to_dict(as_series=False) == {
-        "country_id": ["country:japan"],
-        "name": ["Japan"],
+        "country_id": ["country:japan", generated_id],
+        "name": ["Japan", "Korea"],
     }
 
 


### PR DESCRIPTION
## Summary
- mark existing parent matches during the first lookup join
- split retained and missing parent rows without a second anti-join
- carry collision-resolved IDs forward without rejoining them
- cover mixed existing and newly normalized parent rows

## Validation
- `uv run pytest -m "not integration" -q` (338 passed, 1 skipped)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy .`

Integration tests are left to CI.