### PR TITLE
feat(overrides): paginate unbounded APIs

### DIFF
--- a/docs/replicated-overrides.qmd
+++ b/docs/replicated-overrides.qmd
@@ -334,9 +334,11 @@ store = backend.document_access(connection, config)
 store.create(document_id, name, description, actor_id, recorded_at,
              initial_grants=(), idempotency_key=command_id)
 store.get(document_id)
-store.list_for_groups(groups, include_archived=False)
-store.list_all(include_archived=False)
-store.grants(document_id, include_revoked=False)
+page = store.list_for_groups(groups, include_archived=False, limit=100)
+page.items
+next_page = store.list_for_groups(groups, cursor=page.next_cursor, limit=100)
+store.list_all(include_archived=False, limit=100)
+store.grants(document_id, include_revoked=False, limit=100)
 store.grant(document_id, grant_id, group, role, actor_id, recorded_at,
             expected_revision, idempotency_key=command_id)
 store.revoke(document_id, group, actor_id, recorded_at, expected_revision,
@@ -345,6 +347,10 @@ store.archive(document_id, actor_id, recorded_at, expected_revision,
               idempotency_key=command_id)
 store.guard(document_id, expected_revision) -> RowGuard
 ```
+
+List and history APIs return a `Page`: an immutable `items` tuple and an opaque
+`next_cursor`. Pass that cursor back unchanged to read the next page. Page sizes
+must be between 1 and 500.
 
 `create`, `grant`, `revoke`, and `archive` return `AccessMutationResult` with
 the authoritative document, active grants, and one of `accepted` or

--- a/polars_hist_db/overrides/__init__.py
+++ b/polars_hist_db/overrides/__init__.py
@@ -31,6 +31,7 @@ from .ordering import (
     project_personal_override_operations,
 )
 from .projection import ColumnOverride, apply_columnar_overrides
+from .pagination import Page
 from .arrow import (
     ARROW_OVERRIDE_FORMAT_VERSION,
     ArrowOverrideContractError,
@@ -154,6 +155,7 @@ __all__ = [
     "InMemoryArrowOverrideRepository",
     "RepositoryArrowOverrideOperationStore",
     "OverrideLedger",
+    "Page",
     "override_recorded_order_sql",
     "override_recorded_time_sql",
     "project_personal_override_operations",

--- a/polars_hist_db/overrides/access.py
+++ b/polars_hist_db/overrides/access.py
@@ -8,6 +8,7 @@ from typing import Iterable
 
 from .config import build_document_access_table_configs
 from .crdt import RowGuard
+from .pagination import Page, paginate
 from .types import DocumentAccessStoreConfig
 
 
@@ -124,7 +125,7 @@ class InMemoryDocumentAccessStore:
         if existing is not None and allow_existing:
             return _existing_result(
                 existing,
-                self.grants(existing.document_id),
+                self._all_grants(existing.document_id),
                 owning_group,
             )
         if document_id in self._documents:
@@ -172,29 +173,65 @@ class InMemoryDocumentAccessStore:
         return updated
 
     def list_for_groups(
-        self, groups: Iterable[str], *, include_archived: bool = False
-    ) -> list[AccessDocument]:
+        self,
+        groups: Iterable[str],
+        *,
+        include_archived: bool = False,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> Page[AccessDocument]:
         group_set = set(groups)
         document_ids = {
             grant.document_id
             for grant in self._grants.values()
             if grant.active and grant.group_name in group_set
         }
-        return [
-            doc
-            for doc in self._documents.values()
-            if doc.document_id in document_ids
-            and (include_archived or doc.status == "active")
-        ]
+        return paginate(
+            (
+                doc
+                for doc in self._documents.values()
+                if doc.document_id in document_ids
+                and (include_archived or doc.status == "active")
+            ),
+            _document_page_key,
+            cursor=cursor,
+            limit=limit,
+        )
 
-    def list_all(self, *, include_archived: bool = False) -> list[AccessDocument]:
-        return [
-            doc
-            for doc in self._documents.values()
-            if include_archived or doc.status == "active"
-        ]
+    def list_all(
+        self,
+        *,
+        include_archived: bool = False,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> Page[AccessDocument]:
+        return paginate(
+            (
+                doc
+                for doc in self._documents.values()
+                if include_archived or doc.status == "active"
+            ),
+            _document_page_key,
+            cursor=cursor,
+            limit=limit,
+        )
 
     def grants(
+        self,
+        document_id: str,
+        *,
+        include_revoked: bool = False,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> Page[AccessGrant]:
+        return paginate(
+            self._all_grants(document_id, include_revoked=include_revoked),
+            _grant_page_key,
+            cursor=cursor,
+            limit=limit,
+        )
+
+    def _all_grants(
         self, document_id: str, *, include_revoked: bool = False
     ) -> tuple[AccessGrant, ...]:
         return tuple(
@@ -221,7 +258,7 @@ class InMemoryDocumentAccessStore:
         _require_time(recorded_at)
         if any(
             item.active and item.group_name == grant.group_name
-            for item in self.grants(document_id)
+            for item in self._all_grants(document_id)
         ):
             raise DocumentAccessError("group already has an active grant")
         document = self._advance(document)
@@ -250,7 +287,7 @@ class InMemoryDocumentAccessStore:
         grant = next(
             (
                 item
-                for item in self.grants(document_id)
+                for item in self._all_grants(document_id)
                 if item.group_name == group_name
             ),
             None,
@@ -340,7 +377,7 @@ class InMemoryDocumentAccessStore:
     ) -> AccessMutationResult:
         result = AccessMutationResult(
             document,
-            self.grants(document.document_id, include_revoked=True),
+            self._all_grants(document.document_id, include_revoked=True),
             accepted=True,
         )
         self._commands[idempotency_key] = (payload, result)
@@ -352,6 +389,14 @@ def _normalized(value: str) -> str:
     if not normalized:
         raise DocumentAccessError("name is required")
     return normalized
+
+
+def _document_page_key(document: AccessDocument) -> tuple[datetime, str]:
+    return document.created_at, document.document_id
+
+
+def _grant_page_key(grant: AccessGrant) -> tuple[datetime, str]:
+    return grant.granted_at, grant.grant_id
 
 
 def _create_payload(

--- a/polars_hist_db/overrides/composition.py
+++ b/polars_hist_db/overrides/composition.py
@@ -3,14 +3,19 @@ from __future__ import annotations
 from typing import Protocol
 
 from .operations import CompositionRevision
+from .pagination import Page, paginate
 
 
 class LayerCompositionStore(Protocol):
     def append(self, revision: CompositionRevision, actor_id: str) -> None: ...
 
     def revisions(
-        self, layer_id: str | None = None
-    ) -> tuple[CompositionRevision, ...]: ...
+        self,
+        layer_id: str | None = None,
+        *,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> Page[CompositionRevision]: ...
 
 
 class InMemoryLayerCompositionStore:
@@ -23,12 +28,20 @@ class InMemoryLayerCompositionStore:
             raise ValueError("composition revision already exists")
         self._revisions.append(revision)
 
-    def revisions(self, layer_id: str | None = None) -> tuple[CompositionRevision, ...]:
-        return tuple(
-            item
-            for item in sorted(
-                self._revisions,
-                key=lambda value: (value.recorded_at, value.revision_id),
-            )
-            if layer_id is None or item.layer_id == layer_id
+    def revisions(
+        self,
+        layer_id: str | None = None,
+        *,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> Page[CompositionRevision]:
+        return paginate(
+            (
+                item
+                for item in self._revisions
+                if layer_id is None or item.layer_id == layer_id
+            ),
+            lambda item: (item.recorded_at, item.revision_id),
+            cursor=cursor,
+            limit=limit,
         )

--- a/polars_hist_db/overrides/crdt.py
+++ b/polars_hist_db/overrides/crdt.py
@@ -7,6 +7,7 @@ from typing import Any, Mapping, Sequence
 
 from polars_hist_db.config import TableConfig
 
+from .pagination import Page, paginate
 from .replicated import (
     ReplicatedOverrideOperation,
     finalize_replicated_override_operation,
@@ -364,9 +365,18 @@ class InMemoryCrdtDocumentStore:
         self._rows[self._row_key(table_config, row)] = dict(row)
 
     def projected_operations(
-        self, document_id: str
-    ) -> tuple[ReplicatedOverrideOperation, ...]:
-        return tuple(self._operations.get(document_id, {}).values())
+        self,
+        document_id: str,
+        *,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> Page[ReplicatedOverrideOperation]:
+        return paginate(
+            self._operations.get(document_id, {}).values(),
+            lambda operation: (operation.recorded_at, operation.operation_id),
+            cursor=cursor,
+            limit=limit,
+        )
 
     def _validate_guards(self, guards: Sequence[RowGuard]) -> None:
         for guard in guards:

--- a/polars_hist_db/overrides/ledger.py
+++ b/polars_hist_db/overrides/ledger.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from typing import Protocol
 from uuid import uuid4
 
+from .pagination import Page, paginate
 from .types import OverrideOperation, OverrideOperationType, OverrideTypedValue
 
 
@@ -12,8 +13,14 @@ class OverrideLedgerStore(Protocol):
     def append(self, operation: OverrideOperation) -> None: ...
 
     def history_for_entity(
-        self, owner_user_id: str, feed_id: str, entity_id: str
-    ) -> list[OverrideOperation]: ...
+        self,
+        owner_user_id: str,
+        feed_id: str,
+        entity_id: str,
+        *,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> Page[OverrideOperation]: ...
 
 
 class InMemoryOverrideLedgerStore:
@@ -24,15 +31,26 @@ class InMemoryOverrideLedgerStore:
         self._operations.append(operation)
 
     def history_for_entity(
-        self, owner_user_id: str, feed_id: str, entity_id: str
-    ) -> list[OverrideOperation]:
-        return [
-            operation
-            for operation in self._operations
-            if operation.owner_user_id == owner_user_id
-            and operation.feed_id == feed_id
-            and operation.entity_id == entity_id
-        ]
+        self,
+        owner_user_id: str,
+        feed_id: str,
+        entity_id: str,
+        *,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> Page[OverrideOperation]:
+        return paginate(
+            (
+                operation
+                for operation in self._operations
+                if operation.owner_user_id == owner_user_id
+                and operation.feed_id == feed_id
+                and operation.entity_id == entity_id
+            ),
+            _operation_page_key,
+            cursor=cursor,
+            limit=limit,
+        )
 
 
 class OverrideLedger:
@@ -139,7 +157,7 @@ class OverrideLedger:
         self, owner_user_id: str, feed_id: str, entity_id: str
     ) -> list[OverrideOperation]:
         active: dict[str, OverrideOperation] = {}
-        for operation in self.history_for_entity(owner_user_id, feed_id, entity_id):
+        for operation in self._all_history(owner_user_id, feed_id, entity_id):
             if operation.operation_type == "set":
                 active[operation.field_path] = operation
             elif operation.operation_type in {"close", "system_close"}:
@@ -155,14 +173,32 @@ class OverrideLedger:
         return None
 
     def history_for_entity(
-        self, owner_user_id: str, feed_id: str, entity_id: str
-    ) -> list[OverrideOperation]:
-        return self.store.history_for_entity(owner_user_id, feed_id, entity_id)
+        self,
+        owner_user_id: str,
+        feed_id: str,
+        entity_id: str,
+        *,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> Page[OverrideOperation]:
+        return self.store.history_for_entity(
+            owner_user_id,
+            feed_id,
+            entity_id,
+            cursor=cursor,
+            limit=limit,
+        )
 
     def projected_history_for_entity(
-        self, owner_user_id: str, feed_id: str, entity_id: str
-    ) -> list[OverrideOperation]:
-        history = self.history_for_entity(owner_user_id, feed_id, entity_id)
+        self,
+        owner_user_id: str,
+        feed_id: str,
+        entity_id: str,
+        *,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> Page[OverrideOperation]:
+        history = self._all_history(owner_user_id, feed_id, entity_id)
         projected: list[OverrideOperation] = []
         open_sets: dict[str, int] = {}
         for operation in history:
@@ -176,7 +212,25 @@ class OverrideLedger:
                         valid_to=operation.valid_from,
                     )
             projected.append(operation)
-        return projected
+        return paginate(projected, _operation_page_key, cursor=cursor, limit=limit)
+
+    def _all_history(
+        self, owner_user_id: str, feed_id: str, entity_id: str
+    ) -> tuple[OverrideOperation, ...]:
+        operations: list[OverrideOperation] = []
+        cursor = None
+        while True:
+            page = self.history_for_entity(
+                owner_user_id,
+                feed_id,
+                entity_id,
+                cursor=cursor,
+                limit=500,
+            )
+            operations.extend(page.items)
+            if page.next_cursor is None:
+                return tuple(operations)
+            cursor = page.next_cursor
 
     def _operation(
         self,
@@ -244,3 +298,7 @@ class OverrideLedger:
     def _require_timezone(value: datetime, name: str) -> None:
         if value.tzinfo is None or value.utcoffset() is None:
             raise ValueError(f"{name} must be timezone-aware")
+
+
+def _operation_page_key(operation: OverrideOperation) -> tuple[datetime, str]:
+    return operation.recorded_at or operation.valid_from, operation.operation_id

--- a/polars_hist_db/overrides/pagination.py
+++ b/polars_hist_db/overrides/pagination.py
@@ -30,14 +30,28 @@ def paginate(
     ordered = sorted(items, key=key)
     keys = [key(item) for item in ordered]
     start = bisect_right(keys, decode_cursor(cursor)) if cursor else 0
-    selected = ordered[start : start + limit + 1]
+    return page_from_items(ordered[start : start + limit + 1], key, limit)
+
+
+def page_from_items(
+    items: Iterable[T],
+    key: Callable[[T], tuple[datetime, str]],
+    limit: int,
+) -> Page[T]:
+    validate_limit(limit)
+    selected = list(items)
     page = selected[:limit]
     next_cursor = encode_cursor(key(page[-1])) if len(selected) > len(page) else None
     return Page(tuple(page), next_cursor)
 
 
 def validate_limit(limit: int) -> None:
-    if isinstance(limit, bool) or limit < 1 or limit > 500:
+    if (
+        not isinstance(limit, int)
+        or isinstance(limit, bool)
+        or limit < 1
+        or limit > 500
+    ):
         raise ValueError("limit must be between 1 and 500")
 
 

--- a/polars_hist_db/overrides/pagination.py
+++ b/polars_hist_db/overrides/pagination.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import base64
+import binascii
+from bisect import bisect_right
+from dataclasses import dataclass
+from datetime import datetime
+import json
+from typing import Callable, Generic, Iterable, TypeVar
+
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class Page(Generic[T]):
+    items: tuple[T, ...]
+    next_cursor: str | None
+
+
+def paginate(
+    items: Iterable[T],
+    key: Callable[[T], tuple[datetime, str]],
+    *,
+    cursor: str | None,
+    limit: int,
+) -> Page[T]:
+    if isinstance(limit, bool) or limit < 1 or limit > 500:
+        raise ValueError("limit must be between 1 and 500")
+
+    ordered = sorted(items, key=key)
+    keys = [key(item) for item in ordered]
+    start = bisect_right(keys, decode_cursor(cursor)) if cursor else 0
+    selected = ordered[start : start + limit + 1]
+    page = selected[:limit]
+    next_cursor = encode_cursor(key(page[-1])) if len(selected) > len(page) else None
+    return Page(tuple(page), next_cursor)
+
+
+def encode_cursor(value: tuple[datetime, str]) -> str:
+    payload = json.dumps([value[0].isoformat(), value[1]], separators=(",", ":"))
+    return base64.urlsafe_b64encode(payload.encode()).decode()
+
+
+def decode_cursor(value: str) -> tuple[datetime, str]:
+    try:
+        decoded = json.loads(base64.urlsafe_b64decode(value.encode()).decode())
+        if (
+            not isinstance(decoded, list)
+            or len(decoded) != 2
+            or not isinstance(decoded[0], str)
+            or not isinstance(decoded[1], str)
+        ):
+            raise ValueError
+        timestamp = datetime.fromisoformat(decoded[0])
+        if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+            raise ValueError
+        return timestamp, decoded[1]
+    except (ValueError, TypeError, binascii.Error, json.JSONDecodeError) as exc:
+        raise ValueError("invalid cursor") from exc

--- a/polars_hist_db/overrides/pagination.py
+++ b/polars_hist_db/overrides/pagination.py
@@ -25,8 +25,7 @@ def paginate(
     cursor: str | None,
     limit: int,
 ) -> Page[T]:
-    if isinstance(limit, bool) or limit < 1 or limit > 500:
-        raise ValueError("limit must be between 1 and 500")
+    validate_limit(limit)
 
     ordered = sorted(items, key=key)
     keys = [key(item) for item in ordered]
@@ -35,6 +34,11 @@ def paginate(
     page = selected[:limit]
     next_cursor = encode_cursor(key(page[-1])) if len(selected) > len(page) else None
     return Page(tuple(page), next_cursor)
+
+
+def validate_limit(limit: int) -> None:
+    if isinstance(limit, bool) or limit < 1 or limit > 500:
+        raise ValueError("limit must be between 1 and 500")
 
 
 def encode_cursor(value: tuple[datetime, str]) -> str:

--- a/polars_hist_db/overrides/replicated.py
+++ b/polars_hist_db/overrides/replicated.py
@@ -7,6 +7,7 @@ import json
 from typing import Iterable, Literal
 from uuid import UUID
 
+from .pagination import Page, paginate
 from .types import OverrideTypedValue
 
 ReplicatedOverrideOperationType = Literal["set", "remove"]
@@ -84,15 +85,26 @@ class InMemoryReplicatedOverrideLedger:
         return results
 
     def history_for_entity(
-        self, layer_id: str, feed_id: str, entity_id: str
-    ) -> list[ReplicatedOverrideOperation]:
-        return [
-            operation
-            for operation in self._operations.values()
-            if operation.layer_id == layer_id
-            and operation.feed_id == feed_id
-            and operation.entity_id == entity_id
-        ]
+        self,
+        layer_id: str,
+        feed_id: str,
+        entity_id: str,
+        *,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> Page[ReplicatedOverrideOperation]:
+        return paginate(
+            (
+                operation
+                for operation in self._operations.values()
+                if operation.layer_id == layer_id
+                and operation.feed_id == feed_id
+                and operation.entity_id == entity_id
+            ),
+            lambda operation: (operation.recorded_at, operation.operation_id),
+            cursor=cursor,
+            limit=limit,
+        )
 
 
 def finalize_replicated_override_operation(

--- a/polars_hist_db/overrides/sql.py
+++ b/polars_hist_db/overrides/sql.py
@@ -36,7 +36,13 @@ from .config import (
     build_layer_composition_table_config,
 )
 from .operations import CompositionRevision
-from .pagination import Page, decode_cursor, encode_cursor, validate_limit
+from .pagination import (
+    Page,
+    decode_cursor,
+    encode_cursor,
+    page_from_items,
+    validate_limit,
+)
 from .crdt import (
     AtomicInsert,
     AtomicUpdate,
@@ -458,6 +464,42 @@ class MariaDbDocumentAccessStore:
         return _access_document(row) if row else None
 
     def grants(
+        self,
+        document_id: str,
+        *,
+        include_revoked: bool = False,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> Page[AccessGrant]:
+        validate_limit(limit)
+        query = select(self.grants_table).where(
+            self.grants_table.c.document_id == document_id
+        )
+        if not include_revoked:
+            query = query.where(self.grants_table.c.revoked_at.is_(None))
+        if cursor is not None:
+            granted_at, grant_id = decode_cursor(cursor)
+            query = query.where(
+                or_(
+                    self.grants_table.c.granted_at > granted_at,
+                    and_(
+                        self.grants_table.c.granted_at == granted_at,
+                        self.grants_table.c.grant_id > grant_id,
+                    ),
+                )
+            )
+        rows = self.connection.execute(
+            query.order_by(
+                self.grants_table.c.granted_at, self.grants_table.c.grant_id
+            ).limit(limit + 1)
+        ).mappings()
+        return page_from_items(
+            (_access_grant(row) for row in rows),
+            lambda grant: (grant.granted_at, grant.grant_id),
+            limit,
+        )
+
+    def _all_grants(
         self, document_id: str, *, include_revoked: bool = False
     ) -> tuple[AccessGrant, ...]:
         query = select(self.grants_table).where(
@@ -470,10 +512,18 @@ class MariaDbDocumentAccessStore:
         )
 
     def list_for_groups(
-        self, groups: Sequence[str], *, include_archived: bool = False
-    ) -> list[AccessDocument]:
+        self,
+        groups: Sequence[str],
+        *,
+        include_archived: bool = False,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> Page[AccessDocument]:
+        validate_limit(limit)
         if not groups:
-            return []
+            if cursor is not None:
+                decode_cursor(cursor)
+            return Page((), None)
         query = (
             select(self.documents)
             .distinct()
@@ -485,17 +535,54 @@ class MariaDbDocumentAccessStore:
         )
         if not include_archived:
             query = query.where(self.documents.c.status == "active")
-        return [
-            _access_document(row) for row in self.connection.execute(query).mappings()
-        ]
+        query = self._after_document_cursor(query, cursor)
+        rows = self.connection.execute(
+            query.order_by(
+                self.documents.c.created_at, self.documents.c.document_id
+            ).limit(limit + 1)
+        ).mappings()
+        return page_from_items(
+            (_access_document(row) for row in rows),
+            lambda document: (document.created_at, document.document_id),
+            limit,
+        )
 
-    def list_all(self, *, include_archived: bool = False) -> list[AccessDocument]:
+    def list_all(
+        self,
+        *,
+        include_archived: bool = False,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> Page[AccessDocument]:
+        validate_limit(limit)
         query = select(self.documents)
         if not include_archived:
             query = query.where(self.documents.c.status == "active")
-        return [
-            _access_document(row) for row in self.connection.execute(query).mappings()
-        ]
+        query = self._after_document_cursor(query, cursor)
+        rows = self.connection.execute(
+            query.order_by(
+                self.documents.c.created_at, self.documents.c.document_id
+            ).limit(limit + 1)
+        ).mappings()
+        return page_from_items(
+            (_access_document(row) for row in rows),
+            lambda document: (document.created_at, document.document_id),
+            limit,
+        )
+
+    def _after_document_cursor(self, query: Any, cursor: str | None) -> Any:
+        if cursor is None:
+            return query
+        created_at, document_id = decode_cursor(cursor)
+        return query.where(
+            or_(
+                self.documents.c.created_at > created_at,
+                and_(
+                    self.documents.c.created_at == created_at,
+                    self.documents.c.document_id > document_id,
+                ),
+            )
+        )
 
     def guard(self, document_id: str, expected_revision: int) -> RowGuard:
         return RowGuard(
@@ -553,7 +640,7 @@ class MariaDbDocumentAccessStore:
             if existing is not None:
                 return _existing_result(
                     existing,
-                    self.grants(existing.document_id),
+                    self._all_grants(existing.document_id),
                     owning_group,
                 )
         document = AccessDocument(
@@ -585,7 +672,7 @@ class MariaDbDocumentAccessStore:
             if existing is not None and allow_existing:
                 return _existing_result(
                     existing,
-                    self.grants(existing.document_id),
+                    self._all_grants(existing.document_id),
                     owning_group,
                 )
             raise DocumentAccessError("document or grant already exists") from exc
@@ -811,7 +898,7 @@ class MariaDbDocumentAccessStore:
     ) -> AccessMutationResult:
         result = AccessMutationResult(
             document,
-            self.grants(document.document_id, include_revoked=True),
+            self._all_grants(document.document_id, include_revoked=True),
             accepted=True,
         )
         self.connection.execute(

--- a/polars_hist_db/overrides/sql.py
+++ b/polars_hist_db/overrides/sql.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from hashlib import sha256
 from typing import Any, Sequence
 
-from sqlalchemy import Connection, MetaData, Table, and_, select
+from sqlalchemy import Connection, MetaData, Table, and_, or_, select
 from sqlalchemy.exc import IntegrityError
 
 from polars_hist_db.config import TableConfig
@@ -36,6 +36,7 @@ from .config import (
     build_layer_composition_table_config,
 )
 from .operations import CompositionRevision
+from .pagination import Page, decode_cursor, encode_cursor, validate_limit
 from .crdt import (
     AtomicInsert,
     AtomicUpdate,
@@ -76,14 +77,42 @@ class MariaDbLayerCompositionStore:
             )
         )
 
-    def revisions(self, layer_id: str | None = None) -> tuple[CompositionRevision, ...]:
+    def revisions(
+        self,
+        layer_id: str | None = None,
+        *,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> Page[CompositionRevision]:
+        validate_limit(limit)
         query = select(self.table)
         if layer_id is not None:
             query = query.where(self.table.c.layer_id == layer_id)
-        rows = self.connection.execute(
-            query.order_by(self.table.c.recorded_at, self.table.c.revision_id)
-        ).mappings()
-        return tuple(_composition_revision(row) for row in rows)
+        if cursor is not None:
+            recorded_at, revision_id = decode_cursor(cursor)
+            query = query.where(
+                or_(
+                    self.table.c.recorded_at > recorded_at,
+                    and_(
+                        self.table.c.recorded_at == recorded_at,
+                        self.table.c.revision_id > revision_id,
+                    ),
+                )
+            )
+        rows = list(
+            self.connection.execute(
+                query.order_by(
+                    self.table.c.recorded_at, self.table.c.revision_id
+                ).limit(limit + 1)
+            ).mappings()
+        )
+        revisions = tuple(_composition_revision(row) for row in rows[:limit])
+        next_cursor = (
+            encode_cursor((revisions[-1].recorded_at, revisions[-1].revision_id))
+            if len(rows) > limit
+            else None
+        )
+        return Page(revisions, next_cursor)
 
 
 def _composition_revision(row: Any) -> CompositionRevision:

--- a/polars_hist_db/overrides/xtdb.py
+++ b/polars_hist_db/overrides/xtdb.py
@@ -48,7 +48,13 @@ from .config import (
     build_override_table_config,
 )
 from .operations import CompositionRevision
-from .pagination import Page, decode_cursor, encode_cursor, validate_limit
+from .pagination import (
+    Page,
+    decode_cursor,
+    encode_cursor,
+    page_from_items,
+    validate_limit,
+)
 from .crdt import (
     AtomicInsert,
     AtomicUpdate,
@@ -493,6 +499,37 @@ class XtdbDocumentAccessStore:
         return _access_document_from_row(rows[0]) if rows else None
 
     def grants(
+        self,
+        document_id: str,
+        *,
+        include_revoked: bool = False,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> Page[AccessGrant]:
+        validate_limit(limit)
+        predicates = [f"document_id = {_literal(document_id, 'VARCHAR(128)')}"]
+        if not include_revoked:
+            predicates.append("revoked_at IS NULL")
+        if cursor is not None:
+            granted_at, grant_id = decode_cursor(cursor)
+            timestamp = _literal(granted_at, "TIMESTAMP WITH TIME ZONE")
+            identifier = _literal(grant_id, "VARCHAR(128)")
+            predicates.append(
+                f"(granted_at > {timestamp} OR "
+                f"(granted_at = {timestamp} AND grant_id > {identifier}))"
+            )
+        rows = self._rows(
+            f"SELECT {_access_grant_columns()} FROM {_table_name(self.grants_table)} "
+            f"WHERE {' AND '.join(predicates)} ORDER BY granted_at, grant_id "
+            f"LIMIT {limit + 1}"
+        )
+        return page_from_items(
+            (_access_grant_from_row(row) for row in rows),
+            lambda grant: (grant.granted_at, grant.grant_id),
+            limit,
+        )
+
+    def _all_grants(
         self, document_id: str, *, include_revoked: bool = False
     ) -> tuple[AccessGrant, ...]:
         predicate = f"document_id = {_literal(document_id, 'VARCHAR(128)')}"
@@ -507,29 +544,71 @@ class XtdbDocumentAccessStore:
         )
 
     def list_for_groups(
-        self, groups: Sequence[str], *, include_archived: bool = False
-    ) -> list[AccessDocument]:
+        self,
+        groups: Sequence[str],
+        *,
+        include_archived: bool = False,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> Page[AccessDocument]:
+        validate_limit(limit)
         if not groups:
-            return []
+            if cursor is not None:
+                decode_cursor(cursor)
+            return Page((), None)
         group_sql = ", ".join(_literal(group, "VARCHAR(255)") for group in groups)
         status = "" if include_archived else " AND d.status = 'active'"
+        after = self._document_cursor_predicate(cursor, alias="d")
         rows = self._rows(
             f"SELECT DISTINCT {_access_document_columns('d')} "
             f"FROM {_table_name(self.documents)} d "
             f"JOIN {_table_name(self.grants_table)} g ON d.document_id = g.document_id "
             f"WHERE g.group_name IN ({group_sql}) AND g.revoked_at IS NULL{status}"
+            f"{' AND ' + after if after else ''} "
+            f"ORDER BY d.created_at, d.document_id LIMIT {limit + 1}"
         )
-        return [_access_document_from_row(row) for row in rows]
+        return page_from_items(
+            (_access_document_from_row(row) for row in rows),
+            lambda document: (document.created_at, document.document_id),
+            limit,
+        )
 
-    def list_all(self, *, include_archived: bool = False) -> list[AccessDocument]:
-        predicate = "" if include_archived else " WHERE status = 'active'"
-        return [
-            _access_document_from_row(row)
-            for row in self._rows(
-                f"SELECT {_access_document_columns()} FROM {_table_name(self.documents)}"
-                f"{predicate} ORDER BY created_at, document_id"
-            )
-        ]
+    def list_all(
+        self,
+        *,
+        include_archived: bool = False,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> Page[AccessDocument]:
+        validate_limit(limit)
+        predicates = [] if include_archived else ["status = 'active'"]
+        after = self._document_cursor_predicate(cursor)
+        if after:
+            predicates.append(after)
+        predicate = " WHERE " + " AND ".join(predicates) if predicates else ""
+        rows = self._rows(
+            f"SELECT {_access_document_columns()} FROM {_table_name(self.documents)}"
+            f"{predicate} ORDER BY created_at, document_id LIMIT {limit + 1}"
+        )
+        return page_from_items(
+            (_access_document_from_row(row) for row in rows),
+            lambda document: (document.created_at, document.document_id),
+            limit,
+        )
+
+    @staticmethod
+    def _document_cursor_predicate(cursor: str | None, alias: str = "") -> str:
+        if cursor is None:
+            return ""
+        created_at, document_id = decode_cursor(cursor)
+        prefix = f"{alias}." if alias else ""
+        timestamp = _literal(created_at, "TIMESTAMP WITH TIME ZONE")
+        identifier = _literal(document_id, "VARCHAR(128)")
+        return (
+            f"({prefix}created_at > {timestamp} OR "
+            f"({prefix}created_at = {timestamp} "
+            f"AND {prefix}document_id > {identifier}))"
+        )
 
     def guard(self, document_id: str, expected_revision: int) -> RowGuard:
         return RowGuard(
@@ -589,7 +668,7 @@ class XtdbDocumentAccessStore:
             if existing is not None:
                 return _existing_result(
                     existing,
-                    self.grants(existing.document_id),
+                    self._all_grants(existing.document_id),
                     owning_group,
                 )
         if len({grant.grant_id for grant in grants}) != len(grants) or len(
@@ -641,7 +720,7 @@ class XtdbDocumentAccessStore:
                 if existing is not None:
                     return _existing_result(
                         existing,
-                        self.grants(existing.document_id),
+                        self._all_grants(existing.document_id),
                         owning_group,
                     )
             raise
@@ -676,7 +755,7 @@ class XtdbDocumentAccessStore:
         updated = _updated_document(document)
         new_grant = _new_grant(updated, grant, actor_id, recorded_at)
         result = AccessMutationResult(
-            updated, (*self.grants(document_id), new_grant), accepted=True
+            updated, (*self._all_grants(document_id), new_grant), accepted=True
         )
         statements = [
             self._command_assertion(idempotency_key),
@@ -729,7 +808,7 @@ class XtdbDocumentAccessStore:
         )
         grants = tuple(
             revoked if item.grant_id == revoked.grant_id else item
-            for item in self.grants(document_id, include_revoked=True)
+            for item in self._all_grants(document_id, include_revoked=True)
         )
         result = AccessMutationResult(updated, grants, accepted=True)
         statements = [
@@ -777,7 +856,9 @@ class XtdbDocumentAccessStore:
             archived_by=actor_id,
             archived_at=recorded_at,
         )
-        result = AccessMutationResult(updated, self.grants(document_id), accepted=True)
+        result = AccessMutationResult(
+            updated, self._all_grants(document_id), accepted=True
+        )
         statements = [
             self._command_assertion(idempotency_key),
             self._active_assertion(document_id, expected_revision),

--- a/polars_hist_db/overrides/xtdb.py
+++ b/polars_hist_db/overrides/xtdb.py
@@ -48,6 +48,7 @@ from .config import (
     build_override_table_config,
 )
 from .operations import CompositionRevision
+from .pagination import Page, decode_cursor, encode_cursor, validate_limit
 from .crdt import (
     AtomicInsert,
     AtomicUpdate,
@@ -92,28 +93,55 @@ class XtdbLayerCompositionStore:
             ],
         )
 
-    def revisions(self, layer_id: str | None = None) -> tuple[CompositionRevision, ...]:
-        predicate = (
-            ""
-            if layer_id is None
-            else f" WHERE layer_id = {_literal(layer_id, 'VARCHAR(128)')}"
-        )
+    def revisions(
+        self,
+        layer_id: str | None = None,
+        *,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> Page[CompositionRevision]:
+        validate_limit(limit)
+        predicates = []
+        if layer_id is not None:
+            predicates.append(f"layer_id = {_literal(layer_id, 'VARCHAR(128)')}")
+        if cursor is not None:
+            system_from, revision_id = decode_cursor(cursor)
+            timestamp = _literal(system_from, "TIMESTAMP WITH TIME ZONE")
+            revision = _literal(revision_id, "VARCHAR(128)")
+            predicates.append(
+                f"(_system_from > {timestamp} OR "
+                f"(_system_from = {timestamp} AND revision_id > {revision}))"
+            )
+        predicate = " WHERE " + " AND ".join(predicates) if predicates else ""
         try:
-            rows = self.connection.execute(
-                text(
-                    "SELECT revision_id, layer_id, child_layer_ids_json, "
-                    f"valid_from, valid_to, recorded_at, _system_from AS system_from, "
-                    f"supersedes_revision_id "
-                    f"FROM {_table_name(self.table)}"
-                    f"{predicate} ORDER BY _system_from, revision_id"
+            rows = list(
+                self.connection.execute(
+                    text(
+                        "SELECT revision_id, layer_id, child_layer_ids_json, "
+                        f"valid_from, valid_to, recorded_at, _system_from AS system_from, "
+                        f"supersedes_revision_id "
+                        f"FROM {_table_name(self.table)}"
+                        f"{predicate} ORDER BY _system_from, revision_id LIMIT {limit + 1}"
+                    )
+                ).mappings()
+            )
+            revisions = tuple(_composition_revision(row) for row in rows[:limit])
+            next_cursor = (
+                encode_cursor(
+                    (
+                        revisions[-1].recorded_at,
+                        revisions[-1].revision_id,
+                    )
                 )
-            ).mappings()
-            return tuple(_composition_revision(row) for row in rows)
+                if len(rows) > limit
+                else None
+            )
+            return Page(revisions, next_cursor)
         except Exception as exc:
             if not _is_xtdb_table_not_found_error(exc):
                 raise
             _rollback_xtdb_connection(self.connection)
-            return ()
+            return Page((), None)
 
 
 def _composition_revision(row: Mapping[str, object]) -> CompositionRevision:

--- a/tests/backends/test_xtdb_live.py
+++ b/tests/backends/test_xtdb_live.py
@@ -184,7 +184,7 @@ def test_xtdb_live_document_access_create():
                 owning_group="group-2",
                 allow_existing=True,
             )
-            documents = store.list_all()
+            documents = store.list_all().items
             loaded = store.get(document_id)
 
     assert result.accepted is True

--- a/tests/overrides/test_composition_store.py
+++ b/tests/overrides/test_composition_store.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timezone
 from uuid import uuid4
 
+import pytest
+
 from polars_hist_db.overrides import (
     CompositionRevision,
     InMemoryLayerCompositionStore,
@@ -44,8 +46,25 @@ def test_in_memory_composition_store_preserves_revision_order() -> None:
         datetime(2026, 7, 12, tzinfo=timezone.utc),
     )
     store.append(first, "editor")
+    second = CompositionRevision(
+        str(uuid4()),
+        "root",
+        ("left",),
+        datetime(2026, 7, 14, tzinfo=timezone.utc),
+        None,
+        datetime(2026, 7, 13, tzinfo=timezone.utc),
+    )
+    store.append(second, "editor")
 
-    assert store.revisions("root") == (first,)
+    first_page = store.revisions("root", limit=1)
+    second_page = store.revisions("root", cursor=first_page.next_cursor, limit=1)
+
+    assert first_page.items == (first,)
+    assert second_page.items == (second,)
+    assert first_page.next_cursor is not None
+    assert second_page.next_cursor is None
+    with pytest.raises(ValueError, match="limit must be between"):
+        store.revisions(limit=501)
 
 
 def test_xtdb_composition_history_orders_by_system_time() -> None:
@@ -62,6 +81,7 @@ def test_xtdb_composition_history_orders_by_system_time() -> None:
     connection = Connection()
     store = XtdbLayerCompositionStore(connection, LayerCompositionStoreConfig())
 
-    assert store.revisions() == ()
+    assert store.revisions().items == ()
     assert "_system_from AS system_from" in connection.statement
     assert "ORDER BY _system_from, revision_id" in connection.statement
+    assert "LIMIT 101" in connection.statement

--- a/tests/overrides/test_crdt_document_store.py
+++ b/tests/overrides/test_crdt_document_store.py
@@ -138,11 +138,10 @@ def test_prepared_commit_finalizes_operations_and_rejects_later_mutation():
     assert committed.accepted is True
     assert committed.revision == 1
     assert prepared.source_update_hash != prepared.accepted_update_hash
-    assert store.projected_operations("document-1")[0].actor_id == "user-1"
-    assert store.projected_operations("document-1")[0].metadata_json == {
-        "actor_display_name": "Verified User"
-    }
-    assert store.projected_operations("document-1")[0].payload_hash is not None
+    projected = store.projected_operations("document-1").items
+    assert projected[0].actor_id == "user-1"
+    assert projected[0].metadata_json == {"actor_display_name": "Verified User"}
+    assert projected[0].payload_hash is not None
 
     document: Any = Doc()
     assert committed.document is not None

--- a/tests/overrides/test_document_access_store.py
+++ b/tests/overrides/test_document_access_store.py
@@ -44,8 +44,17 @@ def test_lifecycle_is_versioned_and_preserves_grant_history():
     assert granted.document.revision == 3
     assert archived.document.status == "archived"
     assert archived.document.revision == 4
-    assert len(store.grants("doc-1", include_revoked=True)) == 2
-    assert store.grants("doc-1")[0].role == "resolver"
+    first_page = store.grants("doc-1", include_revoked=True, limit=1)
+    second_page = store.grants(
+        "doc-1", include_revoked=True, cursor=first_page.next_cursor, limit=1
+    )
+    assert len(first_page.items + second_page.items) == 2
+    assert first_page.next_cursor is not None
+    assert second_page.next_cursor is None
+    assert store.grants("doc-1").items[0].role == "resolver"
+    assert store.list_for_groups(["analysts"], include_archived=True).items == (
+        archived.document,
+    )
     with pytest.raises(DocumentArchived):
         store.grant(
             "doc-1",
@@ -138,6 +147,17 @@ def test_same_name_can_exist_in_different_ownership_scopes():
     assert created.document.document_id == "doc-2"
     assert created.document.owning_group == "reviewers"
     assert created.accepted is True
+
+    first_page = store.list_all(limit=1)
+    second_page = store.list_all(cursor=first_page.next_cursor, limit=1)
+    assert {
+        document.document_id for document in first_page.items + second_page.items
+    } == {
+        "doc-1",
+        "doc-2",
+    }
+    assert first_page.next_cursor is not None
+    assert second_page.next_cursor is None
 
 
 def test_allow_existing_idempotency_ignores_generated_identifiers():

--- a/tests/overrides/test_override_ledger_semantics.py
+++ b/tests/overrides/test_override_ledger_semantics.py
@@ -49,8 +49,8 @@ def test_record_classification_set_replace_and_system_close_timeline():
         system=True,
     )
 
-    raw_history = ledger.history_for_entity("user-1", "records", "record-1")
-    history = ledger.projected_history_for_entity("user-1", "records", "record-1")
+    raw_history = ledger.history_for_entity("user-1", "records", "record-1").items
+    history = ledger.projected_history_for_entity("user-1", "records", "record-1").items
 
     assert [operation.operation_type for operation in raw_history] == [
         "set",
@@ -72,6 +72,24 @@ def test_record_classification_set_replace_and_system_close_timeline():
     assert history[3].valid_to == _utc(20)
     assert history[3].reason == "source_match"
     assert ledger.active_for_entity("user-1", "records", "record-1") == []
+
+    first_page = ledger.history_for_entity("user-1", "records", "record-1", limit=2)
+    second_page = ledger.history_for_entity(
+        "user-1",
+        "records",
+        "record-1",
+        cursor=first_page.next_cursor,
+        limit=2,
+    )
+    assert first_page.items + second_page.items == raw_history
+    assert first_page.next_cursor is not None
+    assert second_page.next_cursor is None
+    with pytest.raises(ValueError, match="limit must be between"):
+        ledger.history_for_entity("user-1", "records", "record-1", limit=0)
+    with pytest.raises(ValueError, match="invalid cursor"):
+        ledger.history_for_entity(
+            "user-1", "records", "record-1", cursor="not-a-cursor"
+        )
 
 
 def test_set_rejects_naive_valid_from():
@@ -116,7 +134,7 @@ def test_grouped_sets_share_change_set_id():
         change_set_id="change-1",
     )
 
-    history = ledger.history_for_entity("user-1", "records", "record-1")
+    history = ledger.history_for_entity("user-1", "records", "record-1").items
     assert {operation.change_set_id for operation in history} == {"change-1"}
     assert len(ledger.active_for_entity("user-1", "records", "record-1")) == 2
 
@@ -145,7 +163,7 @@ def test_replacing_same_field_leaves_one_active_override_and_keeps_audit_history
         valid_from=_utc(14),
     )
 
-    history = ledger.projected_history_for_entity("user-1", "records", "record-1")
+    history = ledger.projected_history_for_entity("user-1", "records", "record-1").items
     active = ledger.active_for_entity("user-1", "records", "record-1")
 
     assert [operation.operation_type for operation in history] == [
@@ -182,7 +200,7 @@ def test_user_close_preserves_prior_operation_history():
         reason="user_close",
     )
 
-    history = ledger.projected_history_for_entity("user-1", "records", "record-1")
+    history = ledger.projected_history_for_entity("user-1", "records", "record-1").items
 
     assert [operation.operation_id for operation in history] == [
         set_operation.operation_id,

--- a/tests/overrides/test_replicated_override_ledger.py
+++ b/tests/overrides/test_replicated_override_ledger.py
@@ -117,7 +117,16 @@ def test_ledger_validates_references_and_exact_replay_without_partial_append():
     with pytest.raises(ValueError, match="must already exist"):
         ledger.append_batch([uncommitted, invalid])
 
-    assert [
-        operation.operation_id
-        for operation in ledger.history_for_entity("team", "records", "record-1")
-    ] == [original.operation_id, replacement.operation_id]
+    first_page = ledger.history_for_entity("team", "records", "record-1", limit=1)
+    second_page = ledger.history_for_entity(
+        "team",
+        "records",
+        "record-1",
+        cursor=first_page.next_cursor,
+        limit=1,
+    )
+    assert {
+        operation.operation_id for operation in first_page.items + second_page.items
+    } == {original.operation_id, replacement.operation_id}
+    assert first_page.next_cursor is not None
+    assert second_page.next_cursor is None

--- a/tests/overrides/test_xtdb_document_access_store.py
+++ b/tests/overrides/test_xtdb_document_access_store.py
@@ -8,6 +8,7 @@ from polars_hist_db.overrides import (
     DocumentAccessStoreConfig,
     XtdbDocumentAccessStore,
 )
+from polars_hist_db.overrides.pagination import encode_cursor
 
 
 def test_xtdb_access_create_submits_one_asserted_transaction(monkeypatch):
@@ -66,6 +67,23 @@ def test_xtdb_access_get_uses_logical_key_not_native_id(monkeypatch):
 
     assert "WHERE document_id =" in queries[0]
     assert "WHERE _id =" not in queries[0]
+
+
+def test_xtdb_access_lists_use_keyset_pagination(monkeypatch):
+    queries: list[str] = []
+    store = XtdbDocumentAccessStore(object(), DocumentAccessStoreConfig())
+    monkeypatch.setattr(store, "_rows", lambda sql: queries.append(sql) or [])
+    cursor = encode_cursor(
+        (datetime(2026, 7, 12, 11, tzinfo=timezone.utc), "document-1")
+    )
+
+    page = store.list_all(cursor=cursor, limit=7)
+
+    assert page.items == ()
+    assert page.next_cursor is None
+    assert "created_at >" in queries[0]
+    assert "document_id > 'document-1'" in queries[0]
+    assert "LIMIT 8" in queries[0]
 
 
 def test_xtdb_access_create_reports_the_assertion_that_conflicted(monkeypatch):


### PR DESCRIPTION
## Summary
- add a generic cursor-based `Page` contract with validated page sizes
- paginate personal and replicated history plus projected-operation inspection
- paginate composition revisions across memory, MariaDB, and XTDB
- paginate document and grant listings using database-side keyset queries
- document the new API shape

## API change
List/history methods now return `Page`, with results in `.items` and the continuation token in `.next_cursor`. Limits must be between 1 and 500.

## Validation
- `pytest -m "not integration" -q` (342 passed, 1 skipped, 19 deselected)
- `ruff check .`
- `ruff format --check .`
- `mypy .`
- `uv lock --check`

Docker-backed integration tests are left to CI.