### PR TITLE
fix: reject duplicate Arrow fields

### DIFF
--- a/polars_hist_db/backends/xtdb_transport.py
+++ b/polars_hist_db/backends/xtdb_transport.py
@@ -12,6 +12,7 @@ from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
 from ..config import TableConfig
+from ..utils.arrow import require_unique_arrow_field_names
 from .config import DbEngineConfig
 
 
@@ -349,6 +350,9 @@ def _execute_xtdb_arrow_copy(
         )
 
     arrow_table = _normalize_xtdb_ingest_arrow(df.to_arrow())
+    require_unique_arrow_field_names(
+        arrow_table.schema, context="XTDB Arrow COPY schema"
+    )
     sink = pa.BufferOutputStream()
     with pa.ipc.new_stream(sink, arrow_table.schema) as writer:
         writer.write_table(arrow_table)

--- a/polars_hist_db/overrides/arrow.py
+++ b/polars_hist_db/overrides/arrow.py
@@ -21,6 +21,7 @@ from polars_hist_db.observability import (
     arrow_override_sync_span,
     record_arrow_override_sync,
 )
+from polars_hist_db.utils.arrow import require_unique_arrow_field_names
 
 from .crdt import RowGuard
 
@@ -427,6 +428,9 @@ def empty_arrow_override_operations() -> pa.Table:
 
 
 def encode_arrow_override_operations(table: pa.Table) -> bytes:
+    require_unique_arrow_field_names(
+        table.schema, context="Arrow override operation schema"
+    )
     validate_arrow_override_operations(table, authority="either")
     sink = pa.BufferOutputStream()
     with pa.ipc.new_stream(sink, arrow_override_operation_schema()) as writer:
@@ -439,6 +443,9 @@ def decode_arrow_override_operations(payload: bytes) -> pa.Table:
         table = pa.ipc.open_stream(payload).read_all()
     except pa.ArrowException as exc:
         raise ArrowOverrideContractError("invalid Arrow IPC operation batch") from exc
+    require_unique_arrow_field_names(
+        table.schema, context="Arrow override operation schema"
+    )
     validate_arrow_override_operations(table, authority="either")
     return table
 
@@ -468,6 +475,7 @@ def decode_arrow_override_projection(payload: bytes) -> pa.Table:
 
 
 def _encode_arrow_table(table: pa.Table, schema: pa.Schema) -> bytes:
+    require_unique_arrow_field_names(table.schema, context="Arrow IPC schema")
     sink = pa.BufferOutputStream()
     with pa.ipc.new_stream(sink, schema) as writer:
         writer.write_table(table)
@@ -483,6 +491,9 @@ def _decode_arrow_table(
         raise ArrowOverrideContractError(
             f"invalid Arrow IPC override {description}"
         ) from exc
+    require_unique_arrow_field_names(
+        table.schema, context=f"Arrow {description} schema"
+    )
     if not table.schema.equals(schema, check_metadata=True):
         raise ArrowOverrideContractError(
             f"Arrow override {description} schema mismatch"

--- a/polars_hist_db/utils/__init__.py
+++ b/polars_hist_db/utils/__init__.py
@@ -2,12 +2,15 @@ from .clock import Clock
 from .exceptions import NonRetryableException
 from .compare import compare_dataframes
 from .marshal import to_ipc_b64, from_ipc_b64
+from .arrow import ArrowSchemaContractError, require_unique_arrow_field_names
 from .flatten import recursive_flatten
 
 __all__ = [
     "Clock",
     "compare_dataframes",
     "from_ipc_b64",
+    "ArrowSchemaContractError",
+    "require_unique_arrow_field_names",
     "NonRetryableException",
     "to_ipc_b64",
     "recursive_flatten",

--- a/polars_hist_db/utils/arrow.py
+++ b/polars_hist_db/utils/arrow.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pyarrow as pa
+
+
+class ArrowSchemaContractError(ValueError):
+    pass
+
+
+def require_unique_arrow_field_names(
+    schema: pa.Schema, *, context: str = "Arrow schema"
+) -> None:
+    duplicates = sorted(
+        name
+        for name in set(schema.names)
+        if len(schema.get_all_field_indices(name)) > 1
+    )
+    if duplicates:
+        raise ArrowSchemaContractError(
+            f"{context} contains duplicate field names: {', '.join(duplicates)}"
+        )

--- a/tests/utils/test_arrow.py
+++ b/tests/utils/test_arrow.py
@@ -1,0 +1,35 @@
+from typing import cast
+
+import pyarrow as pa
+import pytest
+
+from polars_hist_db.utils import (
+    ArrowSchemaContractError,
+    require_unique_arrow_field_names,
+)
+
+
+def test_rejects_duplicate_arrow_field_names() -> None:
+    schema = pa.schema(
+        [
+            cast(pa.Field, pa.field("id", pa.int64())),
+            cast(pa.Field, pa.field("id", pa.string())),
+        ]
+    )
+
+    with pytest.raises(
+        ArrowSchemaContractError,
+        match="Arrow response schema contains duplicate field names: id",
+    ):
+        require_unique_arrow_field_names(schema, context="Arrow response schema")
+
+
+def test_accepts_unique_arrow_field_names() -> None:
+    schema = pa.schema(
+        [
+            cast(pa.Field, pa.field("id", pa.int64())),
+            cast(pa.Field, pa.field("name", pa.string())),
+        ]
+    )
+
+    require_unique_arrow_field_names(schema)


### PR DESCRIPTION
## Summary
- add a reusable Arrow schema uniqueness contract
- enforce it on override IPC encoding and decoding
- enforce it before XTDB Arrow COPY streams are written

## Tests
- uv run pytest -q
- uv run ruff check polars_hist_db tests/utils/test_arrow.py
- uv run mypy polars_hist_db