### PR TITLE
fix: support optional rows in typed projections

### DIFF
--- a/polars_hist_db/config/dataset.py
+++ b/polars_hist_db/config/dataset.py
@@ -53,7 +53,8 @@ class PipelineColumn:
     aggregation: Optional[str] = None
     deduce_foreign_key: bool = False
     value_if_missing: Optional[str] = None
-    nullable: bool = True
+    nullable: Optional[bool] = None
+    omit_row_if_null: bool = False
 
 
 @dataclass(frozen=True)
@@ -63,6 +64,7 @@ class PipelineExtractColumn:
     target: str
     required: bool = False
     deduce_foreign_key: bool = False
+    omit_row_if_null: bool = False
 
 
 @dataclass(init=False)
@@ -134,6 +136,7 @@ class Pipeline:
                     target=column.target or "",
                     required=column.required,
                     deduce_foreign_key=column.deduce_foreign_key,
+                    omit_row_if_null=column.omit_row_if_null,
                 )
                 for column in columns
                 if column.pipeline_id == pipeline_id
@@ -180,7 +183,8 @@ class Pipeline:
             aggregation=column.get("aggregation"),
             deduce_foreign_key=bool(column.get("deduce_foreign_key")),
             value_if_missing=column.get("value_if_missing"),
-            nullable=True if column.get("nullable") is None else column["nullable"],
+            nullable=column.get("nullable"),
+            omit_row_if_null=bool(column.get("omit_row_if_null")),
         )
 
     @staticmethod
@@ -237,7 +241,13 @@ class Pipeline:
                         aggregation=column.aggregation,
                         deduce_foreign_key=column.deduce_foreign_key,
                         value_if_missing=column.value_if_missing,
-                        nullable=(table_column.nullable if table_column else None),
+                        nullable=(
+                            column.nullable
+                            if column.nullable is not None
+                            else table_column.nullable
+                            if table_column
+                            else None
+                        ),
                         required=column.required,
                     )
                 )

--- a/polars_hist_db/pipeline_projection.py
+++ b/polars_hist_db/pipeline_projection.py
@@ -1,9 +1,41 @@
-from typing import Any, Optional
+import logging
+from typing import Any, Optional, Sequence
 
 import polars as pl
 
-from .config import TableConfig, ValidTimeConfig
+from .config import PipelineExtractColumn, TableConfig, ValidTimeConfig
 from .types import PolarsType
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _omit_inapplicable_rows(
+    stage_df: pl.DataFrame,
+    upload_items: Sequence[PipelineExtractColumn],
+) -> pl.DataFrame:
+    sources = [item.source for item in upload_items if item.omit_row_if_null]
+    if not sources:
+        return stage_df
+
+    missing = sorted(set(sources).difference(stage_df.columns))
+    if missing:
+        raise ValueError(
+            "omit-row mapping references missing source column(s): "
+            + ", ".join(missing)
+        )
+
+    result = stage_df.filter(
+        pl.all_horizontal(pl.col(source).is_not_null() for source in sources)
+    )
+    omitted = stage_df.height - result.height
+    if omitted:
+        LOGGER.warning(
+            "omitted %d pipeline row(s) because %s contained null",
+            omitted,
+            ", ".join(sources),
+        )
+    return result
 
 
 def _include_valid_time_source_columns(
@@ -70,6 +102,7 @@ def project_staged_pipeline_item_dataframe(
     valid_time: Optional[ValidTimeConfig],
 ) -> pl.DataFrame:
     upload_items = dataset.pipeline.extract_items(pipeline_id)
+    stage_df = _omit_inapplicable_rows(stage_df, upload_items)
     src_tgt_colname_map = {item.source: item.target for item in upload_items}
     selected_columns = [item.source for item in upload_items]
     selected_columns = _include_valid_time_source_columns(

--- a/tests/backends/test_xtdb_staging_ops.py
+++ b/tests/backends/test_xtdb_staging_ops.py
@@ -581,6 +581,68 @@ def test_xtdb_staging_rejects_missing_required_pipeline_columns(monkeypatch):
         )
 
 
+def test_xtdb_staging_omits_explicitly_inapplicable_rows(caplog):
+    dataset = DatasetConfig(
+        name="record_stream",
+        delta_table_schema="sample",
+        input_config={"type": "dsv", "search_paths": []},
+        pipeline=[
+            {
+                "schema": "sample",
+                "table": "records",
+                "type": "primary",
+                "columns": [
+                    {"source": "record_id", "target": "record_id"},
+                    {
+                        "source": "observed_at",
+                        "target": "observed_at",
+                        "nullable": True,
+                        "omit_row_if_null": True,
+                    },
+                ],
+            }
+        ],
+    )
+    table_config = TableConfig(
+        schema="sample",
+        name="records",
+        primary_keys=["record_id"],
+        columns=[
+            TableColumnConfig("records", "record_id", "INT", nullable=False),
+            TableColumnConfig(
+                "records", "observed_at", "TIMESTAMP WITH TIME ZONE", nullable=False
+            ),
+        ],
+    )
+    stage_df = pl.DataFrame(
+        {
+            "record_id": [1, 2],
+            "observed_at": [
+                datetime(2030, 1, 1, tzinfo=timezone.utc),
+                None,
+            ],
+        }
+    )
+    staging = XtdbStagingOps(object())
+    staging._stage_run_cache["stage-1"] = stage_df
+
+    result = staging.prepare_pipeline_item_dataframe(
+        "stage-1",
+        dataset,
+        0,
+        table_config,
+        valid_time=ValidTimeConfig(
+            schema="sample", table="records", from_column="observed_at"
+        ),
+    )
+
+    assert result.to_dict(as_series=False) == {
+        "record_id": [1],
+        "observed_at": [datetime(2030, 1, 1, tzinfo=timezone.utc)],
+    }
+    assert "omitted 1 pipeline row" in caplog.text
+
+
 def test_xtdb_staging_cleanup_only_discards_memory_cache():
     connection = Mock()
     staging = XtdbStagingOps(connection)

--- a/tests/config/test_pipeline_config.py
+++ b/tests/config/test_pipeline_config.py
@@ -19,7 +19,13 @@ def test_pipeline_reuses_cached_lookups():
                 "table": "events",
                 "type": "primary",
                 "columns": [
-                    {"source": "id", "target": "id", "required": True},
+                    {
+                        "source": "id",
+                        "target": "id",
+                        "required": True,
+                        "nullable": True,
+                        "omit_row_if_null": True,
+                    },
                     {"source": "country", "target": "country_id"},
                 ],
             },
