### PR TITLE
fix: avoid rejected historical XTDB transactions

### DIFF
--- a/polars_hist_db/backends/xtdb_transport.py
+++ b/polars_hist_db/backends/xtdb_transport.py
@@ -222,7 +222,8 @@ def _xtdb_transaction_scope(
     begin_sql = "BEGIN READ WRITE"
     if system_time is not None:
         system_time = _next_xtdb_system_time(connection, system_time)
-        begin_sql += f" WITH (SYSTEM_TIME = {_xtdb_timestamp_literal(system_time)})"
+        if system_time is not None:
+            begin_sql += f" WITH (SYSTEM_TIME = {_xtdb_timestamp_literal(system_time)})"
     try:
         driver_connection.execute(begin_sql)
     except Exception as exc:
@@ -309,12 +310,28 @@ def _xtdb_timestamp_literal(value: datetime) -> str:
     return f"{timestamp_type} '{escaped}'"
 
 
-def _next_xtdb_system_time(connection: Any, system_time: datetime) -> datetime:
+def _latest_xtdb_system_time(connection: Any) -> datetime | None:
+    execute = getattr(connection, "execute", None)
+    if not callable(execute):
+        return None
+    result = execute(
+        text("SELECT system_time FROM xt.txs ORDER BY system_time DESC LIMIT 1")
+    )
+    latest = result.scalar_one_or_none()
+    _rollback_xtdb_connection(connection)
+    return latest if isinstance(latest, datetime) else None
+
+
+def _next_xtdb_system_time(connection: Any, system_time: datetime) -> datetime | None:
     info = getattr(connection, "info", None)
     if not isinstance(info, dict):
         return system_time
 
     last_system_time = info.get(_XTDB_LAST_SYSTEM_TIME_KEY)
+    if not isinstance(last_system_time, datetime):
+        latest_system_time = _latest_xtdb_system_time(connection)
+        if latest_system_time is not None and system_time < latest_system_time:
+            return None
     if isinstance(last_system_time, datetime) and system_time <= last_system_time:
         system_time = last_system_time + timedelta(microseconds=1)
     info[_XTDB_LAST_SYSTEM_TIME_KEY] = system_time
@@ -437,10 +454,11 @@ def _execute_xtdb_dml(
     begin_sql = "BEGIN READ WRITE"
     if system_time is not None:
         system_time = _next_xtdb_system_time(connection, system_time)
-        begin_sql = (
-            "BEGIN READ WRITE WITH "
-            f"(SYSTEM_TIME = {_xtdb_timestamp_literal(system_time)})"
-        )
+        if system_time is not None:
+            begin_sql = (
+                "BEGIN READ WRITE WITH "
+                f"(SYSTEM_TIME = {_xtdb_timestamp_literal(system_time)})"
+            )
     driver_connection.execute(begin_sql)
     try:
         if rows is None:
@@ -510,10 +528,11 @@ def _execute_xtdb_arrow_copy(
             driver_connection.autocommit = True
         if system_time is not None:
             system_time = _next_xtdb_system_time(connection, system_time)
-            begin_sql = (
-                "BEGIN READ WRITE WITH "
-                f"(SYSTEM_TIME = {_xtdb_timestamp_literal(system_time)})"
-            )
+            if system_time is not None:
+                begin_sql = (
+                    "BEGIN READ WRITE WITH "
+                    f"(SYSTEM_TIME = {_xtdb_timestamp_literal(system_time)})"
+                )
 
     arrow_table = _normalize_xtdb_ingest_arrow(df.to_arrow())
     require_unique_arrow_field_names(

--- a/tests/backends/test_xtdb_dataframe_ops.py
+++ b/tests/backends/test_xtdb_dataframe_ops.py
@@ -98,6 +98,30 @@ def test_xtdb_dml_retries_with_append_time_when_system_time_is_too_old():
     ]
 
 
+def test_xtdb_dml_uses_append_time_without_submitting_known_old_system_time():
+    driver_connection = Mock()
+    connection = Mock()
+    connection.info = {}
+    connection.connection.driver_connection = driver_connection
+    connection.in_transaction.return_value = False
+    connection.execute.return_value.scalar_one_or_none.return_value = datetime(
+        2026, 1, 1, tzinfo=UTC
+    )
+
+    _execute_xtdb_dml(
+        connection,
+        "INSERT INTO test.records (_id) VALUES (1)",
+        system_time=datetime(2025, 1, 1, tzinfo=UTC),
+    )
+
+    assert "FROM xt.txs" in str(connection.execute.call_args.args[0])
+    assert [call.args[0] for call in driver_connection.execute.call_args_list] == [
+        "BEGIN READ WRITE",
+        "INSERT INTO test.records (_id) VALUES (1)",
+        "COMMIT",
+    ]
+
+
 def test_xtdb_dataframe_ops_reads_table_as_sql():
     connection = object()
     ops = XtdbDataframeOps(connection)


### PR DESCRIPTION
## Summary
- read the latest completed XTDB system-time before the first explicit system-time write on a connection
- use append-time immediately when the requested system-time is already historical
- keep the existing rejection fallback for concurrent writers

## Verification
- `uv run pytest tests/backends/test_xtdb_dataframe_ops.py tests/backends/test_xtdb_backend.py -q` (138 passed, 1 skipped)
- `uv run mypy polars_hist_db/backends/xtdb_transport.py`
- ruff checks and pre-commit hooks pass