### PR TITLE
fix: accept null flattened structural columns

### DIFF
--- a/polars_hist_db/loaders/transform.py
+++ b/polars_hist_db/loaders/transform.py
@@ -52,9 +52,11 @@ def enforce_input_schema(
         if df[name].null_count() == df.height
         and any(source.startswith(f"{name}.") for source in sources)
     }
-    unknown = sorted(unknown.difference(null_structural_columns))
-    if unknown:
-        raise InputSchemaError("undeclared input columns: " + ", ".join(unknown))
+    unknown_names = sorted(unknown.difference(null_structural_columns))
+    if unknown_names:
+        raise InputSchemaError(
+            "undeclared input columns: " + ", ".join(unknown_names)
+        )
 
     result = df.drop(null_structural_columns)
     for name, (dtype, required, nullable) in sources.items():

--- a/polars_hist_db/loaders/transform.py
+++ b/polars_hist_db/loaders/transform.py
@@ -45,11 +45,18 @@ def enforce_input_schema(
         )
 
     accepted = set(sources).union(generated)
-    unknown = sorted(set(df.columns).difference(accepted))
+    unknown = set(df.columns).difference(accepted)
+    null_structural_columns = {
+        name
+        for name in unknown
+        if df[name].null_count() == df.height
+        and any(source.startswith(f"{name}.") for source in sources)
+    }
+    unknown = sorted(unknown.difference(null_structural_columns))
     if unknown:
         raise InputSchemaError("undeclared input columns: " + ", ".join(unknown))
 
-    result = df
+    result = df.drop(null_structural_columns)
     for name, (dtype, required, nullable) in sources.items():
         if name not in result.columns:
             if required or not nullable:

--- a/polars_hist_db/loaders/transform.py
+++ b/polars_hist_db/loaders/transform.py
@@ -54,9 +54,7 @@ def enforce_input_schema(
     }
     unknown_names = sorted(unknown.difference(null_structural_columns))
     if unknown_names:
-        raise InputSchemaError(
-            "undeclared input columns: " + ", ".join(unknown_names)
-        )
+        raise InputSchemaError("undeclared input columns: " + ", ".join(unknown_names))
 
     result = df.drop(null_structural_columns)
     for name, (dtype, required, nullable) in sources.items():

--- a/tests/loaders/test_input_schema.py
+++ b/tests/loaders/test_input_schema.py
@@ -58,6 +58,22 @@ def test_input_schema_types_nulls_and_drops_declared_input_only_columns() -> Non
     assert transformed.columns == ["id", "note"]
 
 
+def test_input_schema_accepts_only_null_structural_ancestors() -> None:
+    columns = [_column("payload.child", "VARCHAR(32)")]
+
+    typed = enforce_input_schema(
+        pl.DataFrame({"payload": [None]}, schema={"payload": pl.Null}), columns
+    )
+
+    assert typed.schema == {"payload.child": pl.String}
+    with pytest.raises(InputSchemaError, match="undeclared input columns: payload"):
+        enforce_input_schema(pl.DataFrame({"payload": ["bad"]}), columns)
+    with pytest.raises(InputSchemaError, match="undeclared input columns: other"):
+        enforce_input_schema(
+            pl.DataFrame({"other": [None]}, schema={"other": pl.Null}), columns
+        )
+
+
 def test_input_schema_rejects_unknown_missing_null_and_conflicting_columns() -> None:
     required = _column("id", "INT", nullable=False)
 


### PR DESCRIPTION
## Summary
- accept an all-null flattened ancestor when declared child paths define its schema
- continue rejecting non-null structural values and unrelated undeclared columns

## Validation
- focused input-schema tests pass
- Ruff passes

The local mypy hook could not complete because its Quarto build exhausted local disk; CI will run the complete check.