### PR TITLE
fix: do not auto-merge benchmark history

### DIFF
--- a/.github/workflows/bespoke_xtdb-benchmark-history.yaml
+++ b/.github/workflows/bespoke_xtdb-benchmark-history.yaml
@@ -76,14 +76,3 @@ jobs:
           body: |
             ## Summary
             - Record the latest ingestion benchmark results.
-
-      - name: Enable auto-merge for benchmark history PR
-        if: steps.create-pull-request.outputs.pull-request-number != ''
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ steps.create-pull-request.outputs.pull-request-number }}
-        run: |
-          set -euo pipefail
-          test "$(gh pr view "${PR_NUMBER}" --json headRefName --jq .headRefName)" = "chore/benchmark-history"
-          test "$(gh pr view "${PR_NUMBER}" --json files --jq '.files[].path')" = "docs/benchmark-history.json"
-          gh pr merge "${PR_NUMBER}" --squash --auto --delete-branch # lint-no-auto-merge:allow


### PR DESCRIPTION
## Summary
- keep creating benchmark-history pull requests
- stop requesting repository auto-merge
- allow the benchmark workflow to finish when auto-merge is disabled

## Validation
- confirmed the previous workflow failed specifically at the auto-merge command
- static regression check confirms the bespoke workflow contains no auto-merge command
- pre-commit checks passed