### PR TITLE
feat(overrides): return typed operation sync deltas

### DIFF
--- a/polars_hist_db/overrides/arrow.py
+++ b/polars_hist_db/overrides/arrow.py
@@ -149,9 +149,13 @@ class ArrowOverridePreconditionFailed(ArrowOverrideContractError):
 
 @dataclass(frozen=True)
 class ArrowOverrideSyncResult:
+    """Typed acknowledgement plus complete operation history for changed scopes."""
+
     generation: int
     revision: int
     acknowledgements: pa.Table
+    # Includes prior operations needed to reconstruct each changed CRDT frontier.
+    operations_delta: pa.Table
     projection_delta: pa.Table
 
 
@@ -411,7 +415,7 @@ class RepositoryArrowOverrideOperationStore:
                 revision=revision,
             )
             return ArrowOverrideSyncResult(
-                generation, revision, acknowledgements, projection
+                generation, revision, acknowledgements, operations, projection
             )
         raise ArrowOverrideRevisionConflict(
             "layer revision changed repeatedly during override commit"

--- a/tests/overrides/test_arrow_override_crdt.py
+++ b/tests/overrides/test_arrow_override_crdt.py
@@ -252,6 +252,11 @@ def test_sync_is_idempotent_and_returns_only_affected_projection() -> None:
 
     assert first.revision == replay.revision == 1
     assert first.acknowledgements["status"].to_pylist() == ["accepted"]
+    assert first.operations_delta.num_rows == 1
+    validate_arrow_override_operations(first.operations_delta, authority="committed")
+    assert first.operations_delta["operation_id"].to_pylist() == [
+        proposal["operation_id"][0].as_py()
+    ]
     assert replay.acknowledgements["status"].to_pylist() == ["duplicate"]
     assert first.projection_delta.num_rows == 1
     assert first.projection_delta["frontier_state"].to_pylist() == ["clean"]


### PR DESCRIPTION
## Summary
- return committed Arrow operation rows for scopes changed since the client revision
- include the prior typed history required to reconstruct each CRDT frontier
- cover the sync result contract with a native Arrow regression test

## Verification
- direnv exec . uv run pytest -q tests/overrides/test_arrow_override_crdt.py