@@ -42,7 +48,13 @@ def test_pipeline_reuses_cached_lookups():
     assert pipeline.get_header_map("events") == {"id": "id", "country_id": "country"}
     assert pipeline.extract_items(1) is extract_items
     assert extract_items == (
-        PipelineExtractColumn("events", "id", "id", required=True),
+        PipelineExtractColumn(
+            "events",
+            "id",
+            "id",
+            required=True,
+            omit_row_if_null=True,
+        ),
         PipelineExtractColumn("events", "country", "country_id"),
     )
 
@@ -117,6 +129,7 @@ def test_pipeline_builds_normalized_table_metadata_without_dataframes():
     assert definitions[("ref", "country_id")].deduce_foreign_key is True
     assert definitions[("ref", "country")].target_data_type == "VARCHAR(64)"
     assert definitions[("sample", "id")].required is True
+    assert definitions[("sample", "id")].nullable is False
     assert definitions[("sample", "unused_payload_field")].column_type == "input_only"
     assert definitions[("sample", "raw_date")].column_type == "dsv_only"
     assert definitions[("sample", "raw_date")].table is None
@@ -128,3 +141,44 @@ def test_pipeline_builds_normalized_table_metadata_without_dataframes():
         ("country_id", "INT"),
         ("event_date", "DATE"),
     ]
+
+
+def test_pipeline_input_nullability_can_override_required_target():
+    pipeline = Pipeline(
+        [
+            {
+                "schema": "sample",
+                "table": "records",
+                "type": "primary",
+                "columns": [
+                    {
+                        "source": "observed_at",
+                        "target": "observed_at",
+                        "nullable": True,
+                        "omit_row_if_null": True,
+                    }
+                ],
+            }
+        ]
+    )
+    tables = TableConfigs(
+        items=[
+            {
+                "schema": "sample",
+                "name": "records",
+                "primary_keys": ["observed_at"],
+                "columns": [
+                    {
+                        "name": "observed_at",
+                        "data_type": "TIMESTAMP WITH TIME ZONE",
+                        "nullable": False,
+                    }
+                ],
+            }
+        ]
+    )
+
+    definitions = pipeline.build_ingestion_column_definitions(tables)
+
+    assert definitions[0].nullable is True
+    assert tables["records"].columns[0].nullable is False


### PR DESCRIPTION
## Summary
- let pipeline input nullability inherit target nullability unless explicitly overridden
- explicitly omit inapplicable projected rows when configured, while retaining strict target constraints
- warn with the omitted-row count

## Verification
- 361 tests passed
- ruff check and format passed
- mypy passed