### PR TITLE
feat: support typed array ingestion columns

### DIFF
--- a/polars_hist_db/types.py
+++ b/polars_hist_db/types.py
@@ -1,7 +1,7 @@
 import dateutil.parser
 import logging
 import re
-from typing import Collection, Dict, List, Mapping, Optional, Tuple, Union
+from typing import Collection, Dict, List, Mapping, Optional, Tuple, Union, cast
 
 import polars as pl
 from sql_metadata import Parser
@@ -139,6 +139,10 @@ class _TypeConversionUtils:
 class SQLType:
     @staticmethod
     def from_polars(pl_dtype: pl.DataType, default_varchar_length: int = 255) -> str:
+        if isinstance(pl_dtype, pl.List):
+            inner = cast(pl.DataType, pl_dtype.inner)
+            return f"ARRAY({SQLType.from_polars(inner, default_varchar_length)})"
+
         idx = _TypeConversionUtils._rowidx_from_polars_type(pl_dtype)
         if idx >= 0:
             return TYPE_PRIORITY_MAP[idx][0]
@@ -176,6 +180,9 @@ class PolarsType:
         type_name, params, param_dict = _TypeConversionUtils._parse_parameterised_type(
             t
         )
+        if type_name == "ARRAY" and len(params) == 1:
+            return pl.List(PolarsType.from_sql(params[0]))
+
         if type_name == "VARCHAR" or type_name.endswith("TEXT"):
             return pl.Utf8()
 

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -35,3 +35,10 @@ def test_timezone_aware_timestamp_type_roundtrip() -> None:
     sqlalchemy_type = SQLAlchemyType.from_sql("TIMESTAMP WITH TIME ZONE")
     assert isinstance(sqlalchemy_type, TIMESTAMP)
     assert sqlalchemy_type.timezone is True
+
+
+def test_array_type_roundtrip() -> None:
+    dtype = pl.List(pl.Float64)
+
+    assert PolarsType.from_sql("ARRAY(DOUBLE)") == dtype
+    assert SQLType.from_polars(dtype) == "ARRAY(DOUBLE)"

--- a/tests/loaders/test_input_schema.py
+++ b/tests/loaders/test_input_schema.py
@@ -58,6 +58,15 @@ def test_input_schema_types_nulls_and_drops_declared_input_only_columns() -> Non
     assert transformed.columns == ["id", "note"]
 
 
+def test_input_schema_preserves_declared_array_input() -> None:
+    columns = [_column("coordinates", "ARRAY(DOUBLE)", column_type="input_only")]
+
+    typed = enforce_input_schema(pl.DataFrame({"coordinates": [[1.5, 2.5]]}), columns)
+
+    assert typed.schema == {"coordinates": pl.List(pl.Float64)}
+    assert apply_transformations(typed, columns).is_empty()
+
+
 def test_input_schema_accepts_only_null_structural_ancestors() -> None:
     columns = [_column("payload.child", "VARCHAR(32)")]
 


### PR DESCRIPTION
Adds recursive ARRAY(...) mapping between SQL-style schema declarations and native Polars list types. This lets strict input schemas validate structured list columns without converting them to strings. Includes type round-trip and input-schema coverage.