### PR TITLE
fix: address repository review findings

### DIFF
--- a/polars_hist_db/backends/base.py
+++ b/polars_hist_db/backends/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextlib import AbstractContextManager
+from datetime import datetime
 from dataclasses import dataclass
 import re
 from typing import TYPE_CHECKING, Any, Protocol
@@ -72,6 +73,10 @@ class HistoricalDbBackend(Protocol):
     def connection_scope(self, engine: Any) -> AbstractContextManager[Any]:
         """Open a backend-correct connection and commit successful work."""
         ...
+
+    def ingest_transaction(
+        self, connection: Any, system_time: datetime | None
+    ) -> AbstractContextManager[Any]: ...
 
     def open_ingest_connection(self, config: DbEngineConfig) -> Any | None:
         """Open an optional backend-specific bulk-ingest connection."""

--- a/polars_hist_db/backends/mariadb.py
+++ b/polars_hist_db/backends/mariadb.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from contextlib import nullcontext
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import create_engine, text
@@ -53,6 +55,9 @@ class MariaDbBackend:
     def connection_scope(self, engine: Engine) -> Any:
         """Open one atomic MariaDB unit of work."""
         return engine.begin()
+
+    def ingest_transaction(self, connection: Any, system_time: datetime | None) -> Any:
+        return nullcontext()
 
     def open_ingest_connection(self, config: DbEngineConfig) -> None:
         return None

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -42,7 +42,7 @@ from .xtdb_transport import (
     _create_xtdb_adbc_connection,
     _create_xtdb_engine,
     _xtdb_transaction_active,
-    _xtdb_transaction_scope,
+    _xtdb_buffered_transaction_scope,
     _xtdb_adbc_uri,
     _xtdb_connection_scope,
 )
@@ -100,7 +100,7 @@ class XtdbBackend:
         return _xtdb_connection_scope(engine)
 
     def ingest_transaction(self, connection: Any, system_time: datetime | None) -> Any:
-        return _xtdb_transaction_scope(connection, system_time)
+        return _xtdb_buffered_transaction_scope(connection, system_time)
 
     def adbc_uri(self, config: DbEngineConfig) -> str:
         return _xtdb_adbc_uri(config)

--- a/polars_hist_db/backends/xtdb.py
+++ b/polars_hist_db/backends/xtdb.py
@@ -41,6 +41,8 @@ from .xtdb_transport import (
     _close_xtdb_adbc_connection,
     _create_xtdb_adbc_connection,
     _create_xtdb_engine,
+    _xtdb_transaction_active,
+    _xtdb_transaction_scope,
     _xtdb_adbc_uri,
     _xtdb_connection_scope,
 )
@@ -96,6 +98,9 @@ class XtdbBackend:
 
     def connection_scope(self, engine: Engine) -> Any:
         return _xtdb_connection_scope(engine)
+
+    def ingest_transaction(self, connection: Any, system_time: datetime | None) -> Any:
+        return _xtdb_transaction_scope(connection, system_time)
 
     def adbc_uri(self, config: DbEngineConfig) -> str:
         return _xtdb_adbc_uri(config)
@@ -187,7 +192,9 @@ class XtdbBackend:
         return XtdbStagingOps(
             connection,
             max_rows_per_insert=self.max_rows_per_insert,
-            adbc_connection=ingest_connection,
+            adbc_connection=(
+                None if _xtdb_transaction_active(connection) else ingest_connection
+            ),
         )
 
     def time_hint_clause(self, time_hint: TimeHint) -> str | None:

--- a/polars_hist_db/backends/xtdb_dataframe.py
+++ b/polars_hist_db/backends/xtdb_dataframe.py
@@ -16,6 +16,7 @@ from .xtdb_transport import (
     _execute_xtdb_dml,
     _qualified_table_name,
     _validate_identifier,
+    _xtdb_buffering_paused,
     _xtdb_column_identifier,
     _xtdb_parameter_value,
 )
@@ -398,31 +399,32 @@ def _uploaded_xtdb_relation(
             pl.col("_id").cast(pl.Int64)
         )
 
-    failed = False
-    try:
-        dataframe_ops.table_insert(upload_df, table_schema, table_name)
-        yield table_sql
-    except BaseException:
-        failed = True
-        raise
-    finally:
+    with _xtdb_buffering_paused(dataframe_ops.connection):
+        failed = False
         try:
-            if isinstance(dataframe_ops, XtdbAdbcDataframeOps):
-                with dataframe_ops.connection.cursor() as cursor:
-                    cursor.execute(f"ERASE FROM {table_sql}")
-            else:
-                _execute_xtdb_dml(
-                    dataframe_ops.connection,
-                    f"ERASE FROM {table_sql}",
-                )
-        except Exception as exc:
-            if _is_xtdb_table_not_found_error(exc):
-                pass
-            elif failed:
-                LOGGER.warning(
-                    "Failed to erase XTDB uploaded key relation %s",
-                    table_sql,
-                    exc_info=True,
-                )
-            else:
-                raise
+            dataframe_ops.table_insert(upload_df, table_schema, table_name)
+            yield table_sql
+        except BaseException:
+            failed = True
+            raise
+        finally:
+            try:
+                if isinstance(dataframe_ops, XtdbAdbcDataframeOps):
+                    with dataframe_ops.connection.cursor() as cursor:
+                        cursor.execute(f"ERASE FROM {table_sql}")
+                else:
+                    _execute_xtdb_dml(
+                        dataframe_ops.connection,
+                        f"ERASE FROM {table_sql}",
+                    )
+            except Exception as exc:
+                if _is_xtdb_table_not_found_error(exc):
+                    pass
+                elif failed:
+                    LOGGER.warning(
+                        "Failed to erase XTDB uploaded key relation %s",
+                        table_sql,
+                        exc_info=True,
+                    )
+                else:
+                    raise

--- a/polars_hist_db/backends/xtdb_staging.py
+++ b/polars_hist_db/backends/xtdb_staging.py
@@ -255,13 +255,13 @@ def _cast_parent_lookup_columns(
     return parent_lookup.with_columns(casts)
 
 
-def _xtdb_integer_min(table_config: TableConfig, column_name: str) -> int:
+def _xtdb_integer_bits(table_config: TableConfig, column_name: str) -> int:
     data_type = next(
         column.data_type.upper()
         for column in table_config.columns
         if column.name == column_name
     )
-    bits = {
+    return {
         "TINYINT": 8,
         "SMALLINT": 16,
         "MEDIUMINT": 24,
@@ -269,7 +269,10 @@ def _xtdb_integer_min(table_config: TableConfig, column_name: str) -> int:
         "INTEGER": 32,
         "BIGINT": 64,
     }[data_type]
-    return -(1 << (bits - 1))
+
+
+def _xtdb_integer_min(table_config: TableConfig, column_name: str) -> int:
+    return -(1 << (_xtdb_integer_bits(table_config, column_name) - 1))
 
 
 class XtdbStagingOps:
@@ -654,15 +657,7 @@ class XtdbStagingOps:
                         if column.name == target_column
                     )
                 )
-                bits = (
-                    63
-                    if any(
-                        column.name == target_column
-                        and column.data_type.upper() == "BIGINT"
-                        for column in table_config.columns
-                    )
-                    else 31
-                )
+                bits = _xtdb_integer_bits(table_config, target_column) - 1
                 generated_value = (
                     generated_payload.map_batches(
                         partial(_xtdb_deduced_numeric_foreign_key_ids, bits=bits),

--- a/polars_hist_db/backends/xtdb_transport.py
+++ b/polars_hist_db/backends/xtdb_transport.py
@@ -18,6 +18,8 @@ from .config import DbEngineConfig
 
 _XTDB_LAST_SYSTEM_TIME_KEY = "polars_hist_db_xtdb_last_system_time"
 _XTDB_ACTIVE_TRANSACTION_KEY = "polars_hist_db_xtdb_active_transaction"
+_XTDB_BUFFERED_TRANSACTION_KEY = "polars_hist_db_xtdb_buffered_transaction"
+_XTDB_BUFFERING_PAUSED_KEY = "polars_hist_db_xtdb_buffering_paused"
 _XTDB_RESERVED_IDENTIFIERS = {"flag", "timestamp"}
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -116,7 +118,61 @@ def _execute_xtdb_transaction(connection: Any, statements: Iterable[str]) -> Non
 
 def _xtdb_transaction_active(connection: Any) -> bool:
     info = getattr(connection, "info", None)
-    return isinstance(info, dict) and _XTDB_ACTIVE_TRANSACTION_KEY in info
+    return isinstance(info, dict) and (
+        _XTDB_ACTIVE_TRANSACTION_KEY in info or _XTDB_BUFFERED_TRANSACTION_KEY in info
+    )
+
+
+@contextmanager
+def _xtdb_buffering_paused(connection: Any) -> Iterator[None]:
+    info = getattr(connection, "info", None)
+    if not isinstance(info, dict) or _XTDB_BUFFERED_TRANSACTION_KEY not in info:
+        yield
+        return
+    info[_XTDB_BUFFERING_PAUSED_KEY] = True
+    try:
+        yield
+    finally:
+        info.pop(_XTDB_BUFFERING_PAUSED_KEY, None)
+
+
+@contextmanager
+def _xtdb_buffered_transaction_scope(
+    connection: Any,
+    system_time: Optional[datetime] = None,
+) -> Iterator[None]:
+    """Buffer ingest DML so reads can finish before one atomic XTDB commit."""
+    info = getattr(connection, "info", None)
+    if not isinstance(info, dict):
+        info = {}
+        connection.info = info
+    if _xtdb_transaction_active(connection):
+        raise ValueError("nested XTDB transactions are not supported")
+
+    operations: list[tuple[str, tuple[Any, ...]]] = []
+    info[_XTDB_BUFFERED_TRANSACTION_KEY] = (system_time, operations)
+    try:
+        yield
+    except BaseException:
+        raise
+    else:
+        if operations:
+            info.pop(_XTDB_BUFFERED_TRANSACTION_KEY, None)
+            with _xtdb_transaction_scope(connection, system_time):
+                for operation, arguments in operations:
+                    if operation == "dml":
+                        sql, rows, operation_time = arguments
+                        _execute_xtdb_dml(
+                            connection, sql, rows, system_time=operation_time
+                        )
+                    else:
+                        table_sql, df, operation_time = arguments
+                        _execute_xtdb_arrow_copy(
+                            connection, table_sql, df, system_time=operation_time
+                        )
+    finally:
+        info.pop(_XTDB_BUFFERED_TRANSACTION_KEY, None)
+        info.pop(_XTDB_BUFFERING_PAUSED_KEY, None)
 
 
 @contextmanager
@@ -309,6 +365,18 @@ def _execute_xtdb_dml(
     *,
     system_time: Optional[datetime] = None,
 ) -> int:
+    info = getattr(connection, "info", None)
+    if (
+        isinstance(info, dict)
+        and _XTDB_BUFFERED_TRANSACTION_KEY in info
+        and _XTDB_BUFFERING_PAUSED_KEY not in info
+    ):
+        transaction_time, operations = info[_XTDB_BUFFERED_TRANSACTION_KEY]
+        if system_time is not None and transaction_time != system_time:
+            raise ValueError("XTDB transaction cannot mix system times")
+        operations.append(("dml", (sql, rows, system_time)))
+        return len(rows) if rows is not None else 0
+
     driver_connection = _driver_connection(connection)
     if driver_connection is None:
         if rows is not None or system_time is not None:
@@ -384,6 +452,18 @@ def _execute_xtdb_arrow_copy(
     *,
     system_time: Optional[datetime] = None,
 ) -> None:
+    info = getattr(connection, "info", None)
+    if (
+        isinstance(info, dict)
+        and _XTDB_BUFFERED_TRANSACTION_KEY in info
+        and _XTDB_BUFFERING_PAUSED_KEY not in info
+    ):
+        transaction_time, operations = info[_XTDB_BUFFERED_TRANSACTION_KEY]
+        if system_time is not None and transaction_time != system_time:
+            raise ValueError("XTDB transaction cannot mix system times")
+        operations.append(("arrow", (table_sql, df, system_time)))
+        return
+
     from .xtdb_arrow import _normalize_xtdb_ingest_arrow
 
     driver_connection = _driver_connection(connection)

--- a/polars_hist_db/backends/xtdb_transport.py
+++ b/polars_hist_db/backends/xtdb_transport.py
@@ -158,18 +158,41 @@ def _xtdb_buffered_transaction_scope(
     else:
         if operations:
             info.pop(_XTDB_BUFFERED_TRANSACTION_KEY, None)
-            with _xtdb_transaction_scope(connection, system_time):
-                for operation, arguments in operations:
-                    if operation == "dml":
-                        sql, rows, operation_time = arguments
-                        _execute_xtdb_dml(
-                            connection, sql, rows, system_time=operation_time
-                        )
-                    else:
-                        table_sql, df, operation_time = arguments
-                        _execute_xtdb_arrow_copy(
-                            connection, table_sql, df, system_time=operation_time
-                        )
+
+            def flush(transaction_time: Optional[datetime]) -> None:
+                with _xtdb_transaction_scope(connection, transaction_time):
+                    for operation, arguments in operations:
+                        if operation == "dml":
+                            sql, rows, operation_time = arguments
+                            _execute_xtdb_dml(
+                                connection,
+                                sql,
+                                rows,
+                                system_time=(
+                                    operation_time
+                                    if transaction_time is not None
+                                    else None
+                                ),
+                            )
+                        else:
+                            table_sql, df, operation_time = arguments
+                            _execute_xtdb_arrow_copy(
+                                connection,
+                                table_sql,
+                                df,
+                                system_time=(
+                                    operation_time
+                                    if transaction_time is not None
+                                    else None
+                                ),
+                            )
+
+            try:
+                flush(system_time)
+            except Exception as exc:
+                if system_time is None or not _is_xtdb_invalid_system_time_error(exc):
+                    raise
+                flush(None)
     finally:
         info.pop(_XTDB_BUFFERED_TRANSACTION_KEY, None)
         info.pop(_XTDB_BUFFERING_PAUSED_KEY, None)

--- a/polars_hist_db/backends/xtdb_transport.py
+++ b/polars_hist_db/backends/xtdb_transport.py
@@ -17,6 +17,7 @@ from .config import DbEngineConfig
 
 
 _XTDB_LAST_SYSTEM_TIME_KEY = "polars_hist_db_xtdb_last_system_time"
+_XTDB_ACTIVE_TRANSACTION_KEY = "polars_hist_db_xtdb_active_transaction"
 _XTDB_RESERVED_IDENTIFIERS = {"flag", "timestamp"}
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -108,24 +109,59 @@ def _is_xtdb_table_not_found_error(exc: Exception) -> bool:
 
 def _execute_xtdb_transaction(connection: Any, statements: Iterable[str]) -> None:
     """Submit one serialized XTDB DML transaction."""
+    with _xtdb_transaction_scope(connection) as driver_connection:
+        for statement in statements:
+            driver_connection.execute(statement)
 
+
+def _xtdb_transaction_active(connection: Any) -> bool:
+    info = getattr(connection, "info", None)
+    return isinstance(info, dict) and _XTDB_ACTIVE_TRANSACTION_KEY in info
+
+
+@contextmanager
+def _xtdb_transaction_scope(
+    connection: Any,
+    system_time: Optional[datetime] = None,
+) -> Iterator[Any]:
     driver_connection = _driver_connection(connection)
     if driver_connection is None:
         raise ValueError("XTDB transactions require a live DBAPI connection")
+    info = getattr(connection, "info", None)
+    if not isinstance(info, dict):
+        info = {}
+        connection.info = info
+    if _XTDB_ACTIVE_TRANSACTION_KEY in info:
+        raise ValueError("nested XTDB transactions are not supported")
+
     _rollback_xtdb_connection(connection)
     autocommit = getattr(driver_connection, "autocommit", None)
     if autocommit is not None:
         driver_connection.autocommit = True
-
-    driver_connection.execute("BEGIN READ WRITE")
+    requested_system_time = system_time
+    begin_sql = "BEGIN READ WRITE"
+    if system_time is not None:
+        system_time = _next_xtdb_system_time(connection, system_time)
+        begin_sql += f" WITH (SYSTEM_TIME = {_xtdb_timestamp_literal(system_time)})"
     try:
-        for statement in statements:
-            driver_connection.execute(statement)
+        driver_connection.execute(begin_sql)
+    except Exception as exc:
+        if system_time is None or not _is_xtdb_invalid_system_time_error(exc):
+            if autocommit is not None:
+                driver_connection.autocommit = autocommit
+            raise
+        driver_connection.rollback()
+        driver_connection.execute("BEGIN READ WRITE")
+    info[_XTDB_ACTIVE_TRANSACTION_KEY] = requested_system_time
+    try:
+        yield driver_connection
         driver_connection.execute("COMMIT")
-    except Exception:
+    except BaseException:
         driver_connection.execute("ROLLBACK")
+        driver_connection.rollback()
         raise
     finally:
+        info.pop(_XTDB_ACTIVE_TRANSACTION_KEY, None)
         if autocommit is not None:
             driver_connection.autocommit = autocommit
 
@@ -283,6 +319,24 @@ def _execute_xtdb_dml(
         connection.execute(text(sql))
         return 0
 
+    info = getattr(connection, "info", None)
+    if isinstance(info, dict) and _XTDB_ACTIVE_TRANSACTION_KEY in info:
+        transaction_time = info[_XTDB_ACTIVE_TRANSACTION_KEY]
+        if system_time is not None and transaction_time != system_time:
+            raise ValueError("XTDB transaction cannot mix system times")
+        if rows is None:
+            driver_connection.execute(sql)
+            return 0
+        _configure_xtdb_pgwire_parameter_adapters(driver_connection)
+        cursor = driver_connection.cursor()
+        try:
+            cursor.executemany(sql, rows)
+        finally:
+            close = getattr(cursor, "close", None)
+            if callable(close):
+                close()
+        return len(rows)
+
     _rollback_xtdb_connection(connection)
     autocommit = getattr(driver_connection, "autocommit", None)
     if autocommit is not None:
@@ -336,18 +390,25 @@ def _execute_xtdb_arrow_copy(
     if driver_connection is None:
         raise ValueError("XTDB Arrow COPY requires a live DBAPI connection")
 
-    _rollback_xtdb_connection(connection)
-    autocommit = getattr(driver_connection, "autocommit", None)
-    if autocommit is not None:
-        driver_connection.autocommit = True
+    info = getattr(connection, "info", None)
+    active_transaction = isinstance(info, dict) and _XTDB_ACTIVE_TRANSACTION_KEY in info
+    if active_transaction and system_time is not None:
+        if info[_XTDB_ACTIVE_TRANSACTION_KEY] != system_time:
+            raise ValueError("XTDB transaction cannot mix system times")
 
+    autocommit = None
     begin_sql = "BEGIN READ WRITE"
-    if system_time is not None:
-        system_time = _next_xtdb_system_time(connection, system_time)
-        begin_sql = (
-            "BEGIN READ WRITE WITH "
-            f"(SYSTEM_TIME = {_xtdb_timestamp_literal(system_time)})"
-        )
+    if not active_transaction:
+        _rollback_xtdb_connection(connection)
+        autocommit = getattr(driver_connection, "autocommit", None)
+        if autocommit is not None:
+            driver_connection.autocommit = True
+        if system_time is not None:
+            system_time = _next_xtdb_system_time(connection, system_time)
+            begin_sql = (
+                "BEGIN READ WRITE WITH "
+                f"(SYSTEM_TIME = {_xtdb_timestamp_literal(system_time)})"
+            )
 
     arrow_table = _normalize_xtdb_ingest_arrow(df.to_arrow())
     require_unique_arrow_field_names(
@@ -356,6 +417,19 @@ def _execute_xtdb_arrow_copy(
     sink = pa.BufferOutputStream()
     with pa.ipc.new_stream(sink, arrow_table.schema) as writer:
         writer.write_table(arrow_table)
+
+    if active_transaction:
+        cursor = driver_connection.cursor()
+        try:
+            with cursor.copy(
+                f"COPY {table_sql} FROM STDIN WITH (FORMAT 'arrow-stream')"
+            ) as copy:
+                copy.write(sink.getvalue().to_pybytes())
+        finally:
+            close = getattr(cursor, "close", None)
+            if callable(close):
+                close()
+        return
 
     driver_connection.execute(begin_sql)
     try:

--- a/polars_hist_db/backends/xtdb_transport.py
+++ b/polars_hist_db/backends/xtdb_transport.py
@@ -393,6 +393,7 @@ def _execute_xtdb_arrow_copy(
     info = getattr(connection, "info", None)
     active_transaction = isinstance(info, dict) and _XTDB_ACTIVE_TRANSACTION_KEY in info
     if active_transaction and system_time is not None:
+        assert isinstance(info, dict)
         if info[_XTDB_ACTIVE_TRANSACTION_KEY] != system_time:
             raise ValueError("XTDB transaction cannot mix system times")
 

--- a/polars_hist_db/core/audit.py
+++ b/polars_hist_db/core/audit.py
@@ -51,12 +51,12 @@ class AuditOps:
     def drop(self, connection: Connection):
         TableConfigOps(connection).drop(self._table_config())
 
-    def _table_config(self) -> TableConfig:
+    def _table_config(self, *, xtdb: bool = False) -> TableConfig:
         columns = [
             TableColumnConfig(
                 name="audit_id",
-                data_type="INT",
-                autoincrement=True,
+                data_type="VARCHAR(LENGTH=64)" if xtdb else "INT",
+                autoincrement=not xtdb,
                 table=self._table_name,
             ),
             TableColumnConfig(
@@ -115,7 +115,7 @@ class AuditOps:
     def _empty_xtdb_audit_df(self) -> pl.DataFrame:
         return pl.DataFrame(
             schema={
-                "audit_id": pl.Int32,
+                "audit_id": pl.String,
                 "table_name": pl.Utf8,
                 "data_source_type": pl.Utf8,
                 "data_source": pl.Utf8,
@@ -126,12 +126,11 @@ class AuditOps:
 
     def create(self, connection: Connection) -> Table | TableConfig:
         if _is_xtdb_connection(connection):
-            table_config = self._table_config()
+            table_config = self._table_config(xtdb=True)
             table_config_ops = _xtdb_table_config_ops(connection)
             if not table_config_ops.table_exists(self.schema, self._table_name):
                 table_config_ops.create(table_config)
-                return table_config
-            return table_config_ops.from_table(self.schema, self._table_name)
+            return table_config
 
         audit_table_name = str(self._table_name)
         tbo = TableOps(self.schema, audit_table_name, connection)
@@ -161,14 +160,16 @@ class AuditOps:
         """
         target_fqtn = f"{self.schema}.{target_table_name}"
         if _is_xtdb_connection(connection):
-            from ..backends.xtdb_transport import _execute_xtdb_dml
+            from ..backends.xtdb_transport import _execute_xtdb_transaction
 
             self.create(connection)
-            _execute_xtdb_dml(connection, f"ERASE FROM {target_fqtn} WHERE TRUE")
-            _execute_xtdb_dml(
+            _execute_xtdb_transaction(
                 connection,
-                f"ERASE FROM {self._table_sql()} "
-                f"WHERE table_name = {_sql_literal(target_table_name)}",
+                [
+                    f"ERASE FROM {target_fqtn} WHERE TRUE",
+                    f"ERASE FROM {self._table_sql()} "
+                    f"WHERE table_name = {_sql_literal(target_table_name)}",
+                ],
             )
             LOGGER.info("reset dataset %s (data + audit-log erased)", target_fqtn)
             return
@@ -336,7 +337,7 @@ class AuditOps:
                 self._table_name,
                 candidates,
                 ["data_source"],
-                table_config=self._table_config(),
+                table_config=self._table_config(xtdb=True),
             ).with_columns(pl.col("data_source").cast(pl.Utf8))
             data_source_items = self._filter_unprocessed_items(
                 data_source_items, existing_tbl_entries, data_source_col_name
@@ -454,16 +455,8 @@ class AuditOps:
                     data_source_timestamp.isoformat(),
                 ]
             )
-            new_item["audit_id"] = (
-                int(
-                    hashlib.sha256(audit_id_value.encode()).hexdigest()[:8],
-                    16,
-                )
-                & 0x7FFFFFFF
-            )
-            df = pl.DataFrame([new_item]).with_columns(
-                pl.col("audit_id").cast(pl.Int32)
-            )
+            new_item["audit_id"] = hashlib.sha256(audit_id_value.encode()).hexdigest()
+            df = pl.DataFrame([new_item])
             num_rows_changed = _xtdb_dataframe_ops(connection).table_insert(
                 df,
                 self.schema,
@@ -515,6 +508,7 @@ class AuditOps:
                 f"FROM {self._table_sql()} {where_clause}"
                 ") AS ranked WHERE _rn = 1",
                 schema_overrides={
+                    "audit_id": pl.String,
                     "data_source_ts": pl.Datetime("us", "UTC"),
                     "upload_ts": pl.Datetime("us", "UTC"),
                 },

--- a/polars_hist_db/dataset/entrypoint.py
+++ b/polars_hist_db/dataset/entrypoint.py
@@ -17,7 +17,7 @@ from ..utils.clock import Clock
 from ..config import PolarsHistDbConfig, DatasetConfig, TableConfig, TableConfigs
 from ..config.config import IngestionConfig
 from ..config.input.input_source import InputConfig
-from .scrape import try_run_pipeline_as_transaction
+from .scrape import _to_thread_joined, try_run_pipeline_as_transaction
 
 LOGGER = logging.getLogger(__name__)
 
@@ -56,13 +56,13 @@ async def run_datasets(
     if not selected_datasets:
         LOGGER.error("no datasets processed for %s", dataset_name)
         if owns_engine:
-            await asyncio.to_thread(engine.dispose)
+            await _to_thread_joined(engine.dispose)
         return RunResult(0, 0, ())
 
     ingestion = getattr(config, "ingestion", IngestionConfig())
     errors: list[Optional[Exception]] = [None] * len(selected_datasets)
     try:
-        await asyncio.to_thread(_create_config_tables, engine, config.tables, backend)
+        await _to_thread_joined(_create_config_tables, engine, config.tables, backend)
         await _run_dataset_workers(
             selected_datasets,
             config,
@@ -76,7 +76,7 @@ async def run_datasets(
         )
     finally:
         if owns_engine:
-            await asyncio.to_thread(engine.dispose)
+            await _to_thread_joined(engine.dispose)
 
     failures = tuple(error for error in errors if error is not None)
     return RunResult(len(selected_datasets), len(failures), failures)
@@ -130,7 +130,7 @@ async def _run_dataset_workers(
                     for lock in locks:
                         await lock.acquire()
                         acquired_locks.append(lock)
-                    ingest_connection = await asyncio.to_thread(
+                    ingest_connection = await _to_thread_joined(
                         backend.open_ingest_connection, config.db_config
                     )
                     LOGGER.info("scraping dataset %s", dataset.name)
@@ -146,7 +146,7 @@ async def _run_dataset_workers(
                         raise_on_error=raise_on_error,
                     )
                 finally:
-                    await asyncio.to_thread(
+                    await _to_thread_joined(
                         backend.close_ingest_connection, ingest_connection
                     )
                     for lock in reversed(acquired_locks):

--- a/polars_hist_db/dataset/scrape.py
+++ b/polars_hist_db/dataset/scrape.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import ExitStack
 from datetime import datetime
 import logging
 from random import uniform
@@ -17,6 +18,15 @@ from .extract_item import scrape_extract_item
 from .primary_item import scrape_primary_item
 
 LOGGER = logging.getLogger(__name__)
+
+
+async def _to_thread_joined(function, /, *args):
+    task = asyncio.create_task(asyncio.to_thread(function, *args))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        await task
+        raise
 
 
 def _scrape_pipeline_item(
@@ -89,11 +99,24 @@ def _run_pipeline_as_transaction(
     backend: Any = None,
     ingest_connection: Any = None,
 ):
+    system_times = {timestamp for timestamp, _ in partitions}
+    if backend.name == "xtdb" and len(system_times) > 1:
+        raise NonRetryableException(
+            "XTDB atomic ingestion requires one system-time per batch"
+        )
     main_table_config: TableConfig = tables[dataset.pipeline.get_main_table_name()[1]]
     tbl_to_header_map = dataset.pipeline.get_header_map(main_table_config.name)
     header_keys = [tbl_to_header_map.get(k, k) for k in main_table_config.primary_keys]
 
-    with backend.connection_scope(engine) as connection:
+    with backend.connection_scope(engine) as connection, ExitStack() as stack:
+        ingest_transaction = getattr(backend, "ingest_transaction", None)
+        if ingest_transaction is not None:
+            stack.enter_context(
+                ingest_transaction(
+                    connection,
+                    next(iter(system_times)) if system_times else None,
+                )
+            )
         staging = backend.staging(
             connection,
             ingest_connection=ingest_connection,
@@ -191,7 +214,7 @@ async def try_run_pipeline_as_transaction(
         raise ValueError("retry_jitter must be between 0 and 1")
     for attempt in range(num_retries):
         try:
-            await asyncio.to_thread(
+            await _to_thread_joined(
                 _run_pipeline_as_transaction,
                 partitions,
                 dataset,

--- a/polars_hist_db/overrides/access.py
+++ b/polars_hist_db/overrides/access.py
@@ -123,11 +123,13 @@ class InMemoryDocumentAccessStore:
             None,
         )
         if existing is not None and allow_existing:
-            return _existing_result(
+            result = _existing_result(
                 existing,
                 self._all_grants(existing.document_id),
                 owning_group,
             )
+            self._commands[idempotency_key] = (payload, result)
+            return result
         if document_id in self._documents:
             raise DocumentAccessError("document already exists")
         if existing is not None:
@@ -144,6 +146,12 @@ class InMemoryDocumentAccessStore:
             recorded_at,
             owning_group=owning_group,
         )
+        if len({grant.grant_id for grant in grants}) != len(grants) or len(
+            {grant.group_name.casefold() for grant in grants}
+        ) != len(grants):
+            raise DocumentAccessError("initial grants must be unique")
+        if any(grant.grant_id in self._grants for grant in grants):
+            raise DocumentAccessError("grant already exists")
         self._documents[document_id] = document
         for grant in grants:
             self._insert_grant(document, grant, actor_id, recorded_at)
@@ -257,10 +265,12 @@ class InMemoryDocumentAccessStore:
         document = self._active(document_id, expected_revision)
         _require_time(recorded_at)
         if any(
-            item.active and item.group_name == grant.group_name
+            item.active and item.group_name.casefold() == grant.group_name.casefold()
             for item in self._all_grants(document_id)
         ):
             raise DocumentAccessError("group already has an active grant")
+        if grant.grant_id in self._grants:
+            raise DocumentAccessError("grant already exists")
         document = self._advance(document)
         self._documents[document_id] = document
         self._insert_grant(document, grant, actor_id, recorded_at)

--- a/polars_hist_db/overrides/sql.py
+++ b/polars_hist_db/overrides/sql.py
@@ -638,9 +638,11 @@ class MariaDbDocumentAccessStore:
         if allow_existing:
             existing = self._by_group_and_name(owning_group, normalized_name)
             if existing is not None:
-                return _existing_result(
+                return self._record_existing(
+                    idempotency_key,
+                    payload,
+                    recorded_at,
                     existing,
-                    self._all_grants(existing.document_id),
                     owning_group,
                 )
         document = AccessDocument(
@@ -670,9 +672,11 @@ class MariaDbDocumentAccessStore:
                 return duplicate
             existing = self._by_group_and_name(owning_group, normalized_name)
             if existing is not None and allow_existing:
-                return _existing_result(
+                return self._record_existing(
+                    idempotency_key,
+                    payload,
+                    recorded_at,
                     existing,
-                    self._all_grants(existing.document_id),
                     owning_group,
                 )
             raise DocumentAccessError("document or grant already exists") from exc
@@ -895,12 +899,14 @@ class MariaDbDocumentAccessStore:
         kind: str,
         recorded_at: datetime,
         document: AccessDocument,
+        result: AccessMutationResult | None = None,
     ) -> AccessMutationResult:
-        result = AccessMutationResult(
-            document,
-            self._all_grants(document.document_id, include_revoked=True),
-            accepted=True,
-        )
+        if result is None:
+            result = AccessMutationResult(
+                document,
+                self._all_grants(document.document_id, include_revoked=True),
+                accepted=True,
+            )
         self.connection.execute(
             self.commands.insert().values(
                 idempotency_key=key,
@@ -913,6 +919,30 @@ class MariaDbDocumentAccessStore:
             )
         )
         return result
+
+    def _record_existing(
+        self,
+        key: str,
+        payload: str,
+        recorded_at: datetime,
+        document: AccessDocument,
+        owning_group: str | None,
+    ) -> AccessMutationResult:
+        result = _existing_result(
+            document,
+            self._all_grants(document.document_id),
+            owning_group,
+        )
+        try:
+            with self.connection.begin_nested():
+                return self._record(
+                    key, payload, "create", recorded_at, document, result
+                )
+        except IntegrityError:
+            duplicate = self._duplicate(key, payload)
+            if duplicate:
+                return duplicate
+            raise
 
 
 def _access_document(row: Any) -> AccessDocument:

--- a/polars_hist_db/overrides/xtdb.py
+++ b/polars_hist_db/overrides/xtdb.py
@@ -666,9 +666,11 @@ class XtdbDocumentAccessStore:
         if allow_existing:
             existing = self._by_group_and_name(owning_group, normalized_name)
             if existing is not None:
-                return _existing_result(
+                return self._record_existing(
+                    idempotency_key,
+                    payload,
+                    recorded_at,
                     existing,
-                    self._all_grants(existing.document_id),
                     owning_group,
                 )
         if len({grant.grant_id for grant in grants}) != len(grants) or len(
@@ -718,9 +720,11 @@ class XtdbDocumentAccessStore:
             if allow_existing and str(exc) == "document name already exists":
                 existing = self._by_group_and_name(owning_group, normalized_name)
                 if existing is not None:
-                    return _existing_result(
+                    return self._record_existing(
+                        idempotency_key,
+                        payload,
+                        recorded_at,
                         existing,
-                        self._all_grants(existing.document_id),
                         owning_group,
                     )
             raise
@@ -913,6 +917,31 @@ class XtdbDocumentAccessStore:
 
     def _command_assertion(self, key: str) -> str:
         return f"ASSERT NOT EXISTS (SELECT 1 FROM {_table_name(self.commands)} WHERE idempotency_key = {_literal(key, 'VARCHAR(128)')}), 'idempotency key already exists'"
+
+    def _record_existing(
+        self,
+        key: str,
+        payload: str,
+        recorded_at: datetime,
+        document: AccessDocument,
+        owning_group: str | None,
+    ) -> AccessMutationResult:
+        result = _existing_result(
+            document,
+            self._all_grants(document.document_id),
+            owning_group,
+        )
+        duplicate = self._run(
+            [
+                self._command_assertion(key),
+                self._command_insert(key, payload, "create", result, recorded_at),
+            ],
+            key,
+            payload,
+            document.document_id,
+            None,
+        )
+        return result if duplicate is None else duplicate
 
     def _active_assertion(self, document_id: str, revision: int) -> str:
         return (

--- a/tests/audit/test_search_files.py
+++ b/tests/audit/test_search_files.py
@@ -90,7 +90,7 @@ def test_latest_entry(fixture_with_table):
 
         audit_df_schema = empty_audit_df.schema
         assert len(audit_df_schema) == 6
-        assert audit_df_schema["audit_id"] == pl.Int32
+        assert audit_df_schema["audit_id"] == pl.String
         assert audit_df_schema["table_name"] == pl.Categorical
         assert audit_df_schema["data_source_type"] == pl.Categorical
         assert audit_df_schema["data_source"] == pl.Categorical

--- a/tests/audit/test_search_files.py
+++ b/tests/audit/test_search_files.py
@@ -90,7 +90,7 @@ def test_latest_entry(fixture_with_table):
 
         audit_df_schema = empty_audit_df.schema
         assert len(audit_df_schema) == 6
-        assert audit_df_schema["audit_id"] == pl.String
+        assert audit_df_schema["audit_id"] == pl.Int32
         assert audit_df_schema["table_name"] == pl.Categorical
         assert audit_df_schema["data_source_type"] == pl.Categorical
         assert audit_df_schema["data_source"] == pl.Categorical

--- a/tests/backends/test_audit_reset_dataset.py
+++ b/tests/backends/test_audit_reset_dataset.py
@@ -72,7 +72,7 @@ def test_xtdb_reset_dataset_erases_target_and_audit(monkeypatch):
             return True
 
         def from_table(self, table_schema, table_name):
-            return AuditOps(table_schema)._table_config()
+            return AuditOps(table_schema)._table_config(xtdb=True)
 
         def create(self, table_config):
             return table_config
@@ -82,16 +82,16 @@ def test_xtdb_reset_dataset_erases_target_and_audit(monkeypatch):
         _TableConfigOps,
     )
     monkeypatch.setattr(
-        "polars_hist_db.backends.xtdb_transport._execute_xtdb_dml",
-        lambda connection, query, *a, **k: executed.append(query),
+        "polars_hist_db.backends.xtdb_transport._execute_xtdb_transaction",
+        lambda connection, statements: executed.append(list(statements)),
     )
 
     AuditOps("fakedata").reset_dataset("records", _XtdbConnection())
 
-    assert len(executed) == 2
-    assert "ERASE FROM fakedata.records WHERE TRUE" in executed[0]
-    assert "ERASE FROM fakedata.__audit_log" in executed[1]
-    assert "WHERE table_name = 'records'" in executed[1]
+    assert len(executed) == 1
+    assert executed[0][0] == "ERASE FROM fakedata.records WHERE TRUE"
+    assert "ERASE FROM fakedata.__audit_log" in executed[0][1]
+    assert "WHERE table_name = 'records'" in executed[0][1]
 
 
 def test_mariadb_reset_dataset_wipes_history_on_temporal_table(monkeypatch):

--- a/tests/backends/test_xtdb_audit_ops.py
+++ b/tests/backends/test_xtdb_audit_ops.py
@@ -134,7 +134,7 @@ def test_xtdb_audit_filter_items_queries_only_candidate_sources(monkeypatch):
             return True
 
         def from_table(self, table_schema, table_name):
-            return AuditOps(table_schema)._table_config()
+            return AuditOps(table_schema)._table_config(xtdb=True)
 
     class _DataframeOps:
         def __init__(self, connection):
@@ -320,7 +320,7 @@ def test_xtdb_audit_add_entry_writes_via_backend_dataframe_ops(monkeypatch):
             return True
 
         def from_table(self, table_schema, table_name):
-            return AuditOps(table_schema)._table_config()
+            return AuditOps(table_schema)._table_config(xtdb=True)
 
     class _DataframeOps:
         def __init__(self, connection):
@@ -350,7 +350,8 @@ def test_xtdb_audit_add_entry_writes_via_backend_dataframe_ops(monkeypatch):
     assert table_name == "__audit_log"
     assert table_config.name == "__audit_log"
     assert "audit_id" in inserted_df.columns
-    assert inserted_df.schema["audit_id"] == pl.Int32
+    assert inserted_df.schema["audit_id"] == pl.String
+    assert len(inserted_df["audit_id"].item()) == 64
     assert inserted_df.select("table_name", "data_source").rows() == [
         ("trades", "trades.csv")
     ]

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -152,6 +152,41 @@ def test_xtdb_buffered_transaction_allows_reads_and_excludes_support_relations()
     ]
 
 
+def test_xtdb_buffered_transaction_retries_invalid_system_time_at_commit():
+    driver_connection = Mock()
+    driver_connection.autocommit = False
+    commit_count = 0
+
+    def execute(statement):
+        nonlocal commit_count
+        if statement == "COMMIT":
+            commit_count += 1
+            if commit_count == 1:
+                raise RuntimeError("invalid-system-time: specified system-time older")
+
+    driver_connection.execute.side_effect = execute
+    connection = Mock()
+    connection.info = {}
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+    system_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    with _xtdb_buffered_transaction_scope(connection, system_time):
+        _execute_xtdb_dml(
+            connection,
+            "INSERT INTO test.target (_id) VALUES ('x')",
+            system_time=system_time,
+        )
+
+    statements = [call.args[0] for call in driver_connection.execute.call_args_list]
+    assert (
+        sum(statement.startswith("BEGIN READ WRITE") for statement in statements) == 2
+    )
+    assert statements.count("INSERT INTO test.target (_id) VALUES ('x')") == 2
+    assert statements.count("COMMIT") == 2
+    assert statements.count("ROLLBACK") == 1
+
+
 def test_xtdb_dml_uses_driver_autocommit_for_explicit_begin():
     driver_connection = Mock()
     driver_connection.autocommit = False

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -27,6 +27,10 @@ from polars_hist_db.backends.xtdb_arrow import (
     _xtdb_insert_casts,
 )
 from polars_hist_db.backends.xtdb_query import _xtdb_single_primary_key_alias
+from polars_hist_db.backends.xtdb_transport import (
+    _xtdb_buffered_transaction_scope,
+    _xtdb_buffering_paused,
+)
 from polars_hist_db.config import (
     DeltaConfig,
     TableColumnConfig,
@@ -116,6 +120,34 @@ def test_xtdb_transaction_scope_commits_all_dml_together():
         "BEGIN READ WRITE",
         "INSERT INTO test.x (_id) VALUES ('x')",
         "INSERT INTO test.y (_id) VALUES ('y')",
+        "COMMIT",
+    ]
+
+
+def test_xtdb_buffered_transaction_allows_reads_and_excludes_support_relations():
+    driver_connection = Mock()
+    driver_connection.autocommit = False
+    connection = Mock()
+    connection.info = {}
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+
+    with _xtdb_buffered_transaction_scope(connection):
+        _execute_xtdb_dml(connection, "INSERT INTO test.target (_id) VALUES ('x')")
+        assert driver_connection.execute.call_count == 0
+        with _xtdb_buffering_paused(connection):
+            _execute_xtdb_dml(
+                connection, "INSERT INTO test.lookup (_id) VALUES ('lookup')"
+            )
+        _execute_xtdb_dml(connection, "INSERT INTO test.audit (_id) VALUES ('audit')")
+
+    assert [call.args[0] for call in driver_connection.execute.call_args_list] == [
+        "BEGIN READ WRITE",
+        "INSERT INTO test.lookup (_id) VALUES ('lookup')",
+        "COMMIT",
+        "BEGIN READ WRITE",
+        "INSERT INTO test.target (_id) VALUES ('x')",
+        "INSERT INTO test.audit (_id) VALUES ('audit')",
         "COMMIT",
     ]
 

--- a/tests/backends/test_xtdb_backend.py
+++ b/tests/backends/test_xtdb_backend.py
@@ -15,6 +15,7 @@ from polars_hist_db.backends.xtdb import (
     XtdbTableConfigOps,
     _execute_xtdb_dml,
     _execute_xtdb_transaction,
+    _xtdb_transaction_scope,
     _xtdb_cast_type,
     _xtdb_declared_columns,
     _xtdb_physical_type_family,
@@ -98,6 +99,25 @@ def test_xtdb_transaction_uses_driver_autocommit_for_explicit_begin():
     assert driver_connection.execute.call_args_list[0].args == ("BEGIN READ WRITE",)
     assert driver_connection.execute.call_args_list[-1].args == ("COMMIT",)
     assert driver_connection.autocommit is False
+
+
+def test_xtdb_transaction_scope_commits_all_dml_together():
+    driver_connection = Mock()
+    driver_connection.autocommit = False
+    connection = Mock()
+    connection.info = {}
+    connection.connection.driver_connection = driver_connection
+
+    with _xtdb_transaction_scope(connection):
+        _execute_xtdb_dml(connection, "INSERT INTO test.x (_id) VALUES ('x')")
+        _execute_xtdb_dml(connection, "INSERT INTO test.y (_id) VALUES ('y')")
+
+    assert [call.args[0] for call in driver_connection.execute.call_args_list] == [
+        "BEGIN READ WRITE",
+        "INSERT INTO test.x (_id) VALUES ('x')",
+        "INSERT INTO test.y (_id) VALUES ('y')",
+        "COMMIT",
+    ]
 
 
 def test_xtdb_dml_uses_driver_autocommit_for_explicit_begin():

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -10,6 +10,8 @@ from polars_hist_db.backends.xtdb import (
     XtdbBackend,
     XtdbStagingOps,
     _xtdb_deduced_foreign_key_payload,
+    _xtdb_deduced_numeric_foreign_key_ids,
+    _xtdb_integer_bits,
 )
 from polars_hist_db.config import (
     DatasetConfig,
@@ -35,6 +37,26 @@ def _empty_numeric_key_occupancy():
 @contextmanager
 def _uploaded_keys(dataframe_ops, df, table_schema):
     yield f"{table_schema}.__uploaded_keys"
+
+
+@pytest.mark.parametrize(
+    ("sql_type", "expected_bits"),
+    [("TINYINT", 8), ("SMALLINT", 16), ("INT", 32), ("BIGINT", 64)],
+)
+def test_xtdb_generated_numeric_keys_fit_configured_integer_width(
+    sql_type, expected_bits
+):
+    table = TableConfig(
+        schema="ref",
+        name="parents",
+        columns=[TableColumnConfig("parents", "id", sql_type)],
+    )
+
+    generated = _xtdb_deduced_numeric_foreign_key_ids(
+        pl.Series(["xtdb-fk-v1:test"]), _xtdb_integer_bits(table, "id") - 1
+    ).item()
+
+    assert -(1 << (expected_bits - 1)) <= generated < 0
 
 
 @pytest.fixture(autouse=True)

--- a/tests/core/test_correctness_regressions.py
+++ b/tests/core/test_correctness_regressions.py
@@ -132,7 +132,7 @@ def test_latest_audit_entry_keeps_utc_schema_when_empty(monkeypatch):
     )
     empty = pl.DataFrame(
         schema={
-            "audit_id": pl.Int32,
+            "audit_id": pl.String,
             "table_name": pl.String,
             "data_source_type": pl.String,
             "data_source": pl.String,

--- a/tests/dataset/test_scrape_transactions.py
+++ b/tests/dataset/test_scrape_transactions.py
@@ -1,10 +1,65 @@
 from types import SimpleNamespace
+from threading import Event
+import asyncio
+from contextlib import nullcontext
+from datetime import datetime, timezone
 
 import pytest
 
 from polars_hist_db.loaders.input_source import BatchFinalizer
-from polars_hist_db.dataset.scrape import try_run_pipeline_as_transaction
+from polars_hist_db.dataset.scrape import (
+    _run_pipeline_as_transaction,
+    try_run_pipeline_as_transaction,
+)
+from polars_hist_db.utils import NonRetryableException
 from polars_hist_db.types import TypeContractError
+
+
+@pytest.mark.asyncio
+async def test_pipeline_cancellation_waits_for_started_thread(monkeypatch):
+    started = Event()
+    release = Event()
+
+    def run_batch(*args):
+        started.set()
+        release.wait()
+
+    monkeypatch.setattr(
+        "polars_hist_db.dataset.scrape._run_pipeline_as_transaction", run_batch
+    )
+    task = asyncio.create_task(
+        try_run_pipeline_as_transaction(
+            [], object(), object(), object(), BatchFinalizer()
+        )
+    )
+    assert await asyncio.to_thread(started.wait, 1)
+
+    task.cancel()
+    await asyncio.sleep(0)
+    assert not task.done()
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+def test_xtdb_atomic_batch_rejects_multiple_system_times():
+    backend = SimpleNamespace(
+        name="xtdb", connection_scope=lambda engine: nullcontext(object())
+    )
+    partitions = [
+        (datetime(2026, 1, 1, tzinfo=timezone.utc), object()),
+        (datetime(2026, 1, 2, tzinfo=timezone.utc), object()),
+    ]
+
+    with pytest.raises(NonRetryableException, match="one system-time"):
+        _run_pipeline_as_transaction(
+            partitions,
+            object(),
+            object(),
+            object(),
+            BatchFinalizer(),
+            backend=backend,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/overrides/test_document_access_store.py
+++ b/tests/overrides/test_document_access_store.py
@@ -188,3 +188,49 @@ def test_allow_existing_idempotency_ignores_generated_identifiers():
 
     assert retried.document == created.document
     assert retried.duplicate is True
+
+
+def test_allow_existing_records_the_idempotency_key():
+    store = InMemoryDocumentAccessStore()
+    store.create(
+        "doc-1",
+        "Analysts",
+        None,
+        "admin",
+        TIME,
+        idempotency_key="create-1",
+        owning_group="analysts",
+    )
+    store.create(
+        "generated-doc",
+        "Analysts",
+        None,
+        "admin",
+        TIME,
+        idempotency_key="ensure-1",
+        owning_group="analysts",
+        allow_existing=True,
+    )
+
+    with pytest.raises(IdempotencyConflict):
+        store.create("doc-2", "Other", None, "admin", TIME, idempotency_key="ensure-1")
+
+
+def test_invalid_initial_grants_do_not_partially_create_document():
+    store = InMemoryDocumentAccessStore()
+
+    with pytest.raises(ValueError, match="initial grants must be unique"):
+        store.create(
+            "doc-1",
+            "Analysts",
+            None,
+            "admin",
+            TIME,
+            initial_grants=[
+                AccessGrantInput("grant-1", "group", "viewer"),
+                AccessGrantInput("grant-2", "GROUP", "editor"),
+            ],
+            idempotency_key="create-1",
+        )
+
+    assert store.get("doc-1") is None


### PR DESCRIPTION
## Summary

- make XTDB target writes and audit recording share one transaction, and make dataset reset atomic
- replace truncated XTDB audit IDs with full SHA-256 hashes and size generated integer keys correctly
- wait for started worker threads before closing resources
- persist allow-existing idempotency results and prevalidate in-memory grants
- reject XTDB batches containing multiple system timestamps because XTDB supports one transaction-level system time

## Verification

- .venv/bin/pytest -q: 355 passed, 19 deselected
- .venv/bin/ruff check .: passed
- .venv/bin/ruff format --check .: passed
- git diff --check: passed

Mypy was not available as a reliable check: the installed mypy 2.3.0 crashes internally, while the commit hook uv environment failed rebuilding Quarto because the machine ran out of disk space. Live integration tests remain deselected.