### PR TITLE
test(jetstream): cover transaction fault lifecycle

### DIFF
--- a/polars_hist_db/loaders/jetstream_input_source.py
+++ b/polars_hist_db/loaders/jetstream_input_source.py
@@ -134,7 +134,13 @@ class JetStreamInputSource(InputSource[JetStreamInputConfig]):
     async def _heartbeat(self, msgs: list[Any]) -> None:
         while True:
             await asyncio.sleep(self.config.jetstream.fetch.heartbeat_interval)
-            await asyncio.gather(*(msg.in_progress() for msg in msgs))
+            results = await asyncio.gather(
+                *(msg.in_progress() for msg in msgs),
+                return_exceptions=True,
+            )
+            for result in results:
+                if isinstance(result, Exception):
+                    LOGGER.warning("JetStream heartbeat failed: %s", result)
 
     async def next_df(
         self, engine: Engine

--- a/tests/dataset/test_scrape_transactions.py
+++ b/tests/dataset/test_scrape_transactions.py
@@ -29,6 +29,61 @@ async def test_pipeline_acks_only_after_transaction_finishes(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_pipeline_does_not_ack_when_transaction_fails(monkeypatch):
+    events = []
+
+    def fail(*args):
+        events.append("failed")
+        raise RuntimeError("commit failed")
+
+    async def ack():
+        events.append("acked")
+
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.scrape._run_pipeline_as_transaction", fail
+    )
+
+    with pytest.raises(RuntimeError, match="commit failed"):
+        await try_run_pipeline_as_transaction(
+            [],
+            object(),
+            object(),
+            object(),
+            BatchFinalizer(ack_after_commit=ack),
+            num_retries=1,
+        )
+
+    assert events == ["failed"]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_surfaces_ack_failure_without_rerunning_transaction(monkeypatch):
+    events = []
+
+    def run_batch(*args):
+        events.append("committed")
+
+    async def fail_ack():
+        events.append("ack_failed")
+        raise RuntimeError("ack failed")
+
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.scrape._run_pipeline_as_transaction", run_batch
+    )
+
+    with pytest.raises(RuntimeError, match="ack failed"):
+        await try_run_pipeline_as_transaction(
+            [],
+            object(),
+            object(),
+            object(),
+            BatchFinalizer(ack_after_commit=fail_ack),
+        )
+
+    assert events == ["committed", "ack_failed"]
+
+
+@pytest.mark.asyncio
 async def test_pipeline_raises_final_retry_error(monkeypatch):
     attempts = 0
 

--- a/tests/loaders/test_jetstream_lifecycle.py
+++ b/tests/loaders/test_jetstream_lifecycle.py
@@ -1,0 +1,96 @@
+import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from polars_hist_db.loaders.input_source import BatchFinalizer
+from polars_hist_db.loaders.jetstream_input_source import JetStreamInputSource
+
+
+def _source(js, heartbeat_interval: float = 0.001):
+    source: Any = object.__new__(JetStreamInputSource)
+    source._js = js
+    source.config = SimpleNamespace(
+        run_until="empty",
+        jetstream=SimpleNamespace(
+            subscription=SimpleNamespace(
+                durable="test",
+                subject="events",
+                stream="EVENTS",
+                consumer_args={},
+                options={},
+            ),
+            fetch=SimpleNamespace(
+                heartbeat_interval=heartbeat_interval,
+                batch_size=10,
+                batch_timeout=0.01,
+            ),
+        ),
+    )
+    source.dataset = SimpleNamespace(
+        scrape_limit=1,
+        pipeline=SimpleNamespace(get_main_table_name=lambda: ("test", "events")),
+    )
+    return source
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_recovers_after_transient_failure():
+    recovered = asyncio.Event()
+
+    class Message:
+        calls = 0
+
+        async def in_progress(self):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("temporary heartbeat failure")
+            recovered.set()
+
+    message = Message()
+    task = asyncio.create_task(_source(None)._heartbeat([message]))
+    try:
+        await asyncio.wait_for(recovered.wait(), timeout=0.5)
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+    assert message.calls >= 2
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_runs_while_batch_is_yielded_and_stops_after_close():
+    heartbeat = asyncio.Event()
+
+    class Message:
+        calls = 0
+        metadata = SimpleNamespace(timestamp=datetime(2026, 7, 20, tzinfo=timezone.utc))
+
+        async def in_progress(self):
+            self.calls += 1
+            heartbeat.set()
+
+    message = Message()
+
+    class Subscription:
+        async def fetch(self, batch_size, timeout):
+            return [message]
+
+    class JetStream:
+        async def pull_subscribe(self, **kwargs):
+            return Subscription()
+
+    source = _source(JetStream())
+    source._prepare_batch = lambda *args: ([], BatchFinalizer())
+    batches = await source.next_df(object())
+
+    await anext(batches)
+    await asyncio.wait_for(heartbeat.wait(), timeout=0.5)
+    await batches.aclose()
+    calls_after_close = message.calls
+    await asyncio.sleep(0.01)
+
+    assert calls_after_close >= 1
+    assert message.calls == calls_after_close


### PR DESCRIPTION
## Summary
- prove failed transactions never ACK JetStream messages
- prove ACK failures remain visible without rerunning committed work
- keep heartbeats alive after transient `in_progress()` errors
- prove heartbeats run while batches are processed and stop when the batch closes

## Validation
- `pytest -m "not integration" -q` (344 passed, 1 skipped, 19 deselected)
- `ruff check .`
- `ruff format --check .`
- `mypy .`
- `uv lock --check`

Live integration tests are left to CI